### PR TITLE
PLFM-1408: Make version labels same as version number by default

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImpl.java
@@ -298,17 +298,15 @@ public class NodeDAOImpl implements NodeDAO, NodeBackupDAO, InitializingBean {
 		// Make a copy of the current revision with an incremented the version number
 		DBORevision newRev = JDORevisionUtils.makeCopyForNewVersion(rev);
 		if(newVersion.getVersionLabel() == null) {
-			// This is a fix for PLFM-995
-			newVersion.setVersionLabel(KeyFactory.keyToString(newRev.getRevisionNumber()));
+			// This is a fix for PLFM-995.  This was modified not to use the KeyFactory because
+			// version labels should NOT be prefixed with syn (per PLFM-1408).
+			newVersion.setVersionLabel(newRev.getRevisionNumber().toString());
 		}
 		// Now update the new revision and node
 		NodeUtils.updateFromDto(newVersion, jdo, newRev);
 		// The new revision becomes the current version
 		jdo.setCurrentRevNumber(newRev.getRevisionNumber());
-		if(newVersion.getVersionLabel() == null) {
-			// This is a fix for PLFM-995
-			newRev.setLabel(KeyFactory.keyToString(newRev.getRevisionNumber()));
-		}
+
 		// Save the change to the node
 		dboBasicDao.update(jdo);
 		dboBasicDao.createNew(newRev);

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImplTest.java
@@ -785,9 +785,21 @@ public class NodeDAOImplTest {
 		loaded = nodeDao.getNode(id);
 		assertNotNull(loaded);
 		assertEquals(node.getVersionComment(), loaded.getVersionComment());
-		assertEquals(KeyFactory.keyToString(newNumber), loaded.getVersionLabel());
+		assertEquals(newNumber.toString(), loaded.getVersionLabel());
 	}
 	
+	@Test public void testCreateVersionDefaults() throws Exception {
+		Node node = privateCreateNew("testCreateNewVersion");
+		String id = nodeDao.createNew(node);
+		toDelete.add(id);
+		assertNotNull(id);
+		Node loaded = nodeDao.getNode(id);
+		assertNotNull(loaded);
+		assertEquals(null, loaded.getVersionComment());
+		assertEquals(NodeConstants.DEFAULT_VERSION_LABEL, loaded.getVersionLabel());
+		assertEquals(NodeConstants.DEFAULT_VERSION_NUMBER, loaded.getVersionNumber());
+	}
+
 	@Test
 	public void testNewVersionAnnotations() throws Exception {
 		Node node = privateCreateNew("testCreateAnnotations");

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/NodeConstants.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/NodeConstants.java
@@ -28,11 +28,7 @@ public class NodeConstants {
 	 * The name of the type column.
 	 */
 	public static final String COLUMN_LAYER_TYPE = "type";
-	
-	/**
-	 * The default versionLabel for nodes
-	 */
-	public static final String DEFAULT_VERSION_LABEL = "0.0.0";
+
 	
 	/**
 	 * Forward slash should be the prefix of a node's path.
@@ -55,4 +51,8 @@ public class NodeConstants {
 	
 	public static final Long DEFAULT_VERSION_NUMBER = new Long(1);
 	
+	/**
+	 * The default versionLabel for nodes
+	 */
+	public static final String DEFAULT_VERSION_LABEL = DEFAULT_VERSION_NUMBER.toString();
 }


### PR DESCRIPTION
Also, fixed the first label being set to "0.0.0"
