### PR TITLE
PLFM-1427 Migrator is not handling changed etags properly

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOUserProfileDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOUserProfileDAOImpl.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.sagebionetworks.repo.model.dbo.dao;
 
 import static org.sagebionetworks.repo.model.query.jdo.SqlConstants.COL_USER_PROFILE_ID;
@@ -30,7 +27,6 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
 
 /**
  * @author brucehoff
@@ -115,9 +111,28 @@ public class DBOUserProfileDAOImpl implements UserProfileDAO {
 	@Transactional(readOnly = false, propagation = Propagation.REQUIRED)
 	@Override
 	public UserProfile update(UserProfile dto, ObjectSchema schema) throws DatastoreException,
-			InvalidModelException, NotFoundException,
-			ConflictingUpdateException {
-		// LOCK the record
+			InvalidModelException, NotFoundException, ConflictingUpdateException {
+		return update(dto, schema, false);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.sagebionetworks.repo.model.UserProfileDAO#update(UserProfile, ObjectSchema)
+	 */
+	@Transactional(readOnly = false, propagation = Propagation.REQUIRED)
+	@Override
+	public UserProfile updateFromBackup(UserProfile dto, ObjectSchema schema) throws DatastoreException,
+			InvalidModelException, NotFoundException, ConflictingUpdateException {
+		return update(dto, schema, true);
+	}
+
+	/**
+	 * @param fromBackup Whether we are updating from backup.
+	 *                   Skip optimistic locking and accept the backup e-tag when restoring from backup.
+	 */
+	private UserProfile update(UserProfile dto, ObjectSchema schema, boolean fromBackup) throws
+			DatastoreException, InvalidModelException, NotFoundException, ConflictingUpdateException {
+
 		DBOUserProfile dbo = null;
 		MapSqlParameterSource param = new MapSqlParameterSource();
 		param.addValue(DBOUserProfile.OWNER_ID_FIELD_NAME, dto.getOwnerId());
@@ -126,23 +141,31 @@ public class DBOUserProfileDAOImpl implements UserProfileDAO {
 		}catch (EmptyResultDataAccessException e) {
 			throw new NotFoundException("The resource you are attempting to access cannot be found");
 		}
-		// check dbo's etag against dto's etag
-		// if different rollback and throw a meaningful exception
-		if (!dbo.geteTag().equals(dto.getEtag()))
-			throw new ConflictingUpdateException("Use profile was updated since you last fetched it, retrieve it again and reapply the update.");
+
+		if (!fromBackup) {
+			// check dbo's etag against dto's etag
+			// if different rollback and throw a meaningful exception
+			if (!dbo.geteTag().equals(dto.getEtag())) {
+				throw new ConflictingUpdateException("Use profile was updated since you last fetched it, retrieve it again and reapply the update.");
+			}
+		}
 		UserProfileUtils.copyDtoToDbo(dto, dbo, schema);
-		dbo.seteTag(eTagGenerator.generateETag(dbo));
+		if (!fromBackup) {
+			// Update with a new e-tag; otherwise, the backup e-tag is used implicitly
+			dbo.seteTag(eTagGenerator.generateETag(dbo));
+		}
+
 		boolean success = basicDao.update(dbo);
 		if (!success) throw new DatastoreException("Unsuccessful updating user profile in database.");
+
 		UserProfile resultantDto = new UserProfile();
 		UserProfileUtils.copyDboToDto(dbo,  resultantDto, schema);
+
 		return resultantDto;
-	} // the 'commit' is implicit in returning from a method annotated 'Transactional'
+	}
 
 	private static final String SELECT_FOR_UPDATE_SQL = "select * from "+TABLE_USER_PROFILE+" where "+COL_USER_PROFILE_ID+
 			"=:"+DBOUserProfile.OWNER_ID_FIELD_NAME+" for update";
-	
-	private static final TableMapping<DBOUserProfile> TABLE_MAPPING = (new DBOUserProfile()).getTableMapping();
-	
 
+	private static final TableMapping<DBOUserProfile> TABLE_MAPPING = (new DBOUserProfile()).getTableMapping();
 }

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessApprovalDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessApprovalDAOImplTest.java
@@ -27,7 +27,6 @@ import org.sagebionetworks.repo.model.TermsOfUseAccessApproval;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserGroupDAO;
 import org.sagebionetworks.repo.model.jdo.NodeTestUtils;
-import org.sagebionetworks.schema.ObjectSchema;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -192,8 +191,7 @@ public class DBOAccessApprovalDAOImplTest {
 		clone = ars.iterator().next();
 		AccessApproval updatedAA = accessApprovalDAO.update(clone);
 		assertEquals(((TermsOfUseAccessApproval)clone).getEntityType(), ((TermsOfUseAccessApproval)updatedAA).getEntityType());
-
-		assertTrue("etags should be incremented after an update", !clone.getEtag().equals(updatedAA.getEtag()));
+		assertTrue("etags should be different after an update", !clone.getEtag().equals(updatedAA.getEtag()));
 
 		try {
 			accessApprovalDAO.update(clone);
@@ -201,11 +199,18 @@ public class DBOAccessApprovalDAOImplTest {
 		}
 		catch(ConflictingUpdateException e){
 			// We expected this exception
-		}	
-		
+		}
+
+		try {
+			// Update from a backup.
+			updatedAA = accessApprovalDAO.updateFromBackup(clone);
+			assertEquals(clone.getEtag(), updatedAA.getEtag());
+		}
+		catch(ConflictingUpdateException e) {
+			fail("Update from backup should not generate exception even if the e-tag is different.");
+		}
+
 		// Delete it
 		accessApprovalDAO.delete(id);
 	}
