### PR TITLE
Partial change for PLFM-1977

### DIFF
--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/evaluation/model/UserEvaluationPermissions.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/evaluation/model/UserEvaluationPermissions.json
@@ -1,0 +1,30 @@
+{
+	"title": "Evaluation Permissions",
+	"description": "The permission a User has for a given Evaluation",
+	"properties": {
+		"canChangePermissions": {
+			"type": "boolean",
+			"description": "Can the user change the permissions of this evaluation?"
+		},
+		"canView": {
+			"type": "boolean",
+			"description": "Can the user view this evaluation?"
+		},
+		"canPublicRead": {
+			"type": "boolean",
+			"description": "Is this evaluation considered public?"
+		},
+		"canEdit": {
+			"type": "boolean",
+			"description": "Can the user edit this evaluation?"
+		},
+		"canDelete": {
+			"type": "boolean",
+			"description": "Can the user delete this entity?"
+		},
+		"ownerPrincipalId": {
+			"type": "integer",
+			"description": "The principal ID of the evaluation's owner (i.e. the entity's 'createdBy')"
+		}
+	}
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationManagerImpl.java
@@ -10,7 +10,6 @@ import org.sagebionetworks.evaluation.model.EvaluationStatus;
 import org.sagebionetworks.evaluation.util.EvaluationUtils;
 import org.sagebionetworks.ids.IdGenerator;
 import org.sagebionetworks.repo.manager.AuthorizationManager;
-import org.sagebionetworks.repo.manager.EvaluationUtil;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
 import org.sagebionetworks.repo.model.DatastoreException;

--- a/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManager.java
@@ -33,7 +33,7 @@ public interface EvaluationPermissionsManager {
 	/**
 	 * Deletes the ACL of the specified evaluation.
 	 */
-	public void updateAcl(UserInfo userInfo, String evalId)
+	public void deleteAcl(UserInfo userInfo, String evalId)
 			throws NotFoundException, DatastoreException, InvalidModelException,
 			UnauthorizedException, ConflictingUpdateException;
 
@@ -46,12 +46,12 @@ public interface EvaluationPermissionsManager {
 	/**
 	 * Whether the user has the access to the specified evaluation.
 	 */
-	public boolean hasAccess(UserInfo userInfo, String evalId, ACCESS_TYPE  accessType)
+	public boolean hasAccess(UserInfo userInfo, String evalId, ACCESS_TYPE accessType)
 			throws NotFoundException, DatastoreException;
 
 	/**
 	 * Gets the user permissions for an evaluation.
 	 */
-	public UserEvaluationPermissions getUserPermissionsForEvaluation(UserInfo userInfo,	String evalId)
+	public UserEvaluationPermissions getUserPermissionsForEvaluation(UserInfo userInfo, String evalId)
 			throws NotFoundException, DatastoreException;
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManager.java
@@ -1,0 +1,57 @@
+package org.sagebionetworks.evaluation.manager;
+
+import org.sagebionetworks.evaluation.model.UserEvaluationPermissions;
+import org.sagebionetworks.repo.model.ACCESS_TYPE;
+import org.sagebionetworks.repo.model.ACLInheritanceException;
+import org.sagebionetworks.repo.model.AccessControlList;
+import org.sagebionetworks.repo.model.ConflictingUpdateException;
+import org.sagebionetworks.repo.model.DatastoreException;
+import org.sagebionetworks.repo.model.InvalidModelException;
+import org.sagebionetworks.repo.model.UnauthorizedException;
+import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.web.NotFoundException;
+
+/**
+ * Manages evaluation permissions.
+ */
+public interface EvaluationPermissionsManager {
+
+	/**
+	 * Creates a new ACL.
+	 */
+	public AccessControlList createAcl(UserInfo userInfo, AccessControlList acl)
+			throws NotFoundException, DatastoreException, InvalidModelException,
+			UnauthorizedException, ConflictingUpdateException;
+
+	/**
+	 * Updates with the given ACL.
+	 */
+	public AccessControlList updateAcl(UserInfo userInfo, AccessControlList acl)
+			throws NotFoundException, DatastoreException, InvalidModelException,
+			UnauthorizedException, ConflictingUpdateException;
+
+	/**
+	 * Deletes the ACL of the specified evaluation.
+	 */
+	public void updateAcl(UserInfo userInfo, String evalId)
+			throws NotFoundException, DatastoreException, InvalidModelException,
+			UnauthorizedException, ConflictingUpdateException;
+
+	/**
+	 * Gets the access control list (ACL) governing the given evaluation.
+	 */
+	public AccessControlList getAcl(UserInfo userInfo, String evalId)
+			throws NotFoundException, DatastoreException, ACLInheritanceException;
+
+	/**
+	 * Whether the user has the access to the specified evaluation.
+	 */
+	public boolean hasAccess(UserInfo userInfo, String evalId, ACCESS_TYPE  accessType)
+			throws NotFoundException, DatastoreException;
+
+	/**
+	 * Gets the user permissions for an evaluation.
+	 */
+	public UserEvaluationPermissions getUserPermissionsForEvaluation(UserInfo userInfo,	String evalId)
+			throws NotFoundException, DatastoreException;
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManagerImpl.java
@@ -1,0 +1,65 @@
+package org.sagebionetworks.evaluation.manager;
+
+import org.sagebionetworks.evaluation.model.UserEvaluationPermissions;
+import org.sagebionetworks.repo.model.ACCESS_TYPE;
+import org.sagebionetworks.repo.model.ACLInheritanceException;
+import org.sagebionetworks.repo.model.AccessControlList;
+import org.sagebionetworks.repo.model.ConflictingUpdateException;
+import org.sagebionetworks.repo.model.DatastoreException;
+import org.sagebionetworks.repo.model.InvalidModelException;
+import org.sagebionetworks.repo.model.UnauthorizedException;
+import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.web.NotFoundException;
+
+public class EvaluationPermissionsManagerImpl implements EvaluationPermissionsManager {
+
+	@Override
+	public AccessControlList createAcl(UserInfo userInfo, AccessControlList acl)
+			throws NotFoundException, DatastoreException,
+			InvalidModelException, UnauthorizedException,
+			ConflictingUpdateException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public AccessControlList updateAcl(UserInfo userInfo, AccessControlList acl)
+			throws NotFoundException, DatastoreException,
+			InvalidModelException, UnauthorizedException,
+			ConflictingUpdateException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void updateAcl(UserInfo userInfo, String evalId)
+			throws NotFoundException, DatastoreException,
+			InvalidModelException, UnauthorizedException,
+			ConflictingUpdateException {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public AccessControlList getAcl(UserInfo userInfo, String evalId)
+			throws NotFoundException, DatastoreException,
+			ACLInheritanceException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean hasAccess(UserInfo userInfo, String evalId,
+			ACCESS_TYPE accessType) throws NotFoundException,
+			DatastoreException {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public UserEvaluationPermissions getUserPermissionsForEvaluation(
+			UserInfo userInfo, String evalId) throws NotFoundException,
+			DatastoreException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManagerImpl.java
@@ -19,7 +19,7 @@ public class EvaluationPermissionsManagerImpl implements EvaluationPermissionsMa
 			InvalidModelException, UnauthorizedException,
 			ConflictingUpdateException {
 		// TODO Auto-generated method stub
-		return null;
+		return acl;
 	}
 
 	@Override
@@ -28,7 +28,7 @@ public class EvaluationPermissionsManagerImpl implements EvaluationPermissionsMa
 			InvalidModelException, UnauthorizedException,
 			ConflictingUpdateException {
 		// TODO Auto-generated method stub
-		return null;
+		return acl;
 	}
 
 	@Override
@@ -44,7 +44,8 @@ public class EvaluationPermissionsManagerImpl implements EvaluationPermissionsMa
 			throws NotFoundException, DatastoreException,
 			ACLInheritanceException {
 		// TODO Auto-generated method stub
-		return null;
+		AccessControlList acl = new AccessControlList();
+		return acl;
 	}
 
 	@Override
@@ -59,7 +60,6 @@ public class EvaluationPermissionsManagerImpl implements EvaluationPermissionsMa
 	public UserEvaluationPermissions getUserPermissionsForEvaluation(
 			UserInfo userInfo, String evalId) throws NotFoundException,
 			DatastoreException {
-		// TODO Auto-generated method stub
-		return null;
+		return new UserEvaluationPermissions();
 	}
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManagerImpl.java
@@ -32,7 +32,7 @@ public class EvaluationPermissionsManagerImpl implements EvaluationPermissionsMa
 	}
 
 	@Override
-	public void updateAcl(UserInfo userInfo, String evalId)
+	public void deleteAcl(UserInfo userInfo, String evalId)
 			throws NotFoundException, DatastoreException,
 			InvalidModelException, UnauthorizedException,
 			ConflictingUpdateException {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityManagerImpl.java
@@ -42,7 +42,7 @@ public class EntityManagerImpl implements EntityManager {
 	@Autowired
 	private S3TokenManager s3TokenManager;
 	@Autowired
-	private PermissionsManager permissionsManager;
+	private EntityPermissionsManager entityPermissionsManager;
 	@Autowired
 	UserManager userManager;
 
@@ -51,11 +51,11 @@ public class EntityManagerImpl implements EntityManager {
 	
 	public EntityManagerImpl(NodeManager nodeManager,
 			S3TokenManager s3TokenManager,
-			PermissionsManager permissionsManager, UserManager userManager) {
+			EntityPermissionsManager permissionsManager, UserManager userManager) {
 		super();
 		this.nodeManager = nodeManager;
 		this.s3TokenManager = s3TokenManager;
-		this.permissionsManager = permissionsManager;
+		this.entityPermissionsManager = permissionsManager;
 		this.userManager = userManager;
 	}
 
@@ -546,7 +546,7 @@ public class EntityManagerImpl implements EntityManager {
 	@Override
 	public void validateReadAccess(UserInfo userInfo, String entityId)
 			throws DatastoreException, NotFoundException, UnauthorizedException {
-		if (!permissionsManager.hasAccess(entityId,
+		if (!entityPermissionsManager.hasAccess(entityId,
 				ACCESS_TYPE.READ, userInfo)) {
 			throw new UnauthorizedException(
 					"update access is required to obtain an S3Token for entity "
@@ -557,7 +557,7 @@ public class EntityManagerImpl implements EntityManager {
 	@Override
 	public void validateUpdateAccess(UserInfo userInfo, String entityId)
 			throws DatastoreException, NotFoundException, UnauthorizedException {
-		if (!permissionsManager.hasAccess(entityId,
+		if (!entityPermissionsManager.hasAccess(entityId,
 				ACCESS_TYPE.UPDATE, userInfo)) {
 			throw new UnauthorizedException(
 					"update access is required to obtain an S3Token for entity "

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityPermissionsManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityPermissionsManager.java
@@ -16,7 +16,7 @@ import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
 import org.sagebionetworks.repo.model.message.ObjectType;
 import org.sagebionetworks.repo.web.NotFoundException;
 
-public interface PermissionsManager {
+public interface EntityPermissionsManager {
 	/**
 	 * Invoked for a node which currently inherits its permissions, this
 	 * method overrides inheritance so that the node defines its own

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityPermissionsManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityPermissionsManager.java
@@ -1,8 +1,5 @@
 package org.sagebionetworks.repo.manager;
 
-import java.util.Collection;
-import java.util.List;
-
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.ACLInheritanceException;
 import org.sagebionetworks.repo.model.AccessControlList;
@@ -10,7 +7,6 @@ import org.sagebionetworks.repo.model.ConflictingUpdateException;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.InvalidModelException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
-import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
 import org.sagebionetworks.repo.model.message.ObjectType;
@@ -91,34 +87,6 @@ public interface EntityPermissionsManager {
 	 */
 	public AccessControlList applyInheritanceToChildren(String rId, UserInfo userInfo) throws NotFoundException, DatastoreException, UnauthorizedException, ConflictingUpdateException;
 
-	// the following methods provide the groups
-	// to which resource access permission may be granted
-	
-	/**
-	 * Get all non-individual user groups, including Public.
-	 * 
-	 * @return
-	 * @throws DatastoreException
-	 * @throws UnauthorizedException
-	 */
-	public Collection<UserGroup> getGroups() throws DatastoreException;
-
-	/**
-	 * Get all non-individual user groups, including Public. Deprecated, since userInfo is
-	 * not required to fetch groups.
-	 * 
-	 * @throws DatastoreException 
-	 * 
-	 **/
-	@Deprecated
-	public Collection<UserGroup> getGroups(UserInfo userInfo) throws DatastoreException;
-	
-	/**
-	 * get non-individual user groups (including Public) in range
-	 * 
-	 **/
-	public List<UserGroup> getGroupsInRange(UserInfo userInfo, long startIncl, long endExcl, String sort, boolean ascending) throws DatastoreException, UnauthorizedException;
-	
 	/**
 	 * Use case:  Need to find out if a user can download a resource.
 	 * 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityPermissionsManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityPermissionsManagerImpl.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.repo.manager;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -10,7 +8,6 @@ import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.ACLInheritanceException;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.AccessControlListDAO;
-import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.InvalidModelException;
@@ -18,7 +15,6 @@ import org.sagebionetworks.repo.model.Node;
 import org.sagebionetworks.repo.model.NodeDAO;
 import org.sagebionetworks.repo.model.ResourceAccess;
 import org.sagebionetworks.repo.model.UnauthorizedException;
-import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserGroupDAO;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
@@ -175,25 +171,6 @@ public class EntityPermissionsManagerImpl implements EntityPermissionsManager {
 				applyInheritanceToChildrenHelper(idToChange, userInfo);
 			}
 		}
-	}
-	
-	@Override
-	public Collection<UserGroup> getGroups(UserInfo userInfo) throws DatastoreException {
-		return getGroups();
-	}
-
-	@Override
-	public Collection<UserGroup> getGroups() throws DatastoreException {
-		List<String> groupsToOmit = new ArrayList<String>();
-		groupsToOmit.add(AuthorizationConstants.BOOTSTRAP_USER_GROUP_NAME);
-		return userGroupDAO.getAllExcept(false, groupsToOmit);
-	}
-
-	@Override
-	public List<UserGroup> getGroupsInRange(UserInfo userInfo, long startIncl, long endExcl, String sort, boolean ascending) throws DatastoreException, UnauthorizedException {
-		List<String> groupsToOmit = new ArrayList<String>();
-		groupsToOmit.add(AuthorizationConstants.BOOTSTRAP_USER_GROUP_NAME);
-		return userGroupDAO.getInRangeExcept(startIncl, endExcl, false, groupsToOmit);
 	}
 
 	/**

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityPermissionsManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityPermissionsManagerImpl.java
@@ -1,12 +1,10 @@
 package org.sagebionetworks.repo.manager;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.ACLInheritanceException;
@@ -30,9 +28,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-public class PermissionsManagerImpl implements PermissionsManager {
-	
-	
+public class EntityPermissionsManagerImpl implements EntityPermissionsManager {
+
 	@Autowired
 	private AccessControlListDAO aclDAO;	
 	@Autowired

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/S3TokenManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/S3TokenManagerImpl.java
@@ -41,7 +41,7 @@ public class S3TokenManagerImpl implements S3TokenManager {
 			.getFileNameMap();
 	
 	@Autowired
-	private PermissionsManager permissionsManager;
+	private EntityPermissionsManager entityPermissionsManager;
 	@Autowired
 	private UserManager userManager;
 	@Autowired
@@ -61,11 +61,11 @@ public class S3TokenManagerImpl implements S3TokenManager {
 	 * @param idGenerator
 	 * @param locationHelper
 	 */
-	public S3TokenManagerImpl(PermissionsManager permissionsManager,
+	public S3TokenManagerImpl(EntityPermissionsManager permissionsManager,
 			UserManager userManager, IdGenerator idGenerator,
 			LocationHelper locationHelper, AmazonS3Utility s3Utility) {
 		super();
-		this.permissionsManager = permissionsManager;
+		this.entityPermissionsManager = permissionsManager;
 		this.userManager = userManager;
 		this.idGenerator = idGenerator;
 		this.locationHelper = locationHelper;
@@ -174,7 +174,7 @@ public class S3TokenManagerImpl implements S3TokenManager {
 	 */
 	void validateUpdateAccess(UserInfo userInfo, String entityId)
 			throws DatastoreException, NotFoundException, UnauthorizedException {
-		if (!permissionsManager.hasAccess(entityId,
+		if (!entityPermissionsManager.hasAccess(entityId,
 				ACCESS_TYPE.UPDATE, userInfo)) {
 			throw new UnauthorizedException(
 					"update access is required to obtain an S3Token for entity "

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserManager.java
@@ -1,12 +1,15 @@
 package org.sagebionetworks.repo.manager;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
 
 import javax.xml.xpath.XPathExpressionException;
 
 import org.sagebionetworks.authutil.AuthenticationException;
 import org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_GROUPS;
 import org.sagebionetworks.repo.model.DatastoreException;
+import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserDAO;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserInfo;
@@ -82,5 +85,19 @@ public interface UserManager {
 	public void updateEmail(UserInfo userInfo, String newEmail) throws DatastoreException, NotFoundException, IOException, AuthenticationException, XPathExpressionException;
 	
 	public void clearCache();
-	
+
+	/**
+	 * Get all non-individual user groups, including Public.
+	 * 
+	 * @return
+	 * @throws DatastoreException
+	 * @throws UnauthorizedException
+	 */
+	public Collection<UserGroup> getGroups() throws DatastoreException;
+
+	/**
+	 * get non-individual user groups (including Public) in range
+	 * 
+	 **/
+	public List<UserGroup> getGroupsInRange(UserInfo userInfo, long startIncl, long endExcl, String sort, boolean ascending) throws DatastoreException, UnauthorizedException;
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserManagerImpl.java
@@ -8,21 +8,19 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 
 import javax.xml.xpath.XPathExpressionException;
 
 import org.sagebionetworks.authutil.AuthenticationException;
-import org.sagebionetworks.authutil.CrowdAuthUtil;
-import org.sagebionetworks.authutil.Session;
-import org.sagebionetworks.authutil.CrowdAuthUtil.PW_MODE;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_GROUPS;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.InvalidModelException;
 import org.sagebionetworks.repo.model.SchemaCache;
+import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.User;
 import org.sagebionetworks.repo.model.UserDAO;
 import org.sagebionetworks.repo.model.UserGroup;
@@ -316,4 +314,17 @@ public class UserManagerImpl implements UserManager {
 		}
 	}
 
+	@Override
+	public Collection<UserGroup> getGroups() throws DatastoreException {
+		List<String> groupsToOmit = new ArrayList<String>();
+		groupsToOmit.add(AuthorizationConstants.BOOTSTRAP_USER_GROUP_NAME);
+		return userGroupDAO.getAllExcept(false, groupsToOmit);
+	}
+
+	@Override
+	public List<UserGroup> getGroupsInRange(UserInfo userInfo, long startIncl, long endExcl, String sort, boolean ascending) throws DatastoreException, UnauthorizedException {
+		List<String> groupsToOmit = new ArrayList<String>();
+		groupsToOmit.add(AuthorizationConstants.BOOTSTRAP_USER_GROUP_NAME);
+		return userGroupDAO.getInRangeExcept(startIncl, endExcl, false, groupsToOmit);
+	}
 }

--- a/services/repository-managers/src/main/resources/managers-spb.xml
+++ b/services/repository-managers/src/main/resources/managers-spb.xml
@@ -109,7 +109,7 @@
 	<bean id="authorizationManager"
 		class="org.sagebionetworks.repo.manager.AuthorizationManagerImpl" />
 
-	<bean id="permissionsManager" class="org.sagebionetworks.repo.manager.PermissionsManagerImpl" />
+	<bean id="entityPermissionsManager" class="org.sagebionetworks.repo.manager.EntityPermissionsManagerImpl" />
 
 	<bean id="userProfileManager" class="org.sagebionetworks.repo.manager.UserProfileManagerImpl" />
 

--- a/services/repository-managers/src/main/resources/managers-spb.xml
+++ b/services/repository-managers/src/main/resources/managers-spb.xml
@@ -227,7 +227,10 @@
 		
 	<bean id="submissionManager" class="org.sagebionetworks.evaluation.manager.SubmissionManagerImpl" 
 		scope="singleton" />
-	
+
+	<bean id="evaluationPermissionsManager" class="org.sagebionetworks.evaluation.manager.EvaluationPermissionsManagerImpl"
+		scope="singleton" />
+
 	<bean id="wikiManager" class="org.sagebionetworks.repo.manager.wiki.WikiManagerImpl" 
 		scope="singleton" />
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/AccessApprovalManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/AccessApprovalManagerImplAutoWiredTest.java
@@ -54,7 +54,7 @@ public class AccessApprovalManagerImplAutoWiredTest {
 	@Autowired
 	public AuthorizationManager authorizationManager;
 	@Autowired
-	public PermissionsManager permissionsManager;
+	public EntityPermissionsManager entityPermissionsManager;
 	
 	private UserInfo adminUserInfo;
 	
@@ -88,13 +88,13 @@ public class AccessApprovalManagerImplAutoWiredTest {
 		ar = accessRequirementManager.createAccessRequirement(adminUserInfo, ar);
 		
 		// now give 'testUserInfo' READ access to the entity
-		AccessControlList acl = permissionsManager.getACL(rootId, adminUserInfo);
+		AccessControlList acl = entityPermissionsManager.getACL(rootId, adminUserInfo);
 		Set<ResourceAccess> ras = acl.getResourceAccess();
 		ResourceAccess ra = new ResourceAccess();
 		ra.setPrincipalId(Long.parseLong(testUserProvider.getTestUserInfo().getIndividualGroup().getId()));
 		ra.setAccessType(new HashSet<ACCESS_TYPE>(Arrays.asList(new ACCESS_TYPE[]{ACCESS_TYPE.READ})));
 		ras.add(ra);
-		permissionsManager.updateACL(acl, adminUserInfo);
+		entityPermissionsManager.updateACL(acl, adminUserInfo);
 }
 	
 	@After

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/EntityManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/EntityManagerImplUnitTest.java
@@ -27,7 +27,7 @@ import com.amazonaws.services.securitytoken.model.Credentials;
 public class EntityManagerImplUnitTest {
 
 	private UserManager mockUserManager;
-	private PermissionsManager mockPermissionsManager;
+	private EntityPermissionsManager mockPermissionsManager;
 	private UserInfo mockUser;
 	private EntityManagerImpl entityManager;
 	private NodeManager mockNodeManager;
@@ -39,7 +39,7 @@ public class EntityManagerImplUnitTest {
 	@Before
 	public void before(){
 		// Create the mocks
-		mockPermissionsManager = Mockito.mock(PermissionsManager.class);
+		mockPermissionsManager = Mockito.mock(EntityPermissionsManager.class);
 		mockUserManager = Mockito.mock(UserManager.class);
 		mockNodeManager = Mockito.mock(NodeManager.class);
 		mockS3TokenManager = Mockito.mock(S3TokenManager.class);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/S3TokenManagerUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/S3TokenManagerUnitTest.java
@@ -32,7 +32,7 @@ import com.amazonaws.services.securitytoken.model.Credentials;
  */
 public class S3TokenManagerUnitTest {
 
-	private PermissionsManager mockPermissionsManager;
+	private EntityPermissionsManager mockPermissionsManager;
 	private UserManager mockUuserManager;
 	private IdGenerator mocIdGenerator;
 	private LocationHelper mocKLocationHelper;
@@ -44,7 +44,7 @@ public class S3TokenManagerUnitTest {
 	@Before
 	public void before(){
 		// Create the mocks
-		mockPermissionsManager = Mockito.mock(PermissionsManager.class);
+		mockPermissionsManager = Mockito.mock(EntityPermissionsManager.class);
 		mockUuserManager = Mockito.mock(UserManager.class);
 		mocIdGenerator = Mockito.mock(IdGenerator.class);
 		mocKLocationHelper = Mockito.mock(LocationHelper.class);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/trash/TrashManagerImplAutowiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/trash/TrashManagerImplAutowiredTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.repo.manager.NodeInheritanceManager;
 import org.sagebionetworks.repo.manager.NodeManager;
-import org.sagebionetworks.repo.manager.PermissionsManager;
+import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.EntityType;
 import org.sagebionetworks.repo.model.Node;
@@ -39,7 +39,7 @@ public class TrashManagerImplAutowiredTest {
 	@Autowired private TrashManager trashManager;
 	@Autowired private NodeManager nodeManager;
 	@Autowired private NodeInheritanceManager nodeInheritanceManager;
-	@Autowired private PermissionsManager permissionsManager;
+	@Autowired private EntityPermissionsManager entityPermissionsManager;
 	@Autowired private DBOTrashCanDao trashCanDao;
 	@Autowired private NodeDAO nodeDAO;
 	@Autowired private UserProvider userProvider;
@@ -54,7 +54,7 @@ public class TrashManagerImplAutowiredTest {
 		assertNotNull(trashManager);
 		assertNotNull(nodeManager);
 		assertNotNull(nodeInheritanceManager);
-		assertNotNull(permissionsManager);
+		assertNotNull(entityPermissionsManager);
 		assertNotNull(trashCanDao);
 		assertNotNull(nodeDAO);
 		assertNotNull(userProvider);
@@ -302,7 +302,7 @@ public class TrashManagerImplAutowiredTest {
 
 		// Modify nodeId12 to be its own benefactor
 		AccessControlList acl = AccessControlListUtil.createACLToGrantAll(nodeId12, testUserInfo);
-		permissionsManager.overrideInheritance(acl, testUserInfo);
+		entityPermissionsManager.overrideInheritance(acl, testUserInfo);
 		assertEquals(nodeId12, nodeInheritanceManager.getBenefactor(nodeId12));
 		assertEquals(nodeId12, nodeInheritanceManager.getBenefactor(nodeId22));
 

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
@@ -552,6 +552,10 @@ public class UrlHelpers {
 	public static final String EVALUATION_ACCESS_REQUIREMENT_UNFULFILLED_WITH_ID = EVALUATION_WITH_ID+"/accessRequirementUnfulfilled";
 	public static final String ACCESS_APPROVAL_WITH_EVALUATION_ID = EVALUATION_WITH_ID+ACCESS_APPROVAL;
 
+	public static final String EVALUATION_ACL = EVALUATION + ACL;
+	public static final String EVALUATION_ID_ACL = EVALUATION + "/" + EVALUATION_ID_PATH_VAR + ACL;
+	public static final String EVALUATION_ID_PERMISSIONS = EVALUATION + "/" + EVALUATION_ID_PATH_VAR + PERMISSIONS;
+
 	// Wiki URL
 	public static final String WIKI = "/wiki";
 	public static final String WIKI_HEADER_TREE = "/wikiheadertree";

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/EvaluationController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/EvaluationController.java
@@ -12,7 +12,9 @@ import org.sagebionetworks.evaluation.model.Submission;
 import org.sagebionetworks.evaluation.model.SubmissionBundle;
 import org.sagebionetworks.evaluation.model.SubmissionStatus;
 import org.sagebionetworks.evaluation.model.SubmissionStatusEnum;
+import org.sagebionetworks.evaluation.model.UserEvaluationPermissions;
 import org.sagebionetworks.repo.model.ACLInheritanceException;
+import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.BooleanResult;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
@@ -33,6 +35,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -408,5 +411,77 @@ public class EvaluationController extends BaseController {
 			HttpServletRequest request) throws DatastoreException, NotFoundException, UnauthorizedException {
 		// pass it along.
 		return new BooleanResult(serviceProvider.getEvaluationService().hasAccess(evalId, userId, request, accessType));
+	}
+
+	/**
+	 * Creates a new ACL.
+	 */
+	@ResponseStatus(HttpStatus.CREATED)
+	@RequestMapping(value = UrlHelpers.EVALUATION_ACL, method = RequestMethod.POST)
+	public @ResponseBody AccessControlList
+	createAcl(
+			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = true) String userId,
+			@RequestBody AccessControlList acl,
+			HttpServletRequest request)
+			throws NotFoundException, DatastoreException, InvalidModelException,
+			UnauthorizedException, ConflictingUpdateException {
+		return serviceProvider.getEvaluationService().createAcl(userId, acl);
+	}
+
+	/**
+	 * Updates with the given ACL.
+	 */
+	@ResponseStatus(HttpStatus.OK)
+	@RequestMapping(value = UrlHelpers.EVALUATION_ACL, method = RequestMethod.PUT)
+	public @ResponseBody AccessControlList
+	updateAcl(
+			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = true) String userId,
+			@RequestBody AccessControlList acl,
+			HttpServletRequest request)
+			throws NotFoundException, DatastoreException, InvalidModelException,
+			UnauthorizedException, ConflictingUpdateException {
+		return serviceProvider.getEvaluationService().updateAcl(userId, acl);
+	}
+
+	/**
+	 * Deletes the ACL of the specified evaluation.
+	 */
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@RequestMapping(value = UrlHelpers.EVALUATION_ID_ACL, method = RequestMethod.DELETE)
+	public void deleteAcl(
+			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = true) String userId,
+			@PathVariable String evalId,
+			HttpServletRequest request)
+			throws NotFoundException, DatastoreException, InvalidModelException,
+			UnauthorizedException, ConflictingUpdateException {
+		serviceProvider.getEvaluationService().deleteAcl(userId, evalId);
+	}
+
+	/**
+	 * Gets the access control list (ACL) governing the given evaluation.
+	 */
+	@ResponseStatus(HttpStatus.OK)
+	@RequestMapping(value = UrlHelpers.EVALUATION_ID_ACL, method = RequestMethod.GET)
+	public @ResponseBody AccessControlList
+	getAcl(
+			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = true) String userId,
+			@PathVariable String evalId,
+			HttpServletRequest request)
+			throws NotFoundException, DatastoreException, ACLInheritanceException {
+		return serviceProvider.getEvaluationService().getAcl(userId, evalId);
+	}
+
+	/**
+	 * Gets the user permissions for an evaluation.
+	 */
+	@ResponseStatus(HttpStatus.OK)
+	@RequestMapping(value = UrlHelpers.EVALUATION_ID_PERMISSIONS, method = RequestMethod.GET)
+	public @ResponseBody UserEvaluationPermissions
+	getUserPermissionsForEvaluation(
+			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = true) String userId,
+			@PathVariable String evalId,
+			HttpServletRequest request)
+			throws NotFoundException, DatastoreException {
+		return serviceProvider.getEvaluationService().getUserPermissionsForEvaluation(userId, evalId);
 	}
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/metadata/AnalysisMetadataProvider.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/metadata/AnalysisMetadataProvider.java
@@ -32,7 +32,7 @@ public class AnalysisMetadataProvider implements
 	@Autowired
 	EntityManager entityManager;
 	@Autowired
-	EntityPermissionsManager permissionsManager;
+	EntityPermissionsManager entityPermissionsManager;
 
 
 	@Override
@@ -90,7 +90,7 @@ public class AnalysisMetadataProvider implements
 					Step.class);
 			step.setParentId(entity.getId());
 			entityManager.updateEntity(user, step, false, null);
-			permissionsManager.restoreInheritance(stepId, user);
+			entityPermissionsManager.restoreInheritance(stepId, user);
 		}
 		// Sorry for the big catch block, its not a good habit to just catch
 		// Exception

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/metadata/AnalysisMetadataProvider.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/metadata/AnalysisMetadataProvider.java
@@ -6,7 +6,7 @@ import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
 
 import org.sagebionetworks.repo.manager.EntityManager;
-import org.sagebionetworks.repo.manager.PermissionsManager;
+import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.model.Analysis;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
 import org.sagebionetworks.repo.model.DatastoreException;
@@ -32,7 +32,7 @@ public class AnalysisMetadataProvider implements
 	@Autowired
 	EntityManager entityManager;
 	@Autowired
-	PermissionsManager permissionsManager;
+	EntityPermissionsManager permissionsManager;
 
 
 	@Override

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/metadata/LocationableMetadataProvider.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/metadata/LocationableMetadataProvider.java
@@ -11,7 +11,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sagebionetworks.repo.manager.AuthorizationManager;
 import org.sagebionetworks.repo.manager.EntityManager;
-import org.sagebionetworks.repo.manager.PermissionsManager;
+import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.DatastoreException;
@@ -49,7 +49,7 @@ public class LocationableMetadataProvider implements
 	LocationHelper locationHelper;
 
 	@Autowired
-	PermissionsManager permissionsManager;
+	EntityPermissionsManager permissionsManager;
 
 	@Autowired
 	EntityManager entityManager;

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/metadata/LocationableMetadataProvider.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/metadata/LocationableMetadataProvider.java
@@ -11,7 +11,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sagebionetworks.repo.manager.AuthorizationManager;
 import org.sagebionetworks.repo.manager.EntityManager;
-import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.DatastoreException;
@@ -47,9 +46,6 @@ public class LocationableMetadataProvider implements
 
 	@Autowired
 	LocationHelper locationHelper;
-
-	@Autowired
-	EntityPermissionsManager permissionsManager;
 
 	@Autowired
 	EntityManager entityManager;

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EntityServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EntityServiceImpl.java
@@ -9,7 +9,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.sagebionetworks.ids.IdGenerator;
 import org.sagebionetworks.repo.manager.EntityManager;
-import org.sagebionetworks.repo.manager.PermissionsManager;
+import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
@@ -73,7 +73,7 @@ public class EntityServiceImpl implements EntityService {
 	@Autowired
 	EntityManager entityManager;
 	@Autowired
-	PermissionsManager permissionsManager;
+	EntityPermissionsManager permissionsManager;
 	@Autowired
 	UserManager userManager;
 	@Autowired

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EntityServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EntityServiceImpl.java
@@ -73,7 +73,7 @@ public class EntityServiceImpl implements EntityService {
 	@Autowired
 	EntityManager entityManager;
 	@Autowired
-	EntityPermissionsManager permissionsManager;
+	EntityPermissionsManager entityPermissionsManager;
 	@Autowired
 	UserManager userManager;
 	@Autowired
@@ -447,7 +447,7 @@ public class EntityServiceImpl implements EntityService {
 			InvalidModelException, UnauthorizedException, NotFoundException, ConflictingUpdateException {
 
 		UserInfo userInfo = userManager.getUserInfo(userId);		
-		AccessControlList acl = permissionsManager.overrideInheritance(newACL, userInfo);
+		AccessControlList acl = entityPermissionsManager.overrideInheritance(newACL, userInfo);
 		acl.setUri(request.getRequestURI());
 		return acl;
 	}
@@ -457,7 +457,7 @@ public class EntityServiceImpl implements EntityService {
 			throws NotFoundException, DatastoreException, UnauthorizedException, ACLInheritanceException {
 		// First try the updated
 		UserInfo userInfo = userManager.getUserInfo(userId);
-		AccessControlList acl = permissionsManager.getACL(entityId, userInfo);
+		AccessControlList acl = entityPermissionsManager.getACL(entityId, userInfo);
 		
 		acl.setUri(UrlHelpers.makeEntityACLUri(entityId));
 
@@ -470,9 +470,9 @@ public class EntityServiceImpl implements EntityService {
 			AccessControlList updated, String recursive, HttpServletRequest request) throws DatastoreException, NotFoundException, InvalidModelException, UnauthorizedException, ConflictingUpdateException {
 		// Resolve the user
 		UserInfo userInfo = userManager.getUserInfo(userId);
-		AccessControlList acl = permissionsManager.updateACL(updated, userInfo);
+		AccessControlList acl = entityPermissionsManager.updateACL(updated, userInfo);
 		if (recursive != null && recursive.equalsIgnoreCase("true"))
-			permissionsManager.applyInheritanceToChildren(updated.getId(), userInfo);
+			entityPermissionsManager.applyInheritanceToChildren(updated.getId(), userInfo);
 		acl.setUri(request.getRequestURI());
 		return acl;
 	}
@@ -482,7 +482,7 @@ public class EntityServiceImpl implements EntityService {
 	public AccessControlList createOrUpdateEntityACL(String userId,
 			AccessControlList acl, String recursive, HttpServletRequest request) throws DatastoreException, NotFoundException, InvalidModelException, UnauthorizedException, ConflictingUpdateException {
 		String entityId = acl.getId();
-		if (permissionsManager.hasLocalACL(entityId)) {
+		if (entityPermissionsManager.hasLocalACL(entityId)) {
 			// Local ACL exists; update it
 			return updateEntityACL(userId, acl, recursive, request);
 		} else {
@@ -496,14 +496,14 @@ public class EntityServiceImpl implements EntityService {
 	public void deleteEntityACL(String userId, String id)
 			throws NotFoundException, DatastoreException, UnauthorizedException, ConflictingUpdateException {
 		UserInfo userInfo = userManager.getUserInfo(userId);
-		permissionsManager.restoreInheritance(id, userInfo);
+		entityPermissionsManager.restoreInheritance(id, userInfo);
 	}
 
 	@Override
 	public boolean hasAccess(String entityId, String userId, HttpServletRequest request, String accessType) 
 		throws NotFoundException, DatastoreException, UnauthorizedException {
 		UserInfo userInfo = userManager.getUserInfo(userId);
-		return permissionsManager.hasAccess(entityId, ACCESS_TYPE.valueOf(accessType), userInfo);
+		return entityPermissionsManager.hasAccess(entityId, ACCESS_TYPE.valueOf(accessType), userInfo);
 	}
 
 	@Override
@@ -525,7 +525,7 @@ public class EntityServiceImpl implements EntityService {
 		if(userId == null) throw new IllegalArgumentException("UserId cannot be null");
 		UserInfo userInfo = userManager.getUserInfo(userId);
 		// First get the permissions benefactor
-		String benefactor = permissionsManager.getPermissionBenefactor(entityId, userInfo);
+		String benefactor = entityPermissionsManager.getPermissionBenefactor(entityId, userInfo);
 		return getEntityHeader(userId, benefactor, null);
 	}
 
@@ -544,7 +544,7 @@ public class EntityServiceImpl implements EntityService {
 	@Override
 	public UserEntityPermissions getUserEntityPermissions(String userId, String entityId) throws NotFoundException, DatastoreException {
 		UserInfo userInfo = userManager.getUserInfo(userId);
-		return permissionsManager.getUserPermissionsForEntity(userInfo, entityId);
+		return entityPermissionsManager.getUserPermissionsForEntity(userInfo, entityId);
 	}
 	
 	@Override

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationService.java
@@ -9,7 +9,9 @@ import org.sagebionetworks.evaluation.model.Submission;
 import org.sagebionetworks.evaluation.model.SubmissionBundle;
 import org.sagebionetworks.evaluation.model.SubmissionStatus;
 import org.sagebionetworks.evaluation.model.SubmissionStatusEnum;
+import org.sagebionetworks.evaluation.model.UserEvaluationPermissions;
 import org.sagebionetworks.repo.model.ACLInheritanceException;
+import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.Entity;
@@ -410,4 +412,37 @@ public interface EvaluationService {
 	public <T extends Entity> boolean hasAccess(String evalId, String userName,
 			HttpServletRequest request, String accessType)
 			throws NotFoundException, DatastoreException, UnauthorizedException;
+
+	/**
+	 * Creates a new ACL.
+	 */
+	public AccessControlList createAcl(String userName, AccessControlList acl)
+			throws NotFoundException, DatastoreException, InvalidModelException,
+			UnauthorizedException, ConflictingUpdateException;
+
+	/**
+	 * Updates with the given ACL.
+	 */
+	public AccessControlList updateAcl(String userName, AccessControlList acl)
+			throws NotFoundException, DatastoreException, InvalidModelException,
+			UnauthorizedException, ConflictingUpdateException;
+
+	/**
+	 * Deletes the ACL of the specified evaluation.
+	 */
+	public void deleteAcl(String userName, String evalId)
+			throws NotFoundException, DatastoreException, InvalidModelException,
+			UnauthorizedException, ConflictingUpdateException;
+
+	/**
+	 * Gets the access control list (ACL) governing the given evaluation.
+	 */
+	public AccessControlList getAcl(String userName, String evalId)
+			throws NotFoundException, DatastoreException, ACLInheritanceException;
+
+	/**
+	 * Gets the user permissions for an evaluation.
+	 */
+	public UserEvaluationPermissions getUserPermissionsForEvaluation(String userName, String evalId)
+			throws NotFoundException, DatastoreException;
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationService.java
@@ -22,6 +22,8 @@ import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 
 public interface EvaluationService {
 
+	////// Methods for managing evaluations //////
+
 	/**
 	 * Create a new Synapse Evaluation
 	 * 
@@ -113,6 +115,8 @@ public interface EvaluationService {
 	public void deleteEvaluation(String userId, String evalId)
 			throws DatastoreException, NotFoundException, UnauthorizedException;
 
+	////// Methods for managing participants //////
+
 	/**
 	 * Add self as a Participant to a Evaluation.
 	 * 
@@ -183,6 +187,8 @@ public interface EvaluationService {
 	 */
 	public long getParticipantCount(String evalId) throws DatastoreException,
 			NotFoundException;
+
+	////// Methods for managing submissions //////
 
 	/**
 	 * Create a Submission.
@@ -364,21 +370,6 @@ public interface EvaluationService {
 			String evalId, SubmissionStatusEnum status, long limit,
 			long offset, HttpServletRequest request) throws DatastoreException,
 			UnauthorizedException, NotFoundException;
-	
-	/**
-	 * determine whether a user has the given access type for a given evaluation
-	 * 
-	 * @param evalId
-	 * @param userId
-	 * @param accessType
-	 * @return
-	 * @throws NotFoundException
-	 * @throws DatastoreException
-	 * @throws UnauthorizedException
-	 */
-	public <T extends Entity> boolean hasAccess(String evalId, String userName,
-			HttpServletRequest request, String accessType)
-			throws NotFoundException, DatastoreException, UnauthorizedException;
 
 	/**
 	 * Get all SubmissionStatuses for a given Evaluation. This method is
@@ -403,4 +394,20 @@ public interface EvaluationService {
 			long limit, long offset, HttpServletRequest request)
 			throws DatastoreException, UnauthorizedException, NotFoundException;
 
+	////// Methods for managing ACLs //////
+
+	/**
+	 * determine whether a user has the given access type for a given evaluation
+	 * 
+	 * @param evalId
+	 * @param userId
+	 * @param accessType
+	 * @return
+	 * @throws NotFoundException
+	 * @throws DatastoreException
+	 * @throws UnauthorizedException
+	 */
+	public <T extends Entity> boolean hasAccess(String evalId, String userName,
+			HttpServletRequest request, String accessType)
+			throws NotFoundException, DatastoreException, UnauthorizedException;
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationServiceImpl.java
@@ -12,7 +12,7 @@ import org.sagebionetworks.evaluation.model.Submission;
 import org.sagebionetworks.evaluation.model.SubmissionBundle;
 import org.sagebionetworks.evaluation.model.SubmissionStatus;
 import org.sagebionetworks.evaluation.model.SubmissionStatusEnum;
-import org.sagebionetworks.repo.manager.PermissionsManager;
+import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.ACLInheritanceException;
@@ -46,7 +46,7 @@ public class EvaluationServiceImpl implements EvaluationService {
 	@Autowired
 	SubmissionManager submissionManager;
 	@Autowired
-	PermissionsManager permissionsManager;
+	EntityPermissionsManager permissionsManager;
 	
 	@Autowired
 	UserManager userManager;

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationServiceImpl.java
@@ -46,7 +46,7 @@ public class EvaluationServiceImpl implements EvaluationService {
 	@Autowired
 	SubmissionManager submissionManager;
 	@Autowired
-	EntityPermissionsManager permissionsManager;
+	EntityPermissionsManager entityPermissionsManager;
 	
 	@Autowired
 	UserManager userManager;
@@ -369,7 +369,7 @@ public class EvaluationServiceImpl implements EvaluationService {
 			HttpServletRequest request, String accessType)
 			throws NotFoundException, DatastoreException, UnauthorizedException {
 		UserInfo userInfo = userManager.getUserInfo(userName);
-		return permissionsManager.hasAccess(id, ObjectType.EVALUATION, ACCESS_TYPE.valueOf(accessType), userInfo);
+		return entityPermissionsManager.hasAccess(id, ObjectType.EVALUATION, ACCESS_TYPE.valueOf(accessType), userInfo);
 	}
 	
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationServiceImpl.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.repo.web.service;
 import javax.servlet.http.HttpServletRequest;
 
 import org.sagebionetworks.evaluation.manager.EvaluationManager;
+import org.sagebionetworks.evaluation.manager.EvaluationPermissionsManager;
 import org.sagebionetworks.evaluation.manager.ParticipantManager;
 import org.sagebionetworks.evaluation.manager.SubmissionManager;
 import org.sagebionetworks.evaluation.model.Evaluation;
@@ -12,10 +13,12 @@ import org.sagebionetworks.evaluation.model.Submission;
 import org.sagebionetworks.evaluation.model.SubmissionBundle;
 import org.sagebionetworks.evaluation.model.SubmissionStatus;
 import org.sagebionetworks.evaluation.model.SubmissionStatusEnum;
+import org.sagebionetworks.evaluation.model.UserEvaluationPermissions;
 import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.ACLInheritanceException;
+import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.Entity;
@@ -36,21 +39,22 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 public class EvaluationServiceImpl implements EvaluationService {
-	
+
 	@Autowired
-	ServiceProvider serviceProvider;
+	private ServiceProvider serviceProvider;
 	@Autowired
-	EvaluationManager evaluationManager;
+	private EvaluationManager evaluationManager;
 	@Autowired
-	ParticipantManager participantManager;
+	private ParticipantManager participantManager;
 	@Autowired
-	SubmissionManager submissionManager;
+	private SubmissionManager submissionManager;
 	@Autowired
-	EntityPermissionsManager entityPermissionsManager;
-	
+	private EntityPermissionsManager entityPermissionsManager; // TODO: To be replaced by evaluationPermissionsManager
 	@Autowired
-	UserManager userManager;
-	
+	private EvaluationPermissionsManager evaluationPermissionsManager;
+	@Autowired
+	private UserManager userManager;
+
 	@Override
 	@Transactional(readOnly = false, propagation = Propagation.REQUIRED)
 	public Evaluation createEvaluation(String userName, Evaluation eval) 
@@ -351,7 +355,58 @@ public class EvaluationServiceImpl implements EvaluationService {
 			NotFoundException {
 		return submissionManager.getSubmissionCount(evalId);
 	}
-	
+
+	@Override
+	public <T extends Entity> boolean hasAccess(String id, String userName,
+			HttpServletRequest request, String accessType)
+			throws NotFoundException, DatastoreException, UnauthorizedException {
+		UserInfo userInfo = userManager.getUserInfo(userName);
+		return entityPermissionsManager.hasAccess(id, ObjectType.EVALUATION, ACCESS_TYPE.valueOf(accessType), userInfo);
+	}
+
+	@Override
+	public AccessControlList createAcl(String userName, AccessControlList acl)
+			throws NotFoundException, DatastoreException,
+			InvalidModelException, UnauthorizedException,
+			ConflictingUpdateException {
+		UserInfo userInfo = userManager.getUserInfo(userName);
+		return evaluationPermissionsManager.createAcl(userInfo, acl);
+	}
+
+	@Override
+	public AccessControlList updateAcl(String userName, AccessControlList acl)
+			throws NotFoundException, DatastoreException,
+			InvalidModelException, UnauthorizedException,
+			ConflictingUpdateException {
+		UserInfo userInfo = userManager.getUserInfo(userName);
+		return evaluationPermissionsManager.updateAcl(userInfo, acl);
+	}
+
+	@Override
+	public void deleteAcl(String userName, String evalId)
+			throws NotFoundException, DatastoreException,
+			InvalidModelException, UnauthorizedException,
+			ConflictingUpdateException {
+		UserInfo userInfo = userManager.getUserInfo(userName);
+		evaluationPermissionsManager.deleteAcl(userInfo, evalId);
+	}
+
+	@Override
+	public AccessControlList getAcl(String userName, String evalId)
+			throws NotFoundException, DatastoreException,
+			ACLInheritanceException {
+		UserInfo userInfo = userManager.getUserInfo(userName);
+		return evaluationPermissionsManager.getAcl(userInfo, evalId);
+	}
+
+	@Override
+	public UserEvaluationPermissions getUserPermissionsForEvaluation(
+			String userName, String evalId) throws NotFoundException,
+			DatastoreException {
+		UserInfo userInfo = userManager.getUserInfo(userName);
+		return evaluationPermissionsManager.getUserPermissionsForEvaluation(userInfo, evalId);
+	}
+
 	/**
 	 * Inserts an evaluation ID into a provided URL anywhere the
 	 * EVALUATION_ID_PATH_VAR is found.
@@ -363,13 +418,4 @@ public class EvaluationServiceImpl implements EvaluationService {
 	private String makeEvalIdUrl(String evalId, String url) {
 		return url.replace(UrlHelpers.EVALUATION_ID_PATH_VAR, evalId);
 	}
-	
-	@Override
-	public <T extends Entity> boolean hasAccess(String id, String userName,
-			HttpServletRequest request, String accessType)
-			throws NotFoundException, DatastoreException, UnauthorizedException {
-		UserInfo userInfo = userManager.getUserInfo(userName);
-		return entityPermissionsManager.hasAccess(id, ObjectType.EVALUATION, ACCESS_TYPE.valueOf(accessType), userInfo);
-	}
-	
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/UserGroupServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/UserGroupServiceImpl.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.PaginatedResults;
@@ -18,8 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class UserGroupServiceImpl implements UserGroupService {
 	
 	@Autowired
-	EntityPermissionsManager permissionsManager;	
-	@Autowired
 	UserManager userManager;
 	
 	@Override
@@ -28,8 +25,8 @@ public class UserGroupServiceImpl implements UserGroupService {
 			throws DatastoreException, UnauthorizedException, NotFoundException {
 		UserInfo userInfo = userManager.getUserInfo(userId);
 		long endExcl = offset+limit;
-		List<UserGroup> results = permissionsManager.getGroupsInRange(userInfo, offset, endExcl, sort, ascending);
-		int totalNumberOfResults = permissionsManager.getGroups().size();
+		List<UserGroup> results = userManager.getGroupsInRange(userInfo, offset, endExcl, sort, ascending);
+		int totalNumberOfResults = userManager.getGroups().size();
 		return new PaginatedResults<UserGroup>(
 				request.getServletPath()+UrlHelpers.USERGROUP, 
 				results,

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/UserGroupServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/UserGroupServiceImpl.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.sagebionetworks.repo.manager.PermissionsManager;
+import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.PaginatedResults;
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class UserGroupServiceImpl implements UserGroupService {
 	
 	@Autowired
-	PermissionsManager permissionsManager;	
+	EntityPermissionsManager permissionsManager;	
 	@Autowired
 	UserManager userManager;
 	

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/UserProfileService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/UserProfileService.java
@@ -8,7 +8,7 @@ import javax.xml.xpath.XPathExpressionException;
 
 import org.sagebionetworks.authutil.AuthenticationException;
 import org.sagebionetworks.repo.manager.EntityManager;
-import org.sagebionetworks.repo.manager.PermissionsManager;
+import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.UserProfileManager;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
@@ -157,7 +157,7 @@ public interface UserProfileService {
 
 	public void setObjectTypeSerializer(ObjectTypeSerializer objectTypeSerializer);
 
-	public void setPermissionsManager(PermissionsManager permissionsManager);
+	public void setPermissionsManager(EntityPermissionsManager permissionsManager);
 
 	public void setUserManager(UserManager userManager);
 

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/UserProfileServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/UserProfileServiceImpl.java
@@ -22,7 +22,7 @@ import org.ardverk.collection.Trie;
 import org.ardverk.collection.Tries;
 import org.sagebionetworks.authutil.AuthenticationException;
 import org.sagebionetworks.repo.manager.EntityManager;
-import org.sagebionetworks.repo.manager.PermissionsManager;
+import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.UserProfileManager;
 import org.sagebionetworks.repo.manager.UserProfileManagerUtils;
@@ -61,7 +61,7 @@ public class UserProfileServiceImpl implements UserProfileService {
 	@Autowired
 	UserManager userManager;	
 	@Autowired
-	PermissionsManager permissionsManager;	
+	EntityPermissionsManager permissionsManager;	
 	@Autowired
 	ObjectTypeSerializer objectTypeSerializer;
 	@Autowired
@@ -256,7 +256,7 @@ public class UserProfileServiceImpl implements UserProfileService {
 	}
 
 	@Override
-	public void setPermissionsManager(PermissionsManager permissionsManager) {
+	public void setPermissionsManager(EntityPermissionsManager permissionsManager) {
 		this.permissionsManager = permissionsManager;
 	}
 

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/UserProfileServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/UserProfileServiceImpl.java
@@ -43,7 +43,6 @@ import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.attachment.PresignedUrl;
 import org.sagebionetworks.repo.model.attachment.S3AttachmentToken;
-import org.sagebionetworks.repo.util.StringUtil;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.repo.web.UrlHelpers;
 import org.sagebionetworks.repo.web.controller.ObjectTypeSerializer;
@@ -61,7 +60,7 @@ public class UserProfileServiceImpl implements UserProfileService {
 	@Autowired
 	UserManager userManager;	
 	@Autowired
-	EntityPermissionsManager permissionsManager;	
+	EntityPermissionsManager entityPermissionsManager;	
 	@Autowired
 	ObjectTypeSerializer objectTypeSerializer;
 	@Autowired
@@ -225,7 +224,7 @@ public class UserProfileServiceImpl implements UserProfileService {
 				addToIdCache(tempIdCache, header);
 			}
 		}
-		Collection<UserGroup> userGroups = permissionsManager.getGroups();
+		Collection<UserGroup> userGroups = userManager.getGroups();
 		this.logger.info("Loaded " + userGroups.size() + " user groups.");
 		for (UserGroup group : userGroups) {
 			if (group.getName() != null) {
@@ -257,7 +256,7 @@ public class UserProfileServiceImpl implements UserProfileService {
 
 	@Override
 	public void setPermissionsManager(EntityPermissionsManager permissionsManager) {
-		this.permissionsManager = permissionsManager;
+		this.entityPermissionsManager = permissionsManager;
 	}
 
 	@Override
@@ -280,7 +279,7 @@ public class UserProfileServiceImpl implements UserProfileService {
 	public EntityHeader addFavorite(String userId, String entityId)
 			throws DatastoreException, InvalidModelException, NotFoundException, UnauthorizedException {
 		UserInfo userInfo = userManager.getUserInfo(userId);
-		if(!permissionsManager.hasAccess(entityId, ACCESS_TYPE.READ, userInfo)) 
+		if(!entityPermissionsManager.hasAccess(entityId, ACCESS_TYPE.READ, userInfo)) 
 			throw new UnauthorizedException("READ access denied to id: "+ entityId +". Favorite not added.");
 		Favorite favorite = userProfileManager.addFavorite(userInfo, entityId);
 		return entityManager.getEntityHeader(userInfo, favorite.getEntityId(), null); // current version

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/service/UserProfileServiceTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/service/UserProfileServiceTest.java
@@ -28,7 +28,7 @@ import javax.servlet.ServletException;
 import org.junit.Before;
 import org.junit.Test;
 import org.sagebionetworks.repo.manager.EntityManager;
-import org.sagebionetworks.repo.manager.PermissionsManager;
+import org.sagebionetworks.repo.manager.EntityPermissionsManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.UserProfileManager;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
@@ -52,14 +52,14 @@ public class UserProfileServiceTest {
 	
 	private UserProfileService userProfileService = new UserProfileServiceImpl();
 	
-	private PermissionsManager mockPermissionsManager;
+	private EntityPermissionsManager mockPermissionsManager;
 	private UserProfileManager mockUserProfileManager;
 	private UserManager mockUserManager;
 	private EntityManager mockEntityManager;
 	
 	@Before
 	public void before() throws Exception {
-		mockPermissionsManager = mock(PermissionsManager.class);
+		mockPermissionsManager = mock(EntityPermissionsManager.class);
 		mockUserProfileManager = mock(UserProfileManager.class);
 		mockUserManager = mock(UserManager.class);
 		mockEntityManager = mock(EntityManager.class);

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/service/UserProfileServiceTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/service/UserProfileServiceTest.java
@@ -35,7 +35,6 @@ import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.Favorite;
 import org.sagebionetworks.repo.model.QueryResults;
-import org.sagebionetworks.repo.model.SchemaCache;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserGroupHeader;
@@ -96,12 +95,12 @@ public class UserProfileServiceTest {
 		userInfo = new UserInfo(false);
 		userInfo.setIndividualGroup(new UserGroup());
 		userInfo.getIndividualGroup().setId(EXTRA_USER_ID);
-		
-		when(mockPermissionsManager.getGroups()).thenReturn(groups);
+
 		when(mockUserProfileManager.getInRange(any(UserInfo.class), anyLong(), anyLong())).thenReturn(profiles);
 		when(mockUserProfileManager.getInRange(any(UserInfo.class), anyLong(), anyLong(), eq(true))).thenReturn(profiles);
 		when(mockUserProfileManager.getUserProfile(any(UserInfo.class), eq(EXTRA_USER_ID))).thenReturn(extraProfile);
 		when(mockUserManager.getUserInfo(EXTRA_USER_ID)).thenReturn(userInfo);
+		when(mockUserManager.getGroups()).thenReturn(groups);
 
 		userProfileService.setPermissionsManager(mockPermissionsManager);
 		userProfileService.setUserProfileManager(mockUserProfileManager);


### PR DESCRIPTION
This is add API for manipulating evaluation ACLs.  Changes include:

1) Rename PermissionsManager to EntityPermissionsManager
2) Add EvaluationPermissionsManager (skeleton code only) and UserEvaluationPermissions
3) Refactor the user group methods by moving them from PermissionsManager to UserManager
