### PR TITLE
DAO for querying storage usage.

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/StorageLocationDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/StorageLocationDAOImpl.java
@@ -1,16 +1,37 @@
 package org.sagebionetworks.repo.model.dbo.dao;
 
+import static org.sagebionetworks.repo.model.query.jdo.SqlConstants.COL_STORAGE_LOCATION_CONTENT_SIZE;
+import static org.sagebionetworks.repo.model.query.jdo.SqlConstants.COL_STORAGE_LOCATION_ID;
 import static org.sagebionetworks.repo.model.query.jdo.SqlConstants.COL_STORAGE_LOCATION_NODE_ID;
+import static org.sagebionetworks.repo.model.query.jdo.SqlConstants.COL_STORAGE_LOCATION_USER_ID;
+import static org.sagebionetworks.repo.model.query.jdo.SqlConstants.LIMIT_PARAM_NAME;
+import static org.sagebionetworks.repo.model.query.jdo.SqlConstants.OFFSET_PARAM_NAME;
 import static org.sagebionetworks.repo.model.query.jdo.SqlConstants.TABLE_STORAGE_LOCATION;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.sagebionetworks.repo.model.DatastoreException;
+import org.sagebionetworks.repo.model.InvalidModelException;
+import org.sagebionetworks.repo.model.LocationTypeNames;
 import org.sagebionetworks.repo.model.StorageLocationDAO;
 import org.sagebionetworks.repo.model.StorageLocations;
 import org.sagebionetworks.repo.model.dbo.DBOBasicDao;
+import org.sagebionetworks.repo.model.dbo.FieldColumn;
 import org.sagebionetworks.repo.model.dbo.persistence.DBOStorageLocation;