-
-
 }

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/AccessApprovalDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/AccessApprovalDAO.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.sagebionetworks.repo.web.NotFoundException;
-import org.sagebionetworks.schema.ObjectSchema;
 
 public interface AccessApprovalDAO {
 
@@ -43,10 +42,10 @@ public interface AccessApprovalDAO {
 	 * @throws DatastoreException
 	 */
 	public List<AccessApproval> getForAccessRequirementsAndPrincipals(Collection<String> accessRequirementIds, Collection<String> principalIds) throws DatastoreException;
-	
+
 	/**
-	 * this updates the 'shallow' properties of an object
-	 * 
+	 * Updates the 'shallow' properties of an object.
+	 *
 	 * @param dto
 	 *            non-null id is required
 	 * @throws DatastoreException
@@ -54,6 +53,18 @@ public interface AccessApprovalDAO {
 	 * @throws NotFoundException
 	 */
 	public <T extends AccessApproval> T  update(T dto) throws DatastoreException, InvalidModelException,
+			NotFoundException, ConflictingUpdateException;
+
+	/**
+	 * Updates the 'shallow' properties of an object from backup.
+	 *
+	 * @param dto
+	 *            non-null id is required
+	 * @throws DatastoreException
+	 * @throws InvalidModelException
+	 * @throws NotFoundException
+	 */
+	public <T extends AccessApproval> T  updateFromBackup(T dto) throws DatastoreException, InvalidModelException,
 			NotFoundException, ConflictingUpdateException;
 
 	/**

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/AccessRequirementDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/AccessRequirementDAO.java
@@ -36,12 +36,21 @@ public interface AccessRequirementDAO extends MigratableDAO {
 	public List<AccessRequirement> getForNode(String nodeId) throws DatastoreException;
 	
 	/**
-	 * updates the 'shallow' properties of an object
-	 * 
+	 * Updates the 'shallow' properties of an object.
+	 *
 	 * @param dto
-	 * @throws DatastoreException 
+	 * @throws DatastoreException
 	 */
 	public <T extends AccessRequirement> T update(T accessRequirement) throws InvalidModelException,
+			NotFoundException, ConflictingUpdateException, DatastoreException;
+
+	/**
+	 * Updates the 'shallow' properties of an object from backup.
+	 *
+	 * @param dto
+	 * @throws DatastoreException
+	 */
+	public <T extends AccessRequirement> T updateFromBackup(T accessRequirement) throws InvalidModelException,
 			NotFoundException, ConflictingUpdateException, DatastoreException;
 
 	/**

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/UserProfileDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/UserProfileDAO.java
@@ -51,10 +51,9 @@ public interface UserProfileDAO {
 	 */
 	public long getCount() throws DatastoreException, NotFoundException;
 
-
 	/**
-	 * UserProfilehis updates the 'shallow' properties of an object
-	 * 
+	 * Updates the 'shallow' properties of an object.
+	 *
 	 * @param dto
 	 *            non-null id is required
 	 * @throws DatastoreException
@@ -62,6 +61,18 @@ public interface UserProfileDAO {
 	 * @throws NotFoundException
 	 */
 	public UserProfile update(UserProfile dto, ObjectSchema schema) throws DatastoreException, InvalidModelException,
+			NotFoundException, ConflictingUpdateException;
+
+	/**
+	 * Updates the 'shallow' properties of an object from backup.
+	 *
+	 * @param dto
+	 *            non-null id is required
+	 * @throws DatastoreException
+	 * @throws InvalidModelException
+	 * @throws NotFoundException
+	 */
+	public UserProfile updateFromBackup(UserProfile dto, ObjectSchema schema) throws DatastoreException, InvalidModelException,
 			NotFoundException, ConflictingUpdateException;
 
 	/**
@@ -73,6 +84,4 @@ public interface UserProfileDAO {
 	 * @throws NotFoundException
 	 */
 	public void delete(String id) throws DatastoreException, NotFoundException;
-
-
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/manager/backup/PrincipalBackupDriver.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/manager/backup/PrincipalBackupDriver.java
@@ -248,8 +248,7 @@ public class PrincipalBackupDriver implements GenericBackupDriver {
 				if (exists) {
 					// is an update needed or are the profiles the same?  check the etags to answer
 					if (!srcUserProfile.getEtag().equals(dstUserProfile.getEtag())) {
-						srcUserProfile.setEtag(dstUserProfile.getEtag());
-						userProfileDAO.update(srcUserProfile, schema);
+						userProfileDAO.updateFromBackup(srcUserProfile, schema);
 					}
 				} else {
 					userProfileDAO.create(srcUserProfile, schema);


### PR DESCRIPTION
When restoring from a backup, it should always accept the backup's e-tag -- optimistic locking does not apply.
