### PR TITLE
More dynamo worker adjustments

### DIFF
--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizer.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizer.java
@@ -20,8 +20,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class DynamoRdsSynchronizer {
 
-	/** How many nodes to check in one batch */
-	private static final int BATCH_SIZE = 30;
+	/** How many nodes to synchronize in one batch */
+	static final long BATCH_SIZE = 30L;
 
 	@Autowired
 	private Consumer consumer;

--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
@@ -85,7 +85,7 @@ public class DynamoQueueWorker implements Callable<List<Message>> {
 		logger.info("DynamoQueueWorker.call() latency is " + latency + " ms.");
 		ProfileData profileData = new ProfileData();
 		profileData.setNamespace("DynamoQueueWorker");
-		profileData.setName("call()"); // Method name
+		profileData.setName("TotalLatency"); // Method name
 		profileData.setLatency(latency);
 		profileData.setUnit("Milliseconds");
 		profileData.setTimestamp(new Date());

--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
@@ -82,6 +82,7 @@ public class DynamoQueueWorker implements Callable<List<Message>> {
 
 		// Emit a latency metric
 		final long latency = (System.nanoTime() - start) / 1000000L;
+		this.logger.info("DynamoQueueWorker.call() latency is " + latency + " ms.");
 		ProfileData profileData = new ProfileData();
 		profileData.setNamespace("DynamoQueueWorker");
 		profileData.setName("call()"); // Method name

--- a/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
+++ b/services/workers/src/main/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorker.java
@@ -49,7 +49,7 @@ public class DynamoQueueWorker implements Callable<List<Message>> {
 
 		final long start = System.nanoTime();
 		final List<Message> processedMessages = new ArrayList<Message>();
-		for (Message message : this.messages) {
+		for (Message message : messages) {
 			// Extract the ChangeMessage
 			ChangeMessage change = MessageUtils.extractMessageBody(message);
 			if (ObjectType.ENTITY.equals(change.getObjectType())) {
@@ -61,19 +61,19 @@ public class DynamoQueueWorker implements Callable<List<Message>> {
 				}
 				try {
 					if (ChangeType.CREATE.equals(change.getChangeType())) {
-						this.updateManager.create(change.getObjectId(),
+						updateManager.create(change.getObjectId(),
 								change.getParentId(), timestamp);
 					} else if (ChangeType.UPDATE.equals(change.getChangeType())) {
-						this.updateManager.update(change.getObjectId(),
+						updateManager.update(change.getObjectId(),
 								change.getParentId(), timestamp);
 					} else if (ChangeType.DELETE.equals(change.getChangeType())) {
-						this.updateManager.delete(change.getObjectId(), timestamp);
+						updateManager.delete(change.getObjectId(), timestamp);
 					} else {
 						throw new IllegalArgumentException("Unknown change type: " + change.getChangeType());
 					}
 					processedMessages.add(message);
 				} catch (Throwable e) {
-					this.logger.error("Failed to process message", e);
+					logger.error("Failed to process message", e);
 				}
 			} else {
 				processedMessages.add(message);
@@ -82,7 +82,7 @@ public class DynamoQueueWorker implements Callable<List<Message>> {
 
 		// Emit a latency metric
 		final long latency = (System.nanoTime() - start) / 1000000L;
-		this.logger.info("DynamoQueueWorker.call() latency is " + latency + " ms.");
+		logger.info("DynamoQueueWorker.call() latency is " + latency + " ms.");
 		ProfileData profileData = new ProfileData();
 		profileData.setNamespace("DynamoQueueWorker");
 		profileData.setName("call()"); // Method name

--- a/services/workers/src/main/resources/dynamo-spb.xml
+++ b/services/workers/src/main/resources/dynamo-spb.xml
@@ -84,7 +84,7 @@
 			</bean>
 		</property>
 		<property name="startDelay" value="0" />
-		<property name="repeatInterval" value="10000" />
+		<property name="repeatInterval" value="30000" />
 	</bean>
 
 </beans>

--- a/services/workers/src/test/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizerTest.java
@@ -38,7 +38,7 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(5L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(), eq(30L))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn("11");
@@ -68,7 +68,7 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(5L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(), eq(30L))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn(null);
@@ -98,7 +98,7 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(5L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(), eq(30L))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn("21");
@@ -128,7 +128,7 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(5L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(), eq(30L))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn("11");
@@ -152,7 +152,7 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setResults(results);
 		queryResults.setTotalNumberOfResults(0L);
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(5L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(), eq(30L))).thenReturn(queryResults);
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		NodeTreeUpdateManager nodeTreeUpdateManager = mock(NodeTreeUpdateManager.class);
 		DynamoRdsSynchronizer sync = new DynamoRdsSynchronizer(

--- a/services/workers/src/test/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/dynamo/workers/DynamoRdsSynchronizerTest.java
@@ -38,7 +38,8 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(30L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(),
+				eq(DynamoRdsSynchronizer.BATCH_SIZE))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn("11");
@@ -68,7 +69,8 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(30L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(),
+				eq(DynamoRdsSynchronizer.BATCH_SIZE))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn(null);
@@ -98,7 +100,8 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(30L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(),
+				eq(DynamoRdsSynchronizer.BATCH_SIZE))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn("21");
@@ -128,14 +131,15 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setTotalNumberOfResults(100L);
 
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(30L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(),
+				eq(DynamoRdsSynchronizer.BATCH_SIZE))).thenReturn(queryResults);
 
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		when(nodeTreeDao.getParent("1")).thenReturn("11");
 		when(nodeTreeDao.isRoot("1")).thenReturn(true);
 
 		NodeTreeUpdateManager nodeTreeUpdateManager = mock(NodeTreeUpdateManager.class);
-		
+
 		DynamoRdsSynchronizer sync = new DynamoRdsSynchronizer(
 				nodeDao, nodeTreeDao, nodeTreeUpdateManager);
 		ReflectionTestUtils.setField(sync, "consumer", mock(Consumer.class));
@@ -143,7 +147,7 @@ public class DynamoRdsSynchronizerTest {
 		sync.triggerFired();
 		verify(nodeTreeDao, times(1)).isRoot("1");
 	}
-	
+
 	@Test
 	public void testEmptyResults() {
 
@@ -152,7 +156,8 @@ public class DynamoRdsSynchronizerTest {
 		queryResults.setResults(results);
 		queryResults.setTotalNumberOfResults(0L);
 		NodeDAO nodeDao = mock(NodeDAO.class);
-		when(nodeDao.getParentRelations(anyLong(), eq(30L))).thenReturn(queryResults);
+		when(nodeDao.getParentRelations(anyLong(),
+				eq(DynamoRdsSynchronizer.BATCH_SIZE))).thenReturn(queryResults);
 		NodeTreeQueryDao nodeTreeDao = mock(NodeTreeQueryDao.class);
 		NodeTreeUpdateManager nodeTreeUpdateManager = mock(NodeTreeUpdateManager.class);
 		DynamoRdsSynchronizer sync = new DynamoRdsSynchronizer(

--- a/services/workers/src/test/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/dynamo/workers/sqs/DynamoQueueWorkerIntegrationTest.java
@@ -25,8 +25,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
 public class DynamoQueueWorkerIntegrationTest {
 
-	public static final long MAX_WAIT = 60 * 1000; // one minute
-
 	@Autowired private EntityManager entityManager;
 	@Autowired private UserProvider userProvider;
 	@Autowired private DynamoAdminDao dynamoAdminDao;
@@ -86,12 +84,12 @@ public class DynamoQueueWorkerIntegrationTest {
 		int i = 0;
 		do {
 			// Pause 1 second for eventual consistency
-			// Wait at most 30 seconds
-			Thread.sleep(3000);
+			// Wait at most 60 seconds
+			Thread.sleep(2000);
 			results = this.nodeTreeQueryDao.getAncestors(
 					KeyFactory.stringToKey(this.project.getId()).toString());
 			i++;
-		} while (i < 10 && results.size() == 0);
+		} while (i < 30 && results.size() == 0);
 
 		Assert.assertNotNull(results);
 		Assert.assertTrue(results.size() > 0);

--- a/services/workers/src/test/resources/test-context.xml
+++ b/services/workers/src/test/resources/test-context.xml
@@ -32,4 +32,18 @@
 		<property name="visibilityTimeoutSec" value="60" />
 	</bean>
 
+	<!-- Redefine the dynamo worker trigger for shorter intervals during tests -->
+	<bean id="dynamoQueueMessageRetrieverTrigger"
+			class="org.springframework.scheduling.quartz.SimpleTriggerBean"
+			scope="singleton">
+		<property name="jobDetail">
+			<bean class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+				<property name="targetObject" ref="dynamoQueueMessageRetriever" />
+				<property name="targetMethod" value="triggerFired" />
+			</bean>
+		</property>
+		<property name="startDelay" value="0" />
+		<property name="repeatInterval" value="200" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
Increase the dynamo-rds synchronizer interval from 10 seconds to  30 seconds and the batch size from 5 to 30 with the aim to further reduce the load on RDS.  Reduce the interval of dynamo worker during tests for stable testing results.
