### PR TITLE
PLFM-1319: close security hole in registration process

### DIFF
--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/UserProfile.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/UserProfile.json
@@ -54,6 +54,11 @@
 				}
 			]
 		},
+		"email": {
+			"type": "string",
+			"title": "Email",
+			"description": "User's current email address"
+		},
 		"userName": {
 			"type": "string",
 			"title": "User Name",

--- a/services/authutil/src/main/java/org/sagebionetworks/authutil/RegistrationInfo.java
+++ b/services/authutil/src/main/java/org/sagebionetworks/authutil/RegistrationInfo.java
@@ -1,0 +1,69 @@
+package org.sagebionetworks.authutil;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class RegistrationInfo {
+	private String registrationToken;
+	private String password;
+	
+	public RegistrationInfo() {}
+	
+	public String getRegistrationToken() {
+		return registrationToken;
+	}
+	public void setRegistrationToken(String registrationToken) {
+		this.registrationToken = registrationToken;
+	}
+	public String getPassword() {
+		return password;
+	}
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return "RegistrationInfo [token=" + registrationToken + "]";
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((registrationToken == null) ? 0 : registrationToken.hashCode());
+		return result;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (!(obj instanceof RegistrationInfo))
+			return false;
+		RegistrationInfo other = (RegistrationInfo) obj;
+		if (registrationToken == null) {
+			if (other.registrationToken != null)
+				return false;
+		} else if (!registrationToken.equals(other.registrationToken))
+			return false;
+		if (password == null) {
+			if (other.password != null)
+				return false;
+		} else if (!password.equals(other.password))
+			return false;
+		return true;
+	}
+	
+}

--- a/services/authutil/src/main/java/org/sagebionetworks/authutil/SendMail.java
+++ b/services/authutil/src/main/java/org/sagebionetworks/authutil/SendMail.java
@@ -82,7 +82,7 @@ public class SendMail {
     				"org.sagebionetworks.portal.endpoint="+System.getProperty("org.sagebionetworks.portal.endpoint"));
     	}
     	// fill in link, with token
-    	EmailUtils.sendMail(user.getEmail(), "reset Synapse password", msg);
+    	EmailUtils.sendMail(user.getEmail(), "Set Synapse password", msg);
     }
     
 }


### PR DESCRIPTION
Issue a special registration token when creating a new user (sends in an email).  The registration token contains the encrypted session token. Caller can use the registration token to change the user's password, but that's all that can be done. After that, initiate a new session to get a real session token (can't avoid the ToU requirement)
