### PR TITLE
Remove the lang field from the delete SDF

### DIFF
--- a/tools/tool-migration-utility/src/main/java/org/sagebionetworks/tool/searchupdater/job/SearchDocumentDeleteWorker.java
+++ b/tools/tool-migration-utility/src/main/java/org/sagebionetworks/tool/searchupdater/job/SearchDocumentDeleteWorker.java
@@ -61,7 +61,6 @@ public class SearchDocumentDeleteWorker implements Callable<WorkerResult> {
 				document.setType(DocumentTypeNames.delete);
 				document.setId(entityId);
 				document.setVersion(now.getMillis() / 1000);
-				document.setLang("en"); // TODO this should have been set via "default" in the schema for this
 				documentBatch.put(EntityFactory.createJSONObjectForEntity(document));
 			}
 


### PR DESCRIPTION
Sending the request below to CloudSearch will get a warning in the response. Note the "lang" field in the SDF.  CloudSearch documentation does not list the "lang" field either.  I am removing it from the SDF.
# 

REQUEST:

``` json
[
    {
        "id": "syn105225",
        "lang": "en",
        "type": "delete",
        "version": 1345155661
    },
    {
        "id": "syn105222",
        "lang": "en",
        "type": "delete",
        "version": 1345155661
    }
]
```

RESPONSE:

``` json
{
  "status": "success",
  "warnings": [
    {
      "message": "\"delete\" has unknown attribute(s): ['lang'] (near operation with index 1; document_id syn105225)"
    },
    {
      "message": "\"delete\" has unknown attribute(s): ['lang'] (near operation with index 2; document_id syn105222)"
    }
  ],
  "adds": 0,
  "deletes": 2
}
```
