### PR TITLE
Add metrics to dynamo workers

### DIFF
--- a/lib/logging/src/main/resources/cloudwatch-spb.xml
+++ b/lib/logging/src/main/resources/cloudwatch-spb.xml
@@ -9,33 +9,44 @@
        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
        http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
-	
+
 	<!-- Turn on Spring's autoproxy using AspectJ's @Aspect annotations. -->
 	<aop:aspectj-autoproxy />
-	
-	<import resource="classpath:aws-spb.xml" />
 
-	<!-- controllerProfiler that collects latency information in the form of CloudWatch objects --> 
-	<bean id="controllerProfiler" class="org.sagebionetworks.cloudwatch.ControllerProfiler">
-		<property name="shouldProfile" ref="stackConfiguration.cloudWatchOnOff"/>
+	<import resource="classpath:stack-configuration.spb.xml" />
+
+	<bean id="userID" class="org.sagebionetworks.StackConfiguration" factory-method="getIAMUserId"/>
+	<bean id="userKey" class="org.sagebionetworks.StackConfiguration" factory-method="getIAMUserKey"/>
+
+	<!-- bean for AmazonWebServices BasicAWSCredentials -->
+	<bean id="awsCredentials" class="com.amazonaws.auth.BasicAWSCredentials">
+		<constructor-arg index="0"><ref bean="userID"/></constructor-arg>
+		<constructor-arg index="1"><ref bean="userKey"/></constructor-arg>
+	</bean>	
+
+	<!-- bean for AmazonCloudWatch client -->
+	<bean id="cloudWatchClient" class="com.amazonaws.services.cloudwatch.AmazonCloudWatchClient">
+  		<constructor-arg>
+            <ref bean="awsCredentials"/>
+        </constructor-arg>
 	</bean>
-	
+
 	<!-- A consumer that logs performance data for all bean method calls to Amazon CloudWatch. -->  
 	<bean id="consumer" class="org.sagebionetworks.cloudwatch.Consumer" scope="singleton"/>
-	
+
 	<!--  bean saying we want to invoke the sendEm method in Consumer class -->
 	<bean id="methodInvoking" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
   		<property name="targetObject" ref="consumer" />
   		<property name="targetMethod" value="executeCloudWatchPut" />
 	</bean>
-	
+
 	<!--  bean that creates trigger for the sendEm method of the consumer every number of seconds -->
 	<bean id="simpleTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerBean">
     	<property name="jobDetail" ref="methodInvoking" />
     	<property name="startDelay" value="0" />
     	<property name="repeatInterval" ref="stackConfiguration.cloudWatchTriggerTime" />
 	</bean>
-	
+
 	<!-- Trigger needs a scheduler to start it -->
 	<bean class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
 		<property name="autoStartup">
@@ -47,20 +58,4 @@
     		</list>
   		</property>
 	</bean>	
-	
-	<bean id="userID" class="org.sagebionetworks.StackConfiguration" factory-method="getIAMUserId"/>
-	<bean id="userKey" class="org.sagebionetworks.StackConfiguration" factory-method="getIAMUserKey"/>
-	
-	<!-- bean for AmazonWebServices BasicAWSCredentials -->
-	<bean id="awsCredentials" class="com.amazonaws.auth.BasicAWSCredentials">
-		<constructor-arg index="0"><ref bean="userID"/></constructor-arg>
-		<constructor-arg index="1"><ref bean="userKey"/></constructor-arg>
-	</bean>	
-	
-	<!-- bean for AmazonCloudWatch client -->
-	<bean id="cloudWatchClient" class="com.amazonaws.services.cloudwatch.AmazonCloudWatchClient">
-  		<constructor-arg>
-            <ref bean="awsCredentials"/>
-        </constructor-arg>
-	</bean>
 </beans>

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/dynamo/NodeTreeUpdateManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/dynamo/NodeTreeUpdateManager.java
@@ -1,4 +1,4 @@
-package org.sagebionetworks.dynamo.manager;
+package org.sagebionetworks.repo.manager.dynamo;
 
 import java.util.Date;
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/dynamo/NodeTreeUpdateManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/dynamo/NodeTreeUpdateManagerImpl.java
@@ -1,4 +1,4 @@
-package org.sagebionetworks.dynamo.manager;
+package org.sagebionetworks.repo.manager.dynamo;
 
 import java.util.ArrayList;
 import java.util.Date;