+import org.sagebionetworks.repo.model.jdo.KeyFactory;
+import org.sagebionetworks.repo.model.storage.StorageUsage;
+import org.sagebionetworks.repo.model.storage.StorageUsageDimension;
+import org.sagebionetworks.repo.model.storage.StorageUsageDimensionValue;
+import org.sagebionetworks.repo.model.storage.StorageUsageList;
+import org.sagebionetworks.repo.model.storage.StorageUsageSummary;
+import org.sagebionetworks.repo.model.storage.StorageUsageSummaryList;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.simple.ParameterizedSingleColumnRowMapper;
 import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,15 +41,39 @@ import com.amazonaws.services.s3.AmazonS3;
 
 public class StorageLocationDAOImpl implements StorageLocationDAO {
 
-	private static String DELETE_SQL = "DELETE FROM "
-			+ TABLE_STORAGE_LOCATION + " WHERE "
-			+ COL_STORAGE_LOCATION_NODE_ID + " = ?";
+	private static final String SELECT_ID_FOR_NODE =
+			"SELECT " + COL_STORAGE_LOCATION_ID +
+			" FROM " + TABLE_STORAGE_LOCATION +
+			" WHERE " + COL_STORAGE_LOCATION_NODE_ID + " = :" + COL_STORAGE_LOCATION_NODE_ID;
+
+	private static final RowMapper<Long> idRowMapper = ParameterizedSingleColumnRowMapper.newInstance(Long.class);
+
+	private static final String SELECT_TOTAL_USAGE_FOR_USER =
+			"SELECT SUM(" + COL_STORAGE_LOCATION_CONTENT_SIZE + ")" +
+			" FROM " + TABLE_STORAGE_LOCATION +
+			" WHERE " + COL_STORAGE_LOCATION_USER_ID + " = :" + COL_STORAGE_LOCATION_USER_ID;
+
+	private static final String COL_TOTAL = "TOTAL";
+	private static final String SELECT_AGGREGATED_USAGE_FOR_USER_PART_1 =
+			"SELECT SUM(" + COL_STORAGE_LOCATION_CONTENT_SIZE + ") AS " + COL_TOTAL;
+	private static final String SELECT_AGGREGATED_USAGE_FOR_USER_PART_2 =
+			" FROM " + TABLE_STORAGE_LOCATION +
+			" WHERE " + COL_STORAGE_LOCATION_USER_ID + " = :" + COL_STORAGE_LOCATION_USER_ID +
+			" GROUP BY ";
+
+	private static final String SELECT_STORAGE_LOCATION_FOR_USER_PAGINATED =
+			"SELECT *" +
+			" FROM " + TABLE_STORAGE_LOCATION +
+			" WHERE " + COL_STORAGE_LOCATION_USER_ID + " = :" + COL_STORAGE_LOCATION_USER_ID +
+			" LIMIT :" + LIMIT_PARAM_NAME + " OFFSET :" + OFFSET_PARAM_NAME;
+
+	private static final RowMapper<DBOStorageLocation> rowMapper = (new DBOStorageLocation()).getTableMapping();
 
 	@Autowired
-	private DBOBasicDao dboBasicDao;
+	private DBOBasicDao basicDao;
 
 	@Autowired
-	private SimpleJdbcTemplate simpleJdbcTempalte;
+	private SimpleJdbcTemplate simpleJdbcTemplate;
 
 	@Autowired
 	private AmazonS3 amazonS3Client;
@@ -42,17 +87,182 @@ public class StorageLocationDAOImpl implements StorageLocationDAO {
 			return;
 		}
 
-		// Delete first
+		// First DELETE
+		// Note: To avoid extensive locking, we select then delete by id.
 		Long nodeId = locations.getNodeId();
-		this.simpleJdbcTempalte.update(DELETE_SQL, nodeId);
+		MapSqlParameterSource paramMap = new MapSqlParameterSource();
+		paramMap.addValue(COL_STORAGE_LOCATION_NODE_ID, nodeId);
+		List<Long> idList = simpleJdbcTemplate.query(SELECT_ID_FOR_NODE, idRowMapper, paramMap);
+		for (Long id : idList) {
+			MapSqlParameterSource params = new MapSqlParameterSource();
+			params.addValue(COL_STORAGE_LOCATION_ID.toLowerCase(), id);
+			basicDao.deleteObjectById(DBOStorageLocation.class, params);
+		}
 
-		// Then update
+		// Then CREATE
 		try {
 			List<DBOStorageLocation> batch = StorageLocationUtils.createBatch(
 					locations, amazonS3Client);
-			this.dboBasicDao.createBatch(batch);
+			basicDao.createBatch(batch);
 		} catch (AmazonClientException e) {
 			throw new DatastoreException(e);
 		}
+	}
+
+	@Transactional(readOnly = true)
+	@Override
+	public Long getTotalUsage(String userId) throws DatastoreException {
+
+		if (userId == null || userId.isEmpty()) {
+			throw new NullPointerException();
+		}
+
+		MapSqlParameterSource paramMap = new MapSqlParameterSource();
+		Long userIdLong = KeyFactory.stringToKey(userId);
+		paramMap.addValue(COL_STORAGE_LOCATION_USER_ID, userIdLong);
+		long total = simpleJdbcTemplate.queryForLong(SELECT_TOTAL_USAGE_FOR_USER, paramMap);
+
+		return total;
+	}
+
+	@Transactional(readOnly = true)
+	@Override
+	public StorageUsageSummaryList getAggregatedUsage(String userId,
+			List<StorageUsageDimension> dimensionList)
+			throws DatastoreException, InvalidModelException {
+
+		if (userId == null || userId.isEmpty()) {
+			throw new NullPointerException();
+		}
+
+		if (dimensionList == null) {
+			throw new NullPointerException();
+		}
+
+		StorageUsageSummaryList summaryList = new StorageUsageSummaryList();
+		summaryList.setUserId(userId);
+
+		Long grandTotal = getTotalUsage(userId);
+		summaryList.setGrandTotal(grandTotal);
+
+		List<StorageUsageSummary> susList = new ArrayList<StorageUsageSummary>();
+		summaryList.setSummaryList(susList);
+
+		if (dimensionList.isEmpty()) {
+			return summaryList;
+		}
+
+		List<String> columnList = getGroupByColumns(dimensionList);
+		assert columnList.size() > 0; // Otherwise we should have returned
+
+		StringBuilder sql = new StringBuilder(SELECT_AGGREGATED_USAGE_FOR_USER_PART_1);
+		for (String column : columnList) {
+			sql.append(", ");
+			sql.append(column);
+		}
+		sql.append(SELECT_AGGREGATED_USAGE_FOR_USER_PART_2);
+		sql.append(columnList.get(0));
+		int i = 1;
+		while (i < columnList.size()) {
+			sql.append(", ");
+			sql.append(columnList.get(i));
+			i++;
+		}
+
+		MapSqlParameterSource paramMap = new MapSqlParameterSource();
+		Long userIdLong = KeyFactory.stringToKey(userId);
+		paramMap.addValue(COL_STORAGE_LOCATION_USER_ID, userIdLong);
+		List<Map<String, Object>> rows = simpleJdbcTemplate.queryForList(sql.toString(), paramMap);
+		for (Map<String, Object> row : rows) {
+			StorageUsageSummary sus = new StorageUsageSummary();
+			sus.setUserId(userId);
+			Object sum = row.get(COL_TOTAL);
+			Long total = (sum == null ? 0L : ((BigDecimal)sum).longValue());
+			sus.setTotalSize(total);
+			List<StorageUsageDimensionValue> dValList = new ArrayList<StorageUsageDimensionValue>();
+			for (String column : columnList) {
+				String value = row.get(column).toString();
+				StorageUsageDimensionValue val = new StorageUsageDimensionValue();
+				val.setDimension(StorageUsageDimension.valueOf(column));
+				val.setValue(value);
+				dValList.add(val);
+			}
+			sus.setDimensionList(dValList);
+			susList.add(sus);
+		}
+
+		return summaryList;
+	}
+
+	@Transactional(readOnly = true)
+	@Override
+	public StorageUsageList getStorageUsageInRange(String userId, long beginIncl, long endExcl)
+			throws DatastoreException {
+
+		if (userId == null || userId.isEmpty()) {
+			throw new NullPointerException();
+		}
+
+		if (beginIncl >= endExcl) {
+			String msg = "begin must be greater than end (begin = " + beginIncl;
+			msg += "; end = ";
+			msg += endExcl;
+			msg += ")";
+			throw new IllegalArgumentException(msg);
+		}
+
+		StorageUsageList suList = new StorageUsageList();
+		suList.setUserId(userId);
+
+		Long grandTotal = getTotalUsage(userId);
+		suList.setGrandTotal(grandTotal);
+
+		MapSqlParameterSource paramMap = new MapSqlParameterSource();
+		paramMap.addValue(OFFSET_PARAM_NAME, beginIncl);
+		paramMap.addValue(LIMIT_PARAM_NAME, endExcl - beginIncl);
+		Long userIdLong = KeyFactory.stringToKey(userId);
+		paramMap.addValue(COL_STORAGE_LOCATION_USER_ID, userIdLong);
+		List<DBOStorageLocation> dboList = simpleJdbcTemplate.query(
+				SELECT_STORAGE_LOCATION_FOR_USER_PAGINATED, rowMapper, paramMap);
+
+		List<StorageUsage> usageList = new ArrayList<StorageUsage>();
+		for (DBOStorageLocation dbo : dboList) {
+			StorageUsage su = new StorageUsage();
+			usageList.add(su);
+			su.setId(dbo.getId().toString());
+			su.setNodeId(KeyFactory.keyToString(dbo.getNodeId()));
+			su.setUserId(dbo.getUserId().toString());
+			su.setIsAttachment(dbo.getIsAttachment());
+			su.setLocation(dbo.getLocation());
+			su.setStorageProvider(LocationTypeNames.valueOf(dbo.getStorageProvider()));
+			su.setContentType(dbo.getContentType());
+			su.setContentSize(dbo.getContentSize());
+			su.setContentMd5(dbo.getContentMd5());
+		}
+		suList.setUsageList(usageList);
+
+		return suList;
+	}
+
+	private List<String> getGroupByColumns(List<StorageUsageDimension> dimensionList) {
+
+		List<String> colNames = new ArrayList<String>();
+		FieldColumn[] columns = (new DBOStorageLocation()).getTableMapping().getFieldColumns();
+		// Both lists should be small thus we can afford a N^2 lookup.
+		for (FieldColumn col : columns) {
+			String colName = col.getColumnName().toUpperCase();
+			for (StorageUsageDimension d : dimensionList) {
+				if (colName.equals(d.name().toUpperCase())) {
+					colNames.add(colName);
+					break;
+				}
+			}
+		}
+
+		if (colNames.size() != dimensionList.size()) {
+			throw new InvalidModelException("The list of StorageUsageDimension has invalid column names.");
+		}
+
+		return colNames;
 	}
 }

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/StorageLocationDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/StorageLocationDAOImplTest.java
@@ -1,5 +1,8 @@
 package org.sagebionetworks.repo.model.dbo.dao;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -10,9 +13,10 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.sagebionetworks.StackConfiguration;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.DatastoreException;
