### PR TITLE
add username back into UserProfile object. 

### DIFF
--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/UserProfile.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/UserProfile.json
@@ -59,6 +59,11 @@
 			"title": "Email",
 			"description": "User's current email address"
 		},
+		"userName": {
+			"type": "string",
+			"title": "User Name",
+			"description": "User Name, unique in the system and typically the user's email address"
+		},
 		"displayName": {
 			"type": "string",
 			"title": "Display Name",


### PR DESCRIPTION
should never be populated, but the migrator does not currently gracefully handle intentional field removal
