### PR TITLE
PLFM-1412  Follow up to governance migrator

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/DMLUtils.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/DMLUtils.java
@@ -68,9 +68,17 @@ public class DMLUtils {
 	public static String createGetCountStatement(TableMapping mapping) {
 		if(mapping == null) throw new IllegalArgumentException("Mapping cannot be null");
 		StringBuilder main = new StringBuilder();
-		main.append("SELECT COUNT(*) FROM ");
+		main.append("SELECT COUNT("+getPrimaryFieldColumnName(mapping)+") FROM ");
 		main.append(mapping.getTableName());
 		return main.toString();		
+	}
+
+	public static String getPrimaryFieldColumnName(TableMapping mapping) {
+		for(int i=0; i<mapping.getFieldColumns().length; i++){
+			FieldColumn fc = mapping.getFieldColumns()[i];
+			if(fc.isPrimaryKey()) return fc.getColumnName();
+		}
+		throw new IllegalArgumentException("Table "+mapping.getTableName()+" has no primary key.");
 	}
 
 	/**

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessRequirementDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessRequirementDAOImpl.java
@@ -189,7 +189,7 @@ public class DBOAccessRequirementDAOImpl implements AccessRequirementDAO {
 					od.setType(MigratableObjectType.ACCESSREQUIREMENT);
 					objectData.setId(od);
 					objectData.setEtag(etag);
-					objectData.setDependencies(new HashSet<MigratableObjectDescriptor>());
+					objectData.setDependencies(new HashSet<MigratableObjectDescriptor>(0));
 					return objectData;
 				}
 			

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOUserGroupDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOUserGroupDAOImpl.java
@@ -186,7 +186,7 @@ public class DBOUserGroupDAOImpl implements UserGroupDAOInitializingBean {
 					id.setType(MigratableObjectType.PRINCIPAL);
 					od.setId(id);
 					od.setEtag(etag);
-					od.setDependencies(new HashSet<MigratableObjectDescriptor>()); // UserGroups have no dependencies
+					od.setDependencies(new HashSet<MigratableObjectDescriptor>(0)); // UserGroups have no dependencies
 					return od;
 				}
 			

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/DMLUtilsTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/DMLUtilsTest.java
@@ -136,7 +136,7 @@ public class DMLUtilsTest {
 		String dml = DMLUtils.createGetCountStatement(mapping);
 		assertNotNull(dml);
 		System.out.println(dml);
-		assertEquals("SELECT COUNT(*) FROM SOME_TABLE", dml);
+		assertEquals("SELECT COUNT(ID) FROM SOME_TABLE", dml);
 	}
 	
 	@Test

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/MigratableDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/MigratableDAO.java
@@ -9,8 +9,21 @@ package org.sagebionetworks.repo.model;
  */
 public interface MigratableDAO {
 	
+	/**
+	 * 
+	 * @return the number of items in the entire system of the type managed by the DAO
+	 * @throws DatastoreException
+	 */
 	long getCount() throws DatastoreException;
 	
+	/**
+	 * 
+	 * @param offset  zero based offset
+	 * @param limit page size
+	 * @param includeDependencies says whether to include dependencies for each object or omit (for efficiency)
+	 * @return paginated list of objects in the system (optionally with their dependencies)
+	 * @throws DatastoreException
+	 */
 	QueryResults<MigratableObjectData> getMigrationObjectData(long offset, long limit, boolean includeDependencies) throws DatastoreException;
 	
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/manager/backup/daemon/BackupDaemonLauncherImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/manager/backup/daemon/BackupDaemonLauncherImpl.java
@@ -46,6 +46,11 @@ public class BackupDaemonLauncherImpl implements BackupDaemonLauncher {
 	
 	@Autowired
 	ExecutorService backupDaemonThreadPool2;
+	
+	// for use by Spring
+	public void setBackupDriverMap(Map<String,GenericBackupDriver> map) {
+		this.backupDriverMap = map;
+	}
 
 	@Override
 	public BackupRestoreStatus startBackup(UserInfo username, Set<String> entitiesToBackup, MigratableObjectType migrationType) throws UnauthorizedException, DatastoreException {

--- a/services/repository/src/main/java/org/sagebionetworks/repo/manager/backup/daemon/BackupDaemonLauncherImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/manager/backup/daemon/BackupDaemonLauncherImpl.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.repo.manager.backup.daemon;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
@@ -15,7 +16,6 @@ import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.daemon.BackupRestoreStatus;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -36,13 +36,7 @@ public class BackupDaemonLauncherImpl implements BackupDaemonLauncher {
 	BackupRestoreStatusDAO backupRestoreStatusDao;
 	
 	@Autowired
-	GenericBackupDriver backupDriver;
-	
-	@Autowired
-	GenericBackupDriver principalBackupDriver;
-	
-	@Autowired
-	GenericBackupDriver accessRequirementBackupDriver;
+	Map<String, GenericBackupDriver> backupDriverMap;
 	
 	@Autowired
 	SearchDocumentDriver searchDocumentDriver;
@@ -61,15 +55,9 @@ public class BackupDaemonLauncherImpl implements BackupDaemonLauncher {
 		
 		AmazonS3Client client = createNewAWSClient();
 		
-		GenericBackupDriver typeSpecificBackupDriver = null;
-		if (migrationType.equals(MigratableObjectType.ENTITY)) {
-			typeSpecificBackupDriver = backupDriver;
-		} else if (migrationType.equals(MigratableObjectType.PRINCIPAL)) {
-			typeSpecificBackupDriver = principalBackupDriver;
-		} else if (migrationType.equals(MigratableObjectType.ACCESSREQUIREMENT)) {
-			typeSpecificBackupDriver = accessRequirementBackupDriver;
-		} else {
-			throw new IllegalArgumentException(migrationType.toString());
+		GenericBackupDriver typeSpecificBackupDriver = backupDriverMap.get(migrationType.name());
+		if (typeSpecificBackupDriver==null) {
+			throw new IllegalArgumentException("No backupDriver for "+migrationType.toString());
 		}
 		
 		// Create a new daemon and start it
@@ -87,7 +75,8 @@ public class BackupDaemonLauncherImpl implements BackupDaemonLauncher {
 		AmazonS3Client client = createNewAWSClient();
 
 		// Create a new daemon and start it
-		BackupDaemon daemon = new BackupDaemon(backupRestoreStatusDao, backupDriver, searchDocumentDriver, client, workflowBucket, backupDaemonThreadPool, backupDaemonThreadPool2, entityIds);
+		GenericBackupDriver entityBackupDriver = backupDriverMap.get(MigratableObjectType.ENTITY.name());
+		BackupDaemon daemon = new BackupDaemon(backupRestoreStatusDao, entityBackupDriver, searchDocumentDriver, client, workflowBucket, backupDaemonThreadPool, backupDaemonThreadPool2, entityIds);
 		// Start that bad boy up!
 		return daemon.startSearchDocument(username.getIndividualGroup().getId());
 	}
@@ -100,18 +89,11 @@ public class BackupDaemonLauncherImpl implements BackupDaemonLauncher {
 		
 		AmazonS3Client client = createNewAWSClient();
 		
-		GenericBackupDriver typeSpecificBackupDriver = null;
-		if (migrationType.equals(MigratableObjectType.ENTITY)) {
-			typeSpecificBackupDriver = backupDriver;
-		} else if (migrationType.equals(MigratableObjectType.PRINCIPAL)) {
-			typeSpecificBackupDriver = principalBackupDriver;
-		} else if (migrationType.equals(MigratableObjectType.ACCESSREQUIREMENT)) {
-			typeSpecificBackupDriver = accessRequirementBackupDriver;
-		} else {
-			throw new IllegalArgumentException(migrationType.toString());
+		GenericBackupDriver typeSpecificBackupDriver = backupDriverMap.get(migrationType.name());
+		if (typeSpecificBackupDriver==null) {
+			throw new IllegalArgumentException("No backupDriver for "+migrationType.toString());
 		}
 		
-
 		// Create a new daemon and start it
 		BackupDaemon daemon = new BackupDaemon(backupRestoreStatusDao, typeSpecificBackupDriver, searchDocumentDriver, client, backupBucket, backupDaemonThreadPool, backupDaemonThreadPool2);
 		return daemon.startRestore(username.getIndividualGroup().getId(), fileName);
@@ -159,16 +141,11 @@ public class BackupDaemonLauncherImpl implements BackupDaemonLauncher {
 		if(!user.isAdmin()) throw new UnauthorizedException("Must be an administrator to invoke the backup/restore daemon");
 		
 		MigratableObjectType migrationType = mod.getType();
-		if (migrationType.equals(MigratableObjectType.ENTITY)) {
-			backupDriver.delete(mod.getId());
-		} else if (migrationType.equals(MigratableObjectType.PRINCIPAL)) {
-			principalBackupDriver.delete(mod.getId());
-		} else if (migrationType.equals(MigratableObjectType.ACCESSREQUIREMENT)) {
-			accessRequirementBackupDriver.delete(mod.getId());
-		} else {
-			throw new IllegalArgumentException(migrationType.toString());
+		GenericBackupDriver typeSpecificBackupDriver = backupDriverMap.get(migrationType.name());
+		if (typeSpecificBackupDriver==null) {
+			throw new IllegalArgumentException("No backupDriver for "+migrationType.toString());
 		}
-		
+		typeSpecificBackupDriver.delete(mod.getId());
 	
 	}
 

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/AdministrationService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/AdministrationService.java
@@ -1,0 +1,37 @@
+package org.sagebionetworks.repo.web.service;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.sagebionetworks.repo.model.DatastoreException;
+import org.sagebionetworks.repo.model.MigratableObjectData;
+import org.sagebionetworks.repo.model.PaginatedResults;
+import org.sagebionetworks.repo.model.UnauthorizedException;
+import org.sagebionetworks.repo.model.daemon.BackupRestoreStatus;
+import org.sagebionetworks.repo.model.daemon.RestoreSubmission;
+import org.sagebionetworks.repo.model.status.StackStatus;
+import org.sagebionetworks.repo.web.NotFoundException;
+import org.springframework.http.HttpHeaders;
+
+public interface AdministrationService {
+	PaginatedResults<MigratableObjectData> getAllBackupObjects(String userId, Integer offset, Integer limit, Boolean includeDependencies) throws DatastoreException, NotFoundException, UnauthorizedException;
+
+	BackupRestoreStatus startBackup(String userId, String type, HttpHeaders header, HttpServletRequest request) throws IOException, DatastoreException, NotFoundException, UnauthorizedException;
+
+	BackupRestoreStatus startRestore(String userId, RestoreSubmission file, String type) throws DatastoreException, NotFoundException, UnauthorizedException;
+	
+	void deleteMigratableObject(String userId, String objectId, String type) throws UnauthorizedException, DatastoreException, NotFoundException;
+	 
+	BackupRestoreStatus startSearchDocument(String userId, HttpHeaders header, HttpServletRequest request) throws UnauthorizedException, DatastoreException, IOException, NotFoundException;
+	
+	BackupRestoreStatus getStatus(String userId, String daemonId) throws UnauthorizedException, DatastoreException, IOException, NotFoundException ;
+	
+	void terminateDaemon(String userId, String daemonId) throws UnauthorizedException, DatastoreException, IOException, NotFoundException ;
+	
+	StackStatus getStackStatus();
+	
+	StackStatus updateStatusStackStatus(String userId, HttpHeaders header, HttpServletRequest request) throws UnauthorizedException, DatastoreException, IOException, NotFoundException ;
+	
+	
+}

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/AdministrationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/AdministrationServiceImpl.java
@@ -1,0 +1,143 @@
+package org.sagebionetworks.repo.web.service;
+
+import java.io.IOException;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.sagebionetworks.repo.manager.StackStatusManager;
+import org.sagebionetworks.repo.manager.UserManager;
+import org.sagebionetworks.repo.manager.backup.daemon.BackupDaemonLauncher;
+import org.sagebionetworks.repo.manager.backup.migration.DependencyManager;
+import org.sagebionetworks.repo.model.DatastoreException;
+import org.sagebionetworks.repo.model.MigratableObjectData;
+import org.sagebionetworks.repo.model.MigratableObjectDescriptor;
+import org.sagebionetworks.repo.model.MigratableObjectType;
+import org.sagebionetworks.repo.model.PaginatedResults;
+import org.sagebionetworks.repo.model.QueryResults;
+import org.sagebionetworks.repo.model.UnauthorizedException;
+import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.model.daemon.BackupRestoreStatus;
+import org.sagebionetworks.repo.model.daemon.BackupSubmission;
+import org.sagebionetworks.repo.model.daemon.RestoreSubmission;
+import org.sagebionetworks.repo.model.status.StackStatus;
+import org.sagebionetworks.repo.web.NotFoundException;
+import org.sagebionetworks.repo.web.controller.ObjectTypeSerializer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+
+public class AdministrationServiceImpl implements AdministrationService {
+	
+	@Autowired
+	private BackupDaemonLauncher backupDaemonLauncher;
+	
+	@Autowired
+	ObjectTypeSerializer objectTypeSerializer;
+	
+	@Autowired
+	UserManager userManager;
+	
+	@Autowired
+	StackStatusManager stackStatusManager;
+	
+	@Autowired
+	DependencyManager dependencyManager;
+	
+
+	public PaginatedResults<MigratableObjectData> getAllBackupObjects(String userId, Integer offset, Integer limit, Boolean includeDependencies) throws DatastoreException, NotFoundException, UnauthorizedException {
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		if (!userInfo.isAdmin()) throw new UnauthorizedException("Only an administrator may access this service.");
+		QueryResults<MigratableObjectData> queryResults = dependencyManager.getAllObjects(offset, limit, includeDependencies);
+		PaginatedResults<MigratableObjectData> result = new PaginatedResults<MigratableObjectData>();
+		result.setResults(queryResults.getResults());
+		result.setTotalNumberOfResults(queryResults.getTotalNumberOfResults());
+		return result;
+		
+	}
+	
+	public BackupRestoreStatus startBackup(String userId, String type, HttpHeaders header, HttpServletRequest request) throws IOException, DatastoreException, NotFoundException, UnauthorizedException {
+		
+		// The BackupSubmission is optional.  When included we will only backup the entity Ids included.
+		// When the body is null all entities will be backed up.
+		Set<String> entityIdsToBackup = null;
+		if(request.getInputStream() != null){
+			BackupSubmission submission = objectTypeSerializer.deserialize(request.getInputStream(), header,BackupSubmission.class, header.getContentType());
+			entityIdsToBackup = submission.getEntityIdsToBackup();
+		}
+		// Get the user
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		// start a backup daemon
+		// This is a full system backup so 
+		return backupDaemonLauncher.startBackup(userInfo, entityIdsToBackup, MigratableObjectType.valueOf(type));
+	}
+	
+	public BackupRestoreStatus startRestore(String userId, RestoreSubmission file, String type) throws DatastoreException, NotFoundException, UnauthorizedException {
+		if(file == null) throw new IllegalArgumentException("File cannot be null");
+		if(file.getFileName() == null) throw new IllegalArgumentException("File.getFileName cannot be null");
+		// Get the user
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		// start a restore daemon
+		return backupDaemonLauncher.startRestore(userInfo, file.getFileName(), MigratableObjectType.valueOf(type));
+	}
+	
+	public void deleteMigratableObject(String userId, String objectId, String type) throws UnauthorizedException, DatastoreException, NotFoundException {
+
+		// Get the user
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		MigratableObjectDescriptor mod = new MigratableObjectDescriptor();
+		mod.setId(objectId);
+		mod.setType(MigratableObjectType.valueOf(type));
+		// start a restore daemon
+		backupDaemonLauncher.delete(userInfo, mod);		
+	}
+	 
+	public BackupRestoreStatus startSearchDocument(String userId, HttpHeaders header, HttpServletRequest request) throws UnauthorizedException, DatastoreException, IOException, NotFoundException {
+		
+		// The BackupSubmission is optional.  When included we will only backup the entity Ids included.
+		// When the body is null all entities will be backed up.
+		Set<String> entityIdsToBackup = null;
+		if(request.getInputStream() != null){
+			BackupSubmission submission = objectTypeSerializer.deserialize(request.getInputStream(), header,BackupSubmission.class, header.getContentType());
+			entityIdsToBackup = submission.getEntityIdsToBackup();
+		}
+		// Get the user
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		// start a search document daemon
+		return backupDaemonLauncher.startSearchDocument(userInfo, entityIdsToBackup);
+		
+	}
+	
+	public BackupRestoreStatus getStatus(String userId, String daemonId) throws UnauthorizedException, DatastoreException, IOException, NotFoundException {
+
+		// Get the user
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		// Get the status of this daemon
+		return backupDaemonLauncher.getStatus(userInfo, daemonId);
+		
+	}
+	
+	public void terminateDaemon(String userId, String daemonId) throws UnauthorizedException, DatastoreException, IOException, NotFoundException {
+
+		// Get the user
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		// Terminate the daemon
+		backupDaemonLauncher.terminate(userInfo, daemonId);
+		
+	}
+	
+	public StackStatus getStackStatus() {
+
+		// Get the status of this daemon
+		return stackStatusManager.getCurrentStatus();		
+	}
+	
+	public StackStatus updateStatusStackStatus(String userId, HttpHeaders header, HttpServletRequest request) throws UnauthorizedException, DatastoreException, IOException, NotFoundException {
+		// Get the status of this daemon
+		StackStatus updatedValue = objectTypeSerializer.deserialize(request.getInputStream(), header, StackStatus.class, header.getContentType());
+		// Get the user
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		return stackStatusManager.updateStatus(userInfo, updatedValue);		
+	}
+
+
+}

--- a/services/repository/src/main/resources/managers-spb.xml
+++ b/services/repository/src/main/resources/managers-spb.xml
@@ -132,7 +132,7 @@
 		class="org.sagebionetworks.repo.manager.backup.SearchDocumentDriverImpl"
 		scope="singleton" />
 
-	<bean id="backupDriver"
+	<bean id="entityBackupDriver"
 		class="org.sagebionetworks.repo.manager.backup.NodeBackupDriverImpl"
 		scope="singleton" />
 
@@ -195,7 +195,22 @@
 
 	<bean id="backupDaemonLauncher"
 		class="org.sagebionetworks.repo.manager.backup.daemon.BackupDaemonLauncherImpl"
-		scope="singleton" />
+		scope="singleton" >
+		<!--  the keys in this map  match the enum MigratableObjectType -->
+		<property name="backupDriverMap">
+			<map>
+				<entry key="PRINCIPAL">
+					<ref bean="principalBackupDriver" />
+				</entry>
+				<entry key="ENTITY">
+					<ref bean="entityBackupDriver" />
+				</entry>
+				<entry key="ACCESSREQUIREMENT">
+					<ref bean="accessRequirementBackupDriver" />
+				</entry>
+			</map>
+		</property>
+	</bean>
 
 	<!-- Provides validation for all types -->
 	<bean id="allTypesValidator"

--- a/services/repository/src/main/resources/managers-spb.xml
+++ b/services/repository/src/main/resources/managers-spb.xml
@@ -30,6 +30,9 @@
 		class="org.sagebionetworks.repo.web.DeadlockWatcher" />
 
 	<!-- The Entity Service  -->
+	<bean id="administrationService"
+		class="org.sagebionetworks.repo.web.service.AdministrationServiceImpl" />
+
 	<bean id="entityService"
 		class="org.sagebionetworks.repo.web.service.EntityServiceImpl" />
 

--- a/services/repository/src/test/java/org/sagebionetworks/repo/manager/backup/migration/DependencyManagerImplTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/manager/backup/migration/DependencyManagerImplTest.java
@@ -16,7 +16,6 @@ import org.sagebionetworks.repo.model.MigratableObjectData;
 import org.sagebionetworks.repo.model.MigratableObjectDescriptor;
 import org.sagebionetworks.repo.model.MigratableObjectType;
 import org.sagebionetworks.repo.model.QueryResults;
-import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.jdo.ObjectDescriptorUtils;
 
 
@@ -42,7 +41,9 @@ public class DependencyManagerImplTest {
 		return qr;
 	}
 
-	
+	/**
+	 * gets one page spanning the entire content of all the DAOs
+	 */
 	@Test
 	public void testGetAllObjectsZeroOffset() throws Exception {
 		DependencyManagerImpl dependencyManager = new DependencyManagerImpl();
@@ -83,6 +84,56 @@ public class DependencyManagerImplTest {
 		}
 	}
 
+	/**
+	 * gets one page spanning twos DAOs, but will just some of the content
+	 */
+	@Test
+	public void testGetSomeObjectsNonZeroOffsetOverlapDAOs() throws Exception {
+		DependencyManagerImpl dependencyManager = new DependencyManagerImpl();
+		List<MigratableDAO> migratableDaos = new ArrayList<MigratableDAO>();
+		
+		MigratableDAO dao1 = Mockito.mock(MigratableDAO.class);
+		when(dao1.getCount()).thenReturn(LIST_SIZE);
+		// return IDs 1,2 (not 0)
+		when(dao1.getMigrationObjectData(anyLong()/*offset*/, eq(3L)/*limit*/, anyBoolean()/*includeDependencies*/)).thenReturn(generateMigrationData(1L, 2L, true));
+		migratableDaos.add(dao1);
+		
+		
+		MigratableDAO dao2 = Mockito.mock(MigratableDAO.class);
+		when(dao2.getCount()).thenReturn(LIST_SIZE);
+		// return ID 3 (not 4)
+		when(dao2.getMigrationObjectData(anyLong()/*offset*/, eq(1L)/*limit*/, anyBoolean()/*includeDependencies*/)).thenReturn(generateMigrationData(3L, 1L, false));
+		migratableDaos.add(dao2);
+		
+
+		dependencyManager.setMigratableDaos(migratableDaos);
+		int offset = 1;
+		int requestedNum = 3;
+		QueryResults<MigratableObjectData> results = dependencyManager.getAllObjects(offset, requestedNum, true);
+		
+		List<MigratableObjectData> ods = results.getResults();
+		assertEquals(requestedNum, ods.size());
+		assertEquals(2L*LIST_SIZE, results.getTotalNumberOfResults());
+		
+		// should get 2 from dao1 and 1 from dao2
+		for (int i=offset; i<2L; i++) {
+			MigratableObjectData od = ods.get(i-offset);
+			MigratableObjectDescriptor id = od.getId();
+			assertEquals(MigratableObjectType.ENTITY, id.getType());
+			assertEquals("syn"+i, id.getId());
+		}
+		for (int i=3; i<4L; i++) {
+			MigratableObjectData od = ods.get(i-1);
+			MigratableObjectDescriptor id = od.getId();
+			assertEquals(MigratableObjectType.PRINCIPAL, id.getType());
+			assertEquals(""+i, id.getId());
+		}
+	}
+
+	/**
+	 * Gets the entire content of DAO #2, starting from its beginning
+	 * 
+	 */
 	@Test
 	public void testGetAllObjectsNonZeroOffset() throws Exception {
 		DependencyManagerImpl dependencyManager = new DependencyManagerImpl();
@@ -111,6 +162,44 @@ public class DependencyManagerImplTest {
 		// should get 2 from dao2
 		for (int i=3; i<5L; i++) {
 			MigratableObjectData od = ods.get(i-3);
+			MigratableObjectDescriptor id = od.getId();
+			assertEquals(MigratableObjectType.PRINCIPAL, id.getType());
+			assertEquals(""+i, id.getId());
+		}
+	}
+	/**
+	 * Gets the partial content of DAO #2, starting from a non-zero offset in DAO #2
+	 * 
+	 */
+	@Test
+	public void testGetSomeObjectsFromDAO2NonZeroOffset() throws Exception {
+		DependencyManagerImpl dependencyManager = new DependencyManagerImpl();
+		List<MigratableDAO> migratableDaos = new ArrayList<MigratableDAO>();
+		
+		MigratableDAO dao1 = Mockito.mock(MigratableDAO.class);
+		when(dao1.getCount()).thenReturn(LIST_SIZE);
+		when(dao1.getMigrationObjectData(eq(4L)/*offset*/, anyLong()/*limit*/, anyBoolean()/*includeDependencies*/)).thenReturn(generateMigrationData(0L, 0L, true));
+		migratableDaos.add(dao1);
+		
+		
+		MigratableDAO dao2 = Mockito.mock(MigratableDAO.class);
+		when(dao2.getCount()).thenReturn(LIST_SIZE);
+		when(dao2.getMigrationObjectData(anyLong()/*offset*/, eq(1L)/*limit*/, anyBoolean()/*includeDependencies*/)).thenReturn(generateMigrationData(4L, 1L, false));
+		migratableDaos.add(dao2);
+		
+
+		dependencyManager.setMigratableDaos(migratableDaos);
+		int requestedNum = 1;
+		int startIndex = 4;
+		QueryResults<MigratableObjectData> results = dependencyManager.getAllObjects(startIndex, requestedNum, true);
+		
+		List<MigratableObjectData> ods = results.getResults();
+		assertEquals(requestedNum, ods.size());
+		assertEquals(2L*LIST_SIZE, results.getTotalNumberOfResults());
+		
+		// should get 2 from dao2
+		for (int i=startIndex; i<5L; i++) {
+			MigratableObjectData od = ods.get(i-startIndex);
 			MigratableObjectDescriptor id = od.getId();
 			assertEquals(MigratableObjectType.PRINCIPAL, id.getType());
 			assertEquals(""+i, id.getId());


### PR DESCRIPTION
```
DONE DaemonLauncherImpl: autowire a map <Type->Driver> rather than autowiring each Driver individually DONE
DONE MigratorDAO: add comments DONE
DONE DMLUtils: select -> select(id) DONE
DONE anywhere there is new HashSet() that will always be empty -> new HashSet(0) DONE
DONE migrate business logic for AdministrationController to an intermediate Service layer which, in turn has the DependencyManager DONE
DONE NodeDaoImpl: only pass benefactors to the second query DONE
DONE NodeDapImplTest: - test modifiedBy dependency; test parent/child/grandchild, in which parent<>benefactor; test dependency of benefactor on ACL principals DONE
DONE Add a DependencyManagerImpl test which spans two DAOs and has a non-zero start DONE
```