-import org.sagebionetworks.repo.model.InvalidModelException;
 import org.sagebionetworks.repo.model.LocationData;
 import org.sagebionetworks.repo.model.LocationTypeNames;
 import org.sagebionetworks.repo.model.Node;
@@ -25,17 +29,30 @@ import org.sagebionetworks.repo.model.dbo.DBOBasicDao;
 import org.sagebionetworks.repo.model.dbo.persistence.DBOStorageLocation;
 import org.sagebionetworks.repo.model.jdo.KeyFactory;
 import org.sagebionetworks.repo.model.jdo.NodeTestUtils;
+import org.sagebionetworks.repo.model.storage.StorageUsage;
+import org.sagebionetworks.repo.model.storage.StorageUsageDimension;
+import org.sagebionetworks.repo.model.storage.StorageUsageDimensionValue;
+import org.sagebionetworks.repo.model.storage.StorageUsageList;
+import org.sagebionetworks.repo.model.storage.StorageUsageSummary;
+import org.sagebionetworks.repo.model.storage.StorageUsageSummaryList;
 import org.sagebionetworks.repo.web.NotFoundException;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:jdomodels-test-context.xml" })
 public class StorageLocationDAOImplTest {
 
 	@Autowired
-	private DBOBasicDao dboBasicDao;
+	private DBOBasicDao basicDao;
 
 	@Autowired
 	private NodeDAO nodeDao;
@@ -52,7 +69,8 @@ public class StorageLocationDAOImplTest {
 	private StorageLocations locations;
 
 	@Before
-	public void before() throws NumberFormatException, DatastoreException, NotFoundException, InvalidModelException {
+	public void before() throws Exception {
+
 		userId = userGroupDAO.findGroup(AuthorizationConstants.BOOTSTRAP_USER_GROUP_NAME, false).getId();
 		Assert.assertNotNull(userId);
 		Long userIdLong = Long.parseLong(userId);
@@ -85,7 +103,7 @@ public class StorageLocationDAOImplTest {
 		ld.setType(LocationTypeNames.external);
 		locationList.add(ld);
 		ld = new LocationData();
-		ld.setPath("/abc/xyz");
+		ld.setPath("abc/xyz");
 		ld.setType(LocationTypeNames.awss3);
 		locationList.add(ld);
 
@@ -100,6 +118,28 @@ public class StorageLocationDAOImplTest {
 
 		locations = new StorageLocations(KeyFactory.stringToKey(nodeId), userIdLong,
 			attachmentList, locationList, strAnnotations);
+
+		List<S3ObjectSummary> objList = new ArrayList<S3ObjectSummary>();
+		S3ObjectSummary objSummary = mock(S3ObjectSummary.class);
+		when(objSummary.getKey()).thenReturn(KeyFactory.stringToKey(nodeId) + "/ad1Token");
+		when(objSummary.getSize()).thenReturn(23L);
+		objList.add(objSummary);
+		objSummary = mock(S3ObjectSummary.class);
+		when(objSummary.getKey()).thenReturn(KeyFactory.stringToKey(nodeId) + "/ad2Token");
+		when(objSummary.getSize()).thenReturn(53L);
+		objList.add(objSummary);
+		objSummary = mock(S3ObjectSummary.class);
+		when(objSummary.getKey()).thenReturn("abc/xyz");
+		when(objSummary.getSize()).thenReturn(11L);
+		objList.add(objSummary);
+		ObjectListing objListing = mock(ObjectListing.class);
+		when(objListing.getObjectSummaries()).thenReturn(objList);
+		when(objListing.isTruncated()).thenReturn(false);
+
+		AmazonS3 s3Client = Mockito.mock(AmazonS3.class);
+		String bucket = StackConfiguration.getS3Bucket();
+		when(s3Client.listObjects(bucket, KeyFactory.stringToKey(nodeId) + "/")).thenReturn(objListing);
+		ReflectionTestUtils.setField(unwrap(), "amazonS3Client", s3Client);
 	}
 
 	@After
@@ -110,9 +150,131 @@ public class StorageLocationDAOImplTest {
 	}
 
 	@Test
-	public void test() throws NotFoundException, DatastoreException {
-		this.dao.replaceLocationData(locations);
+	public void testReplaceLocationData() throws NotFoundException, DatastoreException {
+		long c = basicDao.getCount(DBOStorageLocation.class);
+		dao.replaceLocationData(locations);
 		// We have inserted 4 rows in this unit test
-		Assert.assertTrue(this.dboBasicDao.getCount(DBOStorageLocation.class) >= 4);
+		Assert.assertEquals(4L + c, basicDao.getCount(DBOStorageLocation.class));
+		// Repeat should replace the same 4 rows (i.e. shouldn't add another 4 rows)
+		dao.replaceLocationData(locations);
+		Assert.assertEquals(4L + c, basicDao.getCount(DBOStorageLocation.class));
+	}
+
+	@Test
+	public void testTotalUsage() throws DatastoreException {
+		dao.replaceLocationData(locations);
+		Long total = dao.getTotalUsage(userId);
+		Assert.assertEquals(87L, total.longValue());
+		total = dao.getTotalUsage("syn9293829999990"); // fake user
+		Assert.assertEquals(0L, total.longValue());
+	}
+
+	@Test
+	public void testGetAggregatedUsage() {
+
+		dao.replaceLocationData(locations);
+
+		List<StorageUsageDimension> dList = new ArrayList<StorageUsageDimension>();
+		StorageUsageSummaryList susList = dao.getAggregatedUsage(userId, dList);
+		Assert.assertEquals(userId, susList.getUserId());
+		Assert.assertEquals(87L, susList.getGrandTotal().longValue());
+		Assert.assertEquals(0, susList.getSummaryList().size());
+
+		dList.add(StorageUsageDimension.IS_ATTACHMENT);
+		dList.add(StorageUsageDimension.STORAGE_PROVIDER);
+		susList = dao.getAggregatedUsage(userId, dList);
+		Assert.assertEquals(userId, susList.getUserId());
+		Assert.assertEquals(87L, susList.getGrandTotal().longValue());
+		List<StorageUsageSummary> summaryList = susList.getSummaryList();
+		Assert.assertEquals(3, summaryList.size());
+		long sum = 0;
+		for (StorageUsageSummary summary : summaryList) {
+			Assert.assertEquals(userId, summary.getUserId());
+			List<StorageUsageDimensionValue> dvList = summary.getDimensionList();
+			Assert.assertEquals(2, dvList.size());
+			Assert.assertEquals(StorageUsageDimension.IS_ATTACHMENT, dvList.get(0).getDimension());
+			Assert.assertEquals(StorageUsageDimension.STORAGE_PROVIDER, dvList.get(1).getDimension());
+			sum = sum + summary.getTotalSize();
+		}
+		Assert.assertEquals(87L, sum);
+	}
+
+	@Test
+	public void testGetStorageUsageInRange() {
+
+		dao.replaceLocationData(locations);
+
+		int beginIncl = 0;
+		int endExcl = 1000;
+		StorageUsageList usage = dao.getStorageUsageInRange(userId, beginIncl, endExcl);
+
+		//Assert.assertEquals(87L, usage.getGrandTotal().longValue());
+		Assert.assertEquals(userId, usage.getUserId());
+
+		List<StorageUsage> suList = usage.getUsageList();
+		Assert.assertEquals(4, suList.size());
+		Map<String, StorageUsage> suMap = new HashMap<String, StorageUsage>();
+		for (StorageUsage su : suList) {
+			suMap.put(su.getLocation(), su);
+		}
+		Assert.assertEquals(4, suMap.size());
+
+		StorageUsage su = suMap.get("/" + KeyFactory.stringToKey(nodeId) + "/ad1Token");
+		Assert.assertNotNull(su);
+		Assert.assertEquals(userId, su.getUserId());
+		Assert.assertEquals(nodeId, su.getNodeId());
+		Assert.assertTrue(su.getIsAttachment());
+		Assert.assertEquals(LocationTypeNames.awss3, su.getStorageProvider());
+		Assert.assertEquals("/" + KeyFactory.stringToKey(nodeId) + "/ad1Token", su.getLocation());
+		Assert.assertEquals("ad1Code", su.getContentType());
+		Assert.assertEquals(23L, su.getContentSize().longValue());
+		Assert.assertEquals("ad1Md5", su.getContentMd5());
+
+		su = suMap.get("/" + KeyFactory.stringToKey(nodeId) + "/ad2Token");
+		Assert.assertNotNull(su);
+		Assert.assertEquals(userId, su.getUserId());
+		Assert.assertEquals(nodeId, su.getNodeId());
+		Assert.assertTrue(su.getIsAttachment());
+		Assert.assertEquals(LocationTypeNames.awss3, su.getStorageProvider());
+		Assert.assertEquals("/" + KeyFactory.stringToKey(nodeId) + "/ad2Token", su.getLocation());
+		Assert.assertEquals("ad2Code", su.getContentType());
+		Assert.assertEquals(53L, su.getContentSize().longValue());
+		Assert.assertEquals("ad2Md5", su.getContentMd5());
+
+		su = suMap.get("ld1Path");
+		Assert.assertNotNull(su);
+		Assert.assertEquals(userId, su.getUserId());
+		Assert.assertEquals(nodeId, su.getNodeId());
+		Assert.assertFalse(su.getIsAttachment());
+		Assert.assertEquals(LocationTypeNames.external, su.getStorageProvider());
+		Assert.assertEquals("ld1Path", su.getLocation());
+		Assert.assertEquals("ldContentType", su.getContentType());
+		Assert.assertEquals(0L, su.getContentSize().longValue());
+		Assert.assertEquals("ldMd5", su.getContentMd5());
+
+		su = suMap.get("abc/xyz");
+		Assert.assertNotNull(su);
+		Assert.assertEquals(userId, su.getUserId());
+		Assert.assertEquals(nodeId, su.getNodeId());
+		Assert.assertFalse(su.getIsAttachment());
+		Assert.assertEquals(LocationTypeNames.awss3, su.getStorageProvider());
+		Assert.assertEquals("abc/xyz", su.getLocation());
+		Assert.assertEquals("ldContentType", su.getContentType());
+		Assert.assertEquals(11L, su.getContentSize().longValue());
+		Assert.assertEquals("ldMd5", su.getContentMd5());
+
+		beginIncl = 1;
+		endExcl = 3;
+		usage = dao.getStorageUsageInRange(userId, beginIncl, endExcl);
+		suList = usage.getUsageList();
+		Assert.assertEquals(2, suList.size());
+	}
+
+	private StorageLocationDAO unwrap() throws Exception {
+		if(AopUtils.isAopProxy(dao) && dao instanceof Advised) {
+			Object target = ((Advised)dao).getTargetSource().getTarget();
+			return (StorageLocationDAOImpl)target;
+		}
+		return dao;
 	}
 }

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsage.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsage.json
@@ -1,5 +1,5 @@
 {
-	"description": "JSON schema for information about a single storage location.",
+	"description": "JSON schema for usage information about a single storage location.",
 	"properties": {
 		"id": {
 			"description": "The id of the storage location.",

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsageDimension.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsageDimension.json
@@ -2,7 +2,7 @@
 	"description": "JSON schema for aggregating dimensions for storage usage.",
 	"type": "string",
 	"enum": [
-		"ATTACHMENT",
+		"IS_ATTACHMENT",
 		"STORAGE_PROVIDER",
 		"CONTENT_TYPE"
 	]

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsageDimensionList.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsageDimensionList.json
@@ -1,7 +1,0 @@
-{
-	"description": "JSON schema for a list of aggregating dimensions for storage usage.",
-	"type": "array",
-	"items": {
-		"$ref": "org.sagebionetworks.repo.model.storage.StorageUsageDimension"
-	}
-}

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsageDimensionValue.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsageDimensionValue.json
@@ -1,0 +1,15 @@
+{
+	"description": "JSON schema for an aggregating dimension value. For example, 'aws_s3' is a value for the 'storage_provider' dimension.",
+	"properties": {
+		"dimension": {
+			"description": "The aggregating dimension. For example, STORAGE_PROVIDER.",
+			"$ref": "org.sagebionetworks.repo.model.storage.StorageUsageDimension",
+			"required": true
+		},
+		"value" : {
+			"description": "The value. For example, 'aws_s3'.",
+			"type": "string",
+			"required": true
+		} 
+	}
+}

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsageList.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsageList.json
@@ -11,11 +11,11 @@
 			"type": "integer",
 			"required": true
 		},
-		"locationList": {
-			"description": "The list of storage locations.",
+		"usageList": {
+			"description": "The list of storage usages.",
 			"type": "array",
 			"items":  {
-				"$ref": "org.sagebionetworks.repo.model.storage.StorageLocation"
+				"$ref": "org.sagebionetworks.repo.model.storage.StorageUsage"
 			},
 			"required": true
 		}

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsageSummary.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/storage/StorageUsageSummary.json
@@ -13,7 +13,7 @@
 			],
 			"type": "array",
 			"items": {
-				"type": "string"
+				"$ref": "org.sagebionetworks.repo.model.storage.StorageUsageDimensionValue"
 			},
 			"required": true
 		},

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/StorageLocationDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/StorageLocationDAO.java
@@ -1,5 +1,11 @@
 package org.sagebionetworks.repo.model;
 
+import java.util.List;
+
+import org.sagebionetworks.repo.model.storage.StorageUsageDimension;
+import org.sagebionetworks.repo.model.storage.StorageUsageList;
+import org.sagebionetworks.repo.model.storage.StorageUsageSummaryList;
+
 /**
  * Accesses database for storage locations.
  *
@@ -8,10 +14,30 @@ package org.sagebionetworks.repo.model;
 public interface StorageLocationDAO {
 
 	/**
-	 * Replaces the storage locations for a given node.
+	 * Replaces the storage locations for a given node. Storage locations are
+	 * extracted from the annotations blobs.
 	 */
 	void replaceLocationData(StorageLocations locations) throws DatastoreException;
 
-	// TODO : Long getUsage(String userId, String locationType) 
-	//            throws NotFoundException, DatastoreException, InvalidModelException;
+	/**
+	 * Gets the total usage in bytes for the specified user.
+	 */
+	Long getTotalUsage(String userId) throws DatastoreException;
+
+	/**
+	 * Gets the aggregated totals in bytes for the specified user. Numbers are
+	 * aggregated by the supplied dimension list. If the list of dimensions
+	 * is empty, this will return the grand total.
+	 *
+	 * @throws InvalidModelException Dimensions have invalid column names
+	 */
+	StorageUsageSummaryList getAggregatedUsage(String userId, List<StorageUsageDimension> dimensionList)
+			throws InvalidModelException, DatastoreException;
+
+	/**
+	 * Gets detailed, itemized storage usage for the specified user. Results are paged as
+	 * specified by the begin (inclusive) and the end (exclusive) indices.
+	 */
+	StorageUsageList getStorageUsageInRange(String userId, long beginIncl, long endExcl)
+			throws DatastoreException;
 }


### PR DESCRIPTION
1) Note that this is a release patch.  So first of all it includes modifications on DELETE to avoid deadlocks.  This change was meant to be an minor improvement.  But I noticed today that the data migrator has been running much slower due to deadlocks on insertions into the new storage_location table.  There were already deadlocks on the string annotations table.  Now it is getting much worse with more deadlocks on the storage location table.  The data migrator has been running for 9 hours only 20% done. This prompts me to peel off the changes associated with StorageLocationDAOImpl into a release patch.

2) Storage DTOs get more consistent names.  A new DTO StorageLocationDimensionValue to capture the name-value pair as suggested by your last review.  Remove one storage usage DTO that is not going to be used.

3) Implement StorageLocationDAO for 3 queries of storage usage.

The remaining part of this feature implementation (i.e. controller/service/manager) will be in a separate change list on the develop branch.
