### PR TITLE
Add thread number to logging

### DIFF
--- a/services/repository/src/main/resources/log4j.properties
+++ b/services/repository/src/main/resources/log4j.properties
@@ -9,7 +9,7 @@ log4j.additivity.rootLogger=false
 # Configure the console as our one appender
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
 log4j.appender.A1.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.A1.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] [%x] - %m%n
+log4j.appender.A1.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] - %m%n
 
 # Configure files as appender for profiler
 # Normal profiler
@@ -23,7 +23,7 @@ log4j.appender.traceProfiling.rollingPolicy=org.sagebionetworks.sweeper.log4j.Ti
 log4j.appender.traceProfiling.rollingPolicy.ActiveFileName=logs/repo-trace-profile.log
 log4j.appender.traceProfiling.rollingPolicy.FileNamePattern=logs/repo-trace-profile.%d{yyyy-MM-dd-hh-mm}.log.gz
 log4j.appender.traceProfiling.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.traceProfiling.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] [%x] - %m%n
+log4j.appender.traceProfiling.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] - %m%n
 
 # Critical perf (> 2s)
 #log4j.additivity.profiler.org.sagebionetworks.LoggingProfiler=false
@@ -42,7 +42,7 @@ log4j.appender.slowProfiling.rollingPolicy=org.sagebionetworks.sweeper.log4j.Tim
 log4j.appender.slowProfiling.rollingPolicy.ActiveFileName=logs/repo-slow-profile.log
 log4j.appender.slowProfiling.rollingPolicy.FileNamePattern=logs/repo-slow-profile.%d{yyyy-MM-dd-hh-mm}.log.gz
 log4j.appender.slowProfiling.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.slowProfiling.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] [%x] - %m%n
+log4j.appender.slowProfiling.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] - %m%n
 
 
 # Set this to debug if you want to see what URLs controllers are getting mapped to
@@ -67,4 +67,4 @@ log4j.appender.activityAppender.rollingPolicy=org.sagebionetworks.sweeper.log4j.
 log4j.appender.activityAppender.rollingPolicy.ActiveFileName=logs/repo-activity.log
 log4j.appender.activityAppender.rollingPolicy.FileNamePattern=logs/repo-activity.%d{yyyy-MM-dd-hh-mm}.gz
 log4j.appender.activityAppender.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.activityAppender.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] [%x] - %m%n
+log4j.appender.activityAppender.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] - %m%n

--- a/services/repository/src/main/resources/log4j.properties
+++ b/services/repository/src/main/resources/log4j.properties
@@ -9,7 +9,7 @@ log4j.additivity.rootLogger=false
 # Configure the console as our one appender
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
 log4j.appender.A1.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.A1.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%c] - %m%n
+log4j.appender.A1.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] [%x] - %m%n
 
 # Configure files as appender for profiler
 # Normal profiler
@@ -23,7 +23,7 @@ log4j.appender.traceProfiling.rollingPolicy=org.sagebionetworks.sweeper.log4j.Ti
 log4j.appender.traceProfiling.rollingPolicy.ActiveFileName=logs/repo-trace-profile.log
 log4j.appender.traceProfiling.rollingPolicy.FileNamePattern=logs/repo-trace-profile.%d{yyyy-MM-dd-hh-mm}.log.gz
 log4j.appender.traceProfiling.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.traceProfiling.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%c] - %m%n
+log4j.appender.traceProfiling.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] [%x] - %m%n
 
 # Critical perf (> 2s)
 #log4j.additivity.profiler.org.sagebionetworks.LoggingProfiler=false
@@ -42,7 +42,7 @@ log4j.appender.slowProfiling.rollingPolicy=org.sagebionetworks.sweeper.log4j.Tim
 log4j.appender.slowProfiling.rollingPolicy.ActiveFileName=logs/repo-slow-profile.log
 log4j.appender.slowProfiling.rollingPolicy.FileNamePattern=logs/repo-slow-profile.%d{yyyy-MM-dd-hh-mm}.log.gz
 log4j.appender.slowProfiling.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.slowProfiling.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%c] - %m%n
+log4j.appender.slowProfiling.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] [%x] - %m%n
 
 
 # Set this to debug if you want to see what URLs controllers are getting mapped to
@@ -67,4 +67,4 @@ log4j.appender.activityAppender.rollingPolicy=org.sagebionetworks.sweeper.log4j.
 log4j.appender.activityAppender.rollingPolicy.ActiveFileName=logs/repo-activity.log
 log4j.appender.activityAppender.rollingPolicy.FileNamePattern=logs/repo-activity.%d{yyyy-MM-dd-hh-mm}.gz
 log4j.appender.activityAppender.layout=org.apache.log4j.EnhancedPatternLayout
-log4j.appender.activityAppender.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%c] - %m%n
+log4j.appender.activityAppender.layout.ConversionPattern=%d{ISO8601}{GMT+0} %-5p [%15.15t] [%c] [%x] - %m%n


### PR DESCRIPTION
What we have now:

2012-09-27 11:01:24,098 INFO  [org.sagebionetworks.repo.manager.EntityManagerImpl] - Entered updateEntity()
2012-09-27 11:01:24,207 INFO  [org.sagebionetworks.repo.manager.AmazonS3UtilityImpl] - Attempting to download: 28/58/Australia.png from devewudata.sagebase.org

After the change we will have thread number (notice that the preview worker is on its own thread):

2012-09-27 23:53:05,202 INFO  [io-8080-exec-13] [org.sagebionetworks.repo.manager.EntityManagerImpl] - Entered updateEntity()
2012-09-27 23:53:05,226 INFO  [pool-8-thread-1] [org.sagebionetworks.repo.manager.AmazonS3UtilityImpl] - Attempting to download: 28/60/Denmark.png from devewudata.sagebase.org
