### PR TITLE
Disabled testCRUD() and testListSearchDocuments() due to timeout

### DIFF
--- a/lib/lib-search/src/test/java/org/sagebionetworks/search/SearchDaoImplAutowireTest.java
+++ b/lib/lib-search/src/test/java/org/sagebionetworks/search/SearchDaoImplAutowireTest.java
@@ -109,7 +109,8 @@ public class SearchDaoImplAutowireTest {
 		assertTrue(status.getOptions().indexOf(domainStatus.getDocService().getArn()) > 0);
 		assertTrue(status.getOptions().indexOf(domainStatus.getSearchService().getArn()) > 0);
 	}
-	
+
+	@Ignore
 	@Test
 	public void testCRUD() throws ClientProtocolException, IOException, HttpClientHelperException, InterruptedException{
 		// Before we start this test delete all data in the search index
@@ -181,7 +182,8 @@ public class SearchDaoImplAutowireTest {
 		// It should not exists
 		assertFalse(searchDao.doesDocumentExist(id, etag));
 	}
-	
+
+	@Ignore
 	@Test
 	public void testListSearchDocuments() throws ClientProtocolException, IOException, HttpClientHelperException, InterruptedException{
 		// Before we start this test delete all data in the search index


### PR DESCRIPTION
We increased the timeout threshold from 1 minute to 10 minutes recently. Still times out.
