### PR TITLE
Move query service out of entity service into its class

### DIFF
--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/QueryController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/QueryController.java
@@ -22,33 +22,20 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
  * @author deflaux
- * 
  */
 @Controller
 public class QueryController extends BaseController {
 
 	@Autowired
-	ServiceProvider serviceProvider;	
+	private ServiceProvider serviceProvider;	
 
-	/**
-	 * @param userId
-	 * @param query
-	 * @param request
-	 * @return paginated results
-	 * @throws DatastoreException
-	 * @throws ParseException
-	 * @throws NotFoundException
-	 * @throws UnauthorizedException
-	 */
 	@ResponseStatus(HttpStatus.OK)
 	@RequestMapping(value = UrlHelpers.QUERY, method = RequestMethod.GET)
-	public @ResponseBody
-	QueryResults query(
+	public @ResponseBody QueryResults query(
 			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = false) String userId,
 			@RequestParam(value = ServiceConstants.QUERY_PARAM, required = true) String query,
-			HttpServletRequest request) throws DatastoreException,
-			ParseException, NotFoundException, UnauthorizedException {
-		return serviceProvider.getEntityService().query(userId, query, request);
+			HttpServletRequest request)
+			throws DatastoreException, ParseException, NotFoundException, UnauthorizedException {
+		return serviceProvider.getNodeQueryService().query(userId, query, request);
 	}
-	
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EntityService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EntityService.java
@@ -14,13 +14,11 @@ import org.sagebionetworks.repo.model.Entity;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.InvalidModelException;
 import org.sagebionetworks.repo.model.PaginatedResults;
-import org.sagebionetworks.repo.model.QueryResults;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.attachment.PresignedUrl;
 import org.sagebionetworks.repo.model.attachment.S3AttachmentToken;
 import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
-import org.sagebionetworks.repo.model.query.BasicQuery;
 import org.sagebionetworks.repo.queryparser.ParseException;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.repo.web.PaginatedParameters;
@@ -456,20 +454,6 @@ public interface EntityService {
 			throws NotFoundException, DatastoreException, UnauthorizedException, ConflictingUpdateException;
 
 	/**
-	 * Execute a query and include the annotations for each entity.
-	 * @param <T>
-	 * @param userInfo
-	 * @param query
-	 * @param clazz
-	 * @param request
-	 * @return
-	 * @throws NotFoundException 
-	 * @throws DatastoreException 
-	 * @throws UnauthorizedException 
-	 */
-	public QueryResults executeQueryWithAnnotations(String userId, BasicQuery query, HttpServletRequest request) throws DatastoreException, NotFoundException, UnauthorizedException;
-
-	/**
 	 * determine whether a user has the given access type for a given entity
 	 * @param nodeId
 	 * @param userId
@@ -586,23 +570,6 @@ public interface EntityService {
 			String tokenID) throws NotFoundException, DatastoreException, UnauthorizedException, InvalidModelException;
 
 	/**
-	 * Perform a query.
-	 * 
-	 * @param userId
-	 * @param query
-	 * @param request
-	 * @return
-	 * @throws DatastoreException
-	 * @throws ParseException
-	 * @throws NotFoundException
-	 * @throws UnauthorizedException
-	 */
-	public QueryResults query(String userId, String query, HttpServletRequest request)
-			throws DatastoreException, ParseException, NotFoundException,
-			UnauthorizedException;
-
-	
-	/**
 	 * Get the number of children that this entity has.
 	 * 
 	 * @param userId
@@ -617,5 +584,4 @@ public interface EntityService {
 	public boolean doesEntityHaveChildren(String userId, String entityId,
 			HttpServletRequest request) throws DatastoreException,
 			ParseException, NotFoundException, UnauthorizedException;
-	
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/NodeQueryService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/NodeQueryService.java
@@ -1,0 +1,22 @@
+package org.sagebionetworks.repo.web.service;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.sagebionetworks.repo.model.DatastoreException;
+import org.sagebionetworks.repo.model.QueryResults;
+import org.sagebionetworks.repo.model.UnauthorizedException;
+import org.sagebionetworks.repo.model.query.BasicQuery;
+import org.sagebionetworks.repo.queryparser.ParseException;
+import org.sagebionetworks.repo.web.NotFoundException;
+
+public interface NodeQueryService {
+
+	QueryResults query(String userId, String query, HttpServletRequest request)
+			throws DatastoreException, ParseException, NotFoundException, UnauthorizedException;
+
+	/**
+	 * Executes a query and includes the annotations for each entity.
+	 */
+	QueryResults executeQueryWithAnnotations(String userId, BasicQuery query, HttpServletRequest request)
+			throws DatastoreException, NotFoundException, UnauthorizedException;
+}

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/NodeQueryServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/NodeQueryServiceImpl.java
@@ -1,0 +1,102 @@
+package org.sagebionetworks.repo.web.service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.sagebionetworks.repo.manager.UserManager;
+import org.sagebionetworks.repo.model.DatastoreException;
+import org.sagebionetworks.repo.model.NodeQueryDao;
+import org.sagebionetworks.repo.model.NodeQueryResults;
+import org.sagebionetworks.repo.model.QueryResults;
+import org.sagebionetworks.repo.model.UnauthorizedException;
+import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.model.query.BasicQuery;
+import org.sagebionetworks.repo.queryparser.ParseException;
+import org.sagebionetworks.repo.util.QueryTranslator;
+import org.sagebionetworks.repo.web.NotFoundException;
+import org.sagebionetworks.repo.web.query.QueryStatement;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class NodeQueryServiceImpl implements NodeQueryService {
+
+	private static final String[] excludedDatasetProperties = {
+			"uri", "etag", "annotations", "layer"
+		};
+
+	private static final String[] excludedLayerProperties = {
+			"uri", "etag", "annotations", "preview", "locations"
+		};
+
+	private static final Map<String, Set<String>> EXCLUDED_PROPERTIES;
+	static {
+		Set<String> datasetProperties = new HashSet<String>();
+		datasetProperties.addAll(Arrays.asList(excludedDatasetProperties));
+		Set<String> layerProperties = new HashSet<String>();
+		layerProperties.addAll(Arrays.asList(excludedLayerProperties));
+		Map<String, Set<String>> excludedProperties = new HashMap<String, Set<String>>();
+		excludedProperties.put("dataset", datasetProperties);
+		excludedProperties.put("layer", layerProperties);
+		EXCLUDED_PROPERTIES = Collections.unmodifiableMap(excludedProperties);
+	}
+
+	@Autowired
+	private NodeQueryDao nodeQueryDao;
+
+	@Autowired
+	private UserManager userManager;
+
+	@Override
+	public QueryResults query(String userId, String query, HttpServletRequest request)
+			throws DatastoreException, ParseException, NotFoundException, UnauthorizedException {
+
+		// Parse and validate the query
+		QueryStatement stmt = new QueryStatement(query);
+		// Convert from a query statement to a basic query
+		BasicQuery basic = QueryTranslator.createBasicQuery(stmt);
+		QueryResults results = executeQueryWithAnnotations(userId, basic, request);
+		results.setResults(formulateResult(stmt, results.getResults()));
+		return results;
+	}
+
+	@Override
+	public QueryResults executeQueryWithAnnotations(String userId, BasicQuery query, HttpServletRequest request)
+			throws DatastoreException, NotFoundException, UnauthorizedException {
+
+		if (query == null) {
+			throw new IllegalArgumentException("Query cannot be null");
+		}
+
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		NodeQueryResults nodeResults = nodeQueryDao.executeQuery(query, userInfo);
+		return new QueryResults(nodeResults.getAllSelectedData(), nodeResults.getTotalNumberOfResults());
+	}
+
+	private List<Map<String, Object>> formulateResult(QueryStatement stmt, List<Map<String, Object>> rows) {
+
+		List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
+		for (Map<String, Object> row : rows) {
+			results.add(formulateResult(stmt, row));
+		}
+		return results;
+	}
+
+	private Map<String, Object> formulateResult(QueryStatement stmt,
+			Map<String, Object> fields) {
+
+		Map<String, Object> result = new HashMap<String, Object>();
+		for (String field : fields.keySet()) {
+			if (!EXCLUDED_PROPERTIES.get("dataset").contains(field)) {
+				result.put(stmt.getTableName() + "." + field, fields.get(field));
+			}
+		}
+		return result;
+	}
+}

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/ServiceProvider.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/ServiceProvider.java
@@ -23,6 +23,8 @@ public class ServiceProvider {
 	@Autowired
 	private EntityBundleService entityBundleService;
 	@Autowired
+	private NodeQueryService nodeQueryService;
+	@Autowired
 	private S3TokenService s3TokenService;
 	@Autowired
 	private StorageUsageService storageUsageService;
@@ -49,6 +51,9 @@ public class ServiceProvider {
 	public EntityBundleService getEntityBundleService() {
 		return entityBundleService;
 	}
+	public NodeQueryService getNodeQueryService() {
+		return nodeQueryService;
+	}
 	public S3TokenService getS3TokenService() {
 		return s3TokenService;
 	}
@@ -61,5 +66,4 @@ public class ServiceProvider {
 	public UserProfileService getUserProfileService() {
 		return userProfileService;
 	}
-	
 }

--- a/services/repository/src/main/resources/controller-spb.xml
+++ b/services/repository/src/main/resources/controller-spb.xml
@@ -40,6 +40,9 @@
 	<!-- The Entity Service -->
 	<bean id="entityService" class="org.sagebionetworks.repo.web.service.EntityServiceImpl" />
 
+	<!-- The Node Query Service -->
+	<bean id="nodeQueryService" class="org.sagebionetworks.repo.web.service.NodeQueryServiceImpl" />
+
 	<!-- The S3Token Service -->
 	<bean id="s3TokenService" class="org.sagebionetworks.repo.web.service.S3TokenServiceImpl" />
 


### PR DESCRIPTION
There is the query controller but no query service.  Query service is included within entity service.  At the same time the entity service API and implementation is overloaded with 40+ public methods.  This change separate out query service from entity service to make the code more manageable.
