### PR TITLE
Increase data migrator heap size and timeout threshold

### DIFF
--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/Synapse.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/Synapse.java
@@ -85,7 +85,7 @@ public class Synapse {
 
 	protected static final Logger log = Logger.getLogger(Synapse.class.getName());
 
-	protected static final int DEFAULT_TIMEOUT_MSEC = 5000;
+	protected static final int DEFAULT_TIMEOUT_MSEC = 10000;
 
 	protected static final int JSON_INDENT = 2;
 	protected static final String DEFAULT_REPO_ENDPOINT = "https://repo-prod.sagebase.org/repo/v1";

--- a/tools/tool-migration-utility/run_migrator.sh
+++ b/tools/tool-migration-utility/run_migrator.sh
@@ -1,4 +1,3 @@
 #! /bin/bash
 # usage: ./run_migrator <MIGRATER JAR> <MIGRATER PROPERTY FILE>
-java -Xms256m -Xmx1g -cp $1 org.sagebionetworks.tool.migration.gui.MigrationConsoleUI $2
-
+java -Xms256m -Xmx2g -cp $1 org.sagebionetworks.tool.migration.gui.MigrationConsoleUI $2


### PR DESCRIPTION
To address the OOMs and timeout I started to see over the weekend. It seemed to get worse today.  The increase of the timeout threshold is less ideal than I would like it to be (i.e. to focus on only data migrator as I am not sure if the timeout similarly happens with the web client). So this is a temporary fix until further investigation is done and a better solution is in place.