--- a/services/repository-managers/src/main/resources/managers-spb.xml
+++ b/services/repository-managers/src/main/resources/managers-spb.xml
@@ -217,6 +217,11 @@
 	<bean id="nodeTreeQueryManager" class="org.sagebionetworks.repo.manager.dynamo.NodeTreeQueryManagerImpl"
 		scope="singleton" />
 
+	<bean id="nodeTreeUpdateManager" class="org.sagebionetworks.repo.manager.dynamo.NodeTreeUpdateManagerImpl">
+		<constructor-arg index="0" ref="nodeTreeUpdateDao" />
+		<constructor-arg index="1" ref="nodeDao" />
+	</bean>
+
 	<bean id="storageQuotaManager" class="org.sagebionetworks.repo.manager.StorageQuotaManagerImpl"
 		scope="singleton" />
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/dynamo/NodeTreeUpdateManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/dynamo/NodeTreeUpdateManagerImplTest.java
@@ -1,4 +1,4 @@
-package org.sagebionetworks.dynamo.manager;
+package org.sagebionetworks.repo.manager.dynamo;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -16,6 +16,8 @@ import org.junit.Test;
 import org.sagebionetworks.dynamo.dao.nodetree.IncompletePathException;
 import org.sagebionetworks.dynamo.dao.nodetree.NodeTreeUpdateDao;
 import org.sagebionetworks.dynamo.dao.nodetree.ObsoleteChangeException;
+import org.sagebionetworks.repo.manager.dynamo.NodeTreeUpdateManager;
+import org.sagebionetworks.repo.manager.dynamo.NodeTreeUpdateManagerImpl;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.NodeDAO;

--- a/services/repository/src/main/resources/controller-spb.xml
+++ b/services/repository/src/main/resources/controller-spb.xml
@@ -13,7 +13,7 @@
 
 	<import resource="classpath:search-dao.spb.xml" />
 	<import resource="classpath:managers-spb.xml" />
-	<import resource="classpath:controllerProfiler-spb.xml" />
+	<import resource="classpath:cloudwatch-spb.xml" />
 	<import resource="classpath:activityLogger-spb.xml" />
 
 	<!-- Make sure we can watch for deadlock on all methods of the Generic Entity 

