### PR TITLE
Add an EC2IdProvider

### DIFF
--- a/services/repository/src/main/java/org/sagebionetworks/sweeper/log4j/EC2IdProvider.java
+++ b/services/repository/src/main/java/org/sagebionetworks/sweeper/log4j/EC2IdProvider.java
@@ -1,0 +1,48 @@
+package org.sagebionetworks.sweeper.log4j;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class EC2IdProvider {
+
+	private static final String EC2_METADATA_ENDPOINT = "http://169.254.169.254/latest/meta-data";
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		long start = System.nanoTime();
+		String id = getId();
+		long end = System.nanoTime();
+
+		long elapsed = end - start;
+		System.out.format("Retrieved id: %s in %d milliseconds%n", id, elapsed/1000000);
+	}
+
+	public static String getId() {
+		try {
+			return getEC2InstanceId();
+		} catch (IOException e) {
+			return java.util.UUID.randomUUID().toString();
+		}
+	}
+
+	private static String getEC2InstanceId() throws IOException {
+		String ec2Id = "";
+		String inputLine;
+
+		URL ec2MetaData = new URL(EC2_METADATA_ENDPOINT+"/instance-id");
+		URLConnection EC2MD = ec2MetaData.openConnection();
+
+		BufferedReader in = new BufferedReader(new InputStreamReader(EC2MD.getInputStream()));
+		while ((inputLine = in.readLine()) != null) {
+			ec2Id = inputLine;
+		}
+		in.close();
+
+		return ec2Id;
+	}
+}

--- a/services/repository/src/main/java/org/sagebionetworks/sweeper/log4j/TimeBasedRollingToS3Policy.java
+++ b/services/repository/src/main/java/org/sagebionetworks/sweeper/log4j/TimeBasedRollingToS3Policy.java
@@ -73,9 +73,14 @@ public final class TimeBasedRollingToS3Policy extends RollingPolicyBase
 	 */
 	private long INTERVAL_BETWEEN_CHECKS = 30;
 
-	// this should look something like this: 1c142524-db86-437d-9f0b-56363a7e3f90
-	// since the limit for s3 keys is 1024 bytes, there should be no problems
-	private static final String JVM_INSTANCE_ID = java.util.UUID.randomUUID().toString();
+	/**
+	 * This variable will either hold an EC2 Instance id (if the jvm is on an ec2 instance)
+	 * or a random UUID.  The cost for getting the EC2 id is about 70 milliseconds if it succeeds,
+	 * and 3000 milliseconds if it fails.  The EC2 id should look like this: ccf831b6
+	 * The UUID should look something like this: 1c142524-db86-437d-9f0b-56363a7e3f90
+	 * Since the limit for s3 keys is 1024 bytes, there should be no problems with either approach
+	 */
+	private static final String JVM_INSTANCE_ID = EC2IdProvider.getId();
 
 	private final String AFN_NOT_SET = "The ActiveFileName option must be set before using "+this.getClass().getSimpleName();;
 


### PR DESCRIPTION
That way, if we're on EC2, then we get an ec2 instance id, which is
unique and gives us more information.  If we're not on EC2, there's
a small performance penalty, but it's one time on class load, and we
still get a unique id.