--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizer.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizer.java
@@ -57,7 +57,7 @@ public class DynamoRdsSynchronizer {
 		// This is returns a value between 0 (inclusive) and count (exclusive)
 		// The value range is consistent with the MySQL OFFSET parameter
 		int r = this.random.nextInt(this.count);
-		QueryResults<NodeParentRelation> results = this.nodeDao.getParentRelations(r, 6);
+		QueryResults<NodeParentRelation> results = this.nodeDao.getParentRelations(r, 5);
 		Date date = new Date();
 
 		// Update the count to be used at next trigger

--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizer.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizer.java
@@ -8,7 +8,7 @@ import java.util.Random;
 import org.sagebionetworks.cloudwatch.Consumer;
 import org.sagebionetworks.cloudwatch.ProfileData;
 import org.sagebionetworks.dynamo.dao.nodetree.NodeTreeQueryDao;
-import org.sagebionetworks.dynamo.manager.NodeTreeUpdateManager;
+import org.sagebionetworks.repo.manager.dynamo.NodeTreeUpdateManager;
 import org.sagebionetworks.repo.model.NodeDAO;
 import org.sagebionetworks.repo.model.NodeParentRelation;
 import org.sagebionetworks.repo.model.QueryResults;

--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizer.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizer.java
@@ -5,13 +5,15 @@ import java.util.Date;
 import java.util.List;
 import java.util.Random;
 
-import org.apache.log4j.Logger;
+import org.sagebionetworks.cloudwatch.Consumer;
+import org.sagebionetworks.cloudwatch.ProfileData;
 import org.sagebionetworks.dynamo.dao.nodetree.NodeTreeQueryDao;
 import org.sagebionetworks.dynamo.manager.NodeTreeUpdateManager;
 import org.sagebionetworks.repo.model.NodeDAO;
 import org.sagebionetworks.repo.model.NodeParentRelation;
 import org.sagebionetworks.repo.model.QueryResults;
 import org.sagebionetworks.repo.model.jdo.KeyFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Synchronizes RDS and DynamoDB on randomly selected nodes.
@@ -20,7 +22,8 @@ import org.sagebionetworks.repo.model.jdo.KeyFactory;
  */
 public class DynamoRdsSynchronizer {
 
-	private final Logger logger = Logger.getLogger(DynamoRdsSynchronizer.class);
+	@Autowired
+	private Consumer consumer;
 
 	private final NodeDAO nodeDao;
 	private final NodeTreeQueryDao nodeTreeQueryDao;
@@ -54,7 +57,7 @@ public class DynamoRdsSynchronizer {
 		// This is returns a value between 0 (inclusive) and count (exclusive)
 		// The value range is consistent with the MySQL OFFSET parameter
 		int r = this.random.nextInt(this.count);
-		QueryResults<NodeParentRelation> results = this.nodeDao.getParentRelations(r, 1);
+		QueryResults<NodeParentRelation> results = this.nodeDao.getParentRelations(r, 6);
 		Date date = new Date();
 
 		// Update the count to be used at next trigger
@@ -67,16 +70,16 @@ public class DynamoRdsSynchronizer {
 
 		// Now cross check with DynamoDB
 		List<NodeParentRelation> list = results.getResults();
-		if (list != null && list.size() > 0) {
+		this.addMetric("TotalSync", list.size());
+		for (NodeParentRelation childParent : list) {
 
-			NodeParentRelation childParent = list.get(0);
 			String childInRds = childParent.getId();
 			String parentInRds = childParent.getParentId();
 			String childKeyInRds = KeyFactory.stringToKey(childInRds).toString();
 			String parentKeyInDynamo = this.nodeTreeQueryDao.getParent(childKeyInRds);
 			if (parentKeyInDynamo == null) {
 				// The child does not exist in DynamoDB yet
-				this.logger.info("Dynamo is missing " + childInRds);
+				this.addMetric("MissingNode", 1);
 				this.nodeTreeUpdateManager.create(childInRds, parentInRds, date);
 				return;
 			}
@@ -84,20 +87,28 @@ public class DynamoRdsSynchronizer {
 			if (parentInRds == null) {
 				// Check against the root
 				if (!this.nodeTreeQueryDao.isRoot(childKeyInRds)) {
-					this.logger.info("RDS's root node " + childKeyInRds + " is missing in Dynamo.");
+					this.addMetric("IncorrectRoot", 1);
+					this.nodeTreeUpdateManager.update(childKeyInRds, childKeyInRds, date);
 				}
-				this.nodeTreeUpdateManager.create(childKeyInRds, childKeyInRds, date);
 				return;
 			}
 
 			String parentKeyInRds = KeyFactory.stringToKey(parentInRds).toString();
 			if (!parentKeyInDynamo.equals(parentKeyInRds)) {
 				// Implies that the child is pointing to the wrong parent
-				this.logger.info("Child " + childKeyInRds
-						+ " is pointing to the wrong parent " + parentKeyInDynamo
-						+ ". It should point to " + parentKeyInRds + " instead.");
+				this.addMetric("IncorrectParent", 1);;
 				this.nodeTreeUpdateManager.update(childInRds, parentInRds, date);
 			}
 		}
+	}
+
+	private void addMetric(String name, long count) {
+		ProfileData profileData = new ProfileData();
+		profileData.setNamespace("DynamoRdsSynchronizer");
+		profileData.setName(name); // Method name
+		profileData.setLatency(count);
+		profileData.setUnit("Count");
+		profileData.setTimestamp(new Date());
+		consumer.addProfileData(profileData);
 	}
 }

--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
@@ -9,7 +9,7 @@ import org.apache.log4j.Logger;
 import org.sagebionetworks.asynchronous.workers.sqs.MessageUtils;
 import org.sagebionetworks.cloudwatch.Consumer;
 import org.sagebionetworks.cloudwatch.ProfileData;
-import org.sagebionetworks.dynamo.manager.NodeTreeUpdateManager;
+import org.sagebionetworks.repo.manager.dynamo.NodeTreeUpdateManager;
 import org.sagebionetworks.repo.model.message.ChangeMessage;
 import org.sagebionetworks.repo.model.message.ChangeType;
 import org.sagebionetworks.repo.model.message.ObjectType;

--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
@@ -21,12 +21,12 @@ public class DynamoQueueWorker implements Callable<List<Message>> {
 
 	private final Logger logger = Logger.getLogger(DynamoQueueWorker.class);
 
+	@Autowired
+	private Consumer consumer;
+
 	private final List<Message> messages;
 
 	private final NodeTreeUpdateManager updateManager;
-
-	@Autowired
-	private Consumer consumer;
 
 	public DynamoQueueWorker(List<Message> messageList,
 			NodeTreeUpdateManager updateManager) {

--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
@@ -13,7 +13,6 @@ import org.sagebionetworks.repo.manager.dynamo.NodeTreeUpdateManager;
 import org.sagebionetworks.repo.model.message.ChangeMessage;
 import org.sagebionetworks.repo.model.message.ChangeType;
 import org.sagebionetworks.repo.model.message.ObjectType;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import com.amazonaws.services.sqs.model.Message;
 
@@ -21,15 +20,14 @@ public class DynamoQueueWorker implements Callable<List<Message>> {
 
 	private final Logger logger = Logger.getLogger(DynamoQueueWorker.class);
 
-	@Autowired
-	private Consumer consumer;
+	private final Consumer consumer;
 
 	private final List<Message> messages;
 
 	private final NodeTreeUpdateManager updateManager;
 
 	public DynamoQueueWorker(List<Message> messageList,
-			NodeTreeUpdateManager updateManager) {
+			NodeTreeUpdateManager updateManager, Consumer consumer) {
 
 		if (messageList == null) {
 			throw new IllegalArgumentException("The list of messages cannot be null.");
@@ -37,9 +35,13 @@ public class DynamoQueueWorker implements Callable<List<Message>> {
 		if (updateManager == null) {
 			throw new IllegalArgumentException("Update manager cannot be null.");
 		}
+		if (consumer == null) {
+			throw new IllegalArgumentException("Consumer manager cannot be null.");
+		}
 
 		this.messages = messageList;
 		this.updateManager = updateManager;
+		this.consumer = consumer;
 	}
 
 	@Override

--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorkerFactory.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorkerFactory.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.sagebionetworks.asynchronous.workers.sqs.MessageWorkerFactory;
-import org.sagebionetworks.dynamo.manager.NodeTreeUpdateManager;
+import org.sagebionetworks.repo.manager.dynamo.NodeTreeUpdateManager;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.amazonaws.services.sqs.model.Message;

--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorkerFactory.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorkerFactory.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.sagebionetworks.asynchronous.workers.sqs.MessageWorkerFactory;
+import org.sagebionetworks.cloudwatch.Consumer;
 import org.sagebionetworks.repo.manager.dynamo.NodeTreeUpdateManager;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -14,8 +15,11 @@ public class DynamoQueueWorkerFactory implements MessageWorkerFactory{
 	@Autowired
 	private NodeTreeUpdateManager nodeTreeUpdateManager;
 
+	@Autowired
+	private Consumer consumer;
+
 	@Override
 	public Callable<List<Message>> createWorker(List<Message> messages) {
-		return new DynamoQueueWorker(messages, this.nodeTreeUpdateManager);
+		return new DynamoQueueWorker(messages, this.nodeTreeUpdateManager, this.consumer);
 	}
 }

--- a/services/workers/src/main/resources/dynamo-spb.xml
+++ b/services/workers/src/main/resources/dynamo-spb.xml
@@ -13,6 +13,7 @@
 	<aop:aspectj-autoproxy />
 
 	<import resource="classpath:aws-spb.xml" />
+	<import resource="classpath:cloudwatch-spb.xml" />
 	<import resource="classpath:dynamo-dao-spb.xml" />
 	<import resource="classpath:dao-beans.spb.xml" />
 
@@ -88,7 +89,7 @@
 			</bean>
 		</property>
 		<property name="startDelay" value="0" />
-		<property name="repeatInterval" value="1000" />
+		<property name="repeatInterval" value="6000" />
 	</bean>
 
 </beans>

--- a/services/workers/src/main/resources/dynamo-spb.xml
+++ b/services/workers/src/main/resources/dynamo-spb.xml
@@ -84,7 +84,7 @@
 			</bean>
 		</property>
 		<property name="startDelay" value="0" />
-		<property name="repeatInterval" value="6000" />
+		<property name="repeatInterval" value="10000" />
 	</bean>
 
 </beans>

--- a/services/workers/src/main/resources/dynamo-spb.xml
+++ b/services/workers/src/main/resources/dynamo-spb.xml
@@ -17,11 +17,6 @@
 	<import resource="classpath:dynamo-dao-spb.xml" />
 	<import resource="classpath:dao-beans.spb.xml" />
 
-	<bean id="nodeTreeUpdateManager" class="org.sagebionetworks.dynamo.manager.NodeTreeUpdateManagerImpl">
-		<constructor-arg index="0" ref="nodeTreeUpdateDao" />
-		<constructor-arg index="1" ref="nodeDao" />
-	</bean>
-
 	<bean id="awsSQSClient"
 			class="com.amazonaws.services.sqs.AmazonSQSClient"
 			scope="singleton"

--- a/services/workers/src/main/resources/main-scheduler-spb.xml
+++ b/services/workers/src/main/resources/main-scheduler-spb.xml
@@ -23,8 +23,7 @@
 		<property name="triggers">
 			<list>
 				<ref bean="dynamoQueueMessageRetrieverTrigger" />
-<!-- We removed this worker because it is non-essential and we believe it was pushing the Database CPU to 100% -->				
-<!-- 				<ref bean="dynamoRdsSynchronizerTrigger" /> -->
+ 				<ref bean="dynamoRdsSynchronizerTrigger" />
 				<ref bean="rdsQueueMessageReveiverTrigger" />
 				<ref bean="searchQueueMessageReveiverTrigger" />
 				<ref bean="fileQueueMessageReveiverTrigger" />

--- a/services/workers/src/test/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizerTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.sagebionetworks.dynamo.dao.nodetree.NodeTreeQueryDao;
-import org.sagebionetworks.dynamo.manager.NodeTreeUpdateManager;
+import org.sagebionetworks.repo.manager.dynamo.NodeTreeUpdateManager;
 import org.sagebionetworks.repo.model.NodeDAO;
 import org.sagebionetworks.repo.model.NodeParentRelation;
 import org.sagebionetworks.repo.model.QueryResults;

--- a/services/workers/src/test/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizerTest.java
@@ -14,11 +14,13 @@ import java.util.Date;
 import java.util.List;
 
 import org.junit.Test;
+import org.sagebionetworks.cloudwatch.Consumer;
 import org.sagebionetworks.dynamo.dao.nodetree.NodeTreeQueryDao;
 import org.sagebionetworks.repo.manager.dynamo.NodeTreeUpdateManager;
 import org.sagebionetworks.repo.model.NodeDAO;
 import org.sagebionetworks.repo.model.NodeParentRelation;
 import org.sagebionetworks.repo.model.QueryResults;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class DynamoRdsSynchronizerTest {
 
@@ -36,17 +38,18 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(1L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(), eq(5L))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn("11");
 
 		NodeTreeUpdateManager nodeTreeUpdateManager = mock(NodeTreeUpdateManager.class);
-		
+
 		DynamoRdsSynchronizer sync = new DynamoRdsSynchronizer(
 				nodeDao, nodeTreeDao, nodeTreeUpdateManager);
-		sync.triggerFired();
+		ReflectionTestUtils.setField(sync, "consumer", mock(Consumer.class));
 
+		sync.triggerFired();
 		verify(nodeTreeUpdateManager, times(0)).create(anyString(), anyString(), any(Date.class));
 		verify(nodeTreeUpdateManager, times(0)).update(anyString(), anyString(), any(Date.class));
 	}
@@ -65,17 +68,18 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(1L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(), eq(5L))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn(null);
 
 		NodeTreeUpdateManager nodeTreeUpdateManager = mock(NodeTreeUpdateManager.class);
-		
+
 		DynamoRdsSynchronizer sync = new DynamoRdsSynchronizer(
 				nodeDao, nodeTreeDao, nodeTreeUpdateManager);
-		sync.triggerFired();
+		ReflectionTestUtils.setField(sync, "consumer", mock(Consumer.class));
 
+		sync.triggerFired();
 		verify(nodeTreeUpdateManager, times(1)).create(eq("syn1"), eq("syn11"), any(Date.class));
 		verify(nodeTreeUpdateManager, times(0)).update(anyString(), anyString(), any(Date.class));
 	}
@@ -94,17 +98,18 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(1L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(), eq(5L))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn("21");
 
 		NodeTreeUpdateManager nodeTreeUpdateManager = mock(NodeTreeUpdateManager.class);
-		
+
 		DynamoRdsSynchronizer sync = new DynamoRdsSynchronizer(
 				nodeDao, nodeTreeDao, nodeTreeUpdateManager);
-		sync.triggerFired();
+		ReflectionTestUtils.setField(sync, "consumer", mock(Consumer.class));
 
+		sync.triggerFired();
 		verify(nodeTreeUpdateManager, times(0)).create(anyString(), anyString(), any(Date.class));
 		verify(nodeTreeUpdateManager, times(1)).update(eq("syn1"), eq("syn11"), any(Date.class));
 	}
@@ -123,7 +128,7 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(1L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(), eq(5L))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn("11");
@@ -133,8 +138,9 @@ public class DynamoRdsSynchronizerTest {
 		
 		DynamoRdsSynchronizer sync = new DynamoRdsSynchronizer(
 				nodeDao, nodeTreeDao, nodeTreeUpdateManager);
-		sync.triggerFired();
+		ReflectionTestUtils.setField(sync, "consumer", mock(Consumer.class));
 
+		sync.triggerFired();
 		verify(nodeTreeDao, times(1)).isRoot("1");
 	}
 	
@@ -146,14 +152,14 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setResults(results);
 		queryResults.setTotalNumberOfResults(0L);
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(1L))).thenReturn(queryResults);
-
+		when(nodeDao.getParentRelations(anyLong(), eq(5L))).thenReturn(queryResults);
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		NodeTreeUpdateManager nodeTreeUpdateManager = mock(NodeTreeUpdateManager.class);
 		DynamoRdsSynchronizer sync = new DynamoRdsSynchronizer(
 				nodeDao, nodeTreeDao, nodeTreeUpdateManager);
-		sync.triggerFired();
+		ReflectionTestUtils.setField(sync, "consumer", mock(Consumer.class));
 
+		sync.triggerFired();
 		verify(nodeTreeDao, times(0)).isRoot(anyString());
 		verify(nodeTreeUpdateManager, times(0)).create(anyString(), anyString(), any(Date.class));
 		verify(nodeTreeUpdateManager, times(0)).update(anyString(), anyString(), any(Date.class));


### PR DESCRIPTION
Re-enabled the dynamo-rds synchronizer.  The load on RDS was mainly caused by extremely large offsets.  The worker takes more than 1 second to finish if the offset is near 1 million.  Whereas the worker's interval is 1 second, which is not long enough to finish on time.  So instead of randomly sampling one node every 1 second, sample 5 nodes every 5 seconds, which should eliminate the increased load on RDS.

Added latency and count metrics to the two dynamo workers.

Moved the dynamo update manager to the repository-managers package.
