### PR TITLE
Deadlock consideration for GroupMembersDAO

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/CrowdGroupMembersDAO.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/CrowdGroupMembersDAO.java
@@ -3,9 +3,7 @@ package org.sagebionetworks.repo.model.dbo.dao;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.sagebionetworks.authutil.AuthenticationException;
 import org.sagebionetworks.authutil.CrowdAuthUtil;
 import org.sagebionetworks.repo.model.DatastoreException;
@@ -141,12 +139,6 @@ public class CrowdGroupMembersDAO implements GroupMembersDAO {
 		} catch (IOException e) {
 			throw new DatastoreException("500 Server Error - "+e.getMessage(), e);
 		}
-	}
-
-	@Override
-	public Set<String> markAsUpdated(String groupId, List<String> memberIds)
-			throws DatastoreException {
-		throw new NotImplementedException("This method should not be used on this DAO");
 	}
 	
 }

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOUserGroupDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOUserGroupDAOImpl.java
@@ -7,7 +7,6 @@ import static org.sagebionetworks.repo.model.query.jdo.SqlConstants.TABLE_USER_G
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +14,6 @@ import java.util.UUID;
 
 import org.sagebionetworks.ids.IdGenerator;
 import org.sagebionetworks.ids.IdGenerator.TYPE;
-import org.sagebionetworks.ids.UuidETagGenerator;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.InvalidModelException;
@@ -27,6 +25,7 @@ import org.sagebionetworks.repo.model.dbo.persistence.DBOUserGroup;
 import org.sagebionetworks.repo.model.query.jdo.SqlConstants;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
@@ -85,26 +84,12 @@ public class DBOUserGroupDAOImpl implements UserGroupDAO {
 			" LIMIT :"+LIMIT_PARAM_NAME+" OFFSET :"+OFFSET_PARAM_NAME;
 	
 	private static final String SELECT_ALL = 
-		"SELECT * FROM "+SqlConstants.TABLE_USER_GROUP;
+			"SELECT * FROM "+SqlConstants.TABLE_USER_GROUP;
 	
 	private static final String UPDATE_ETAG_LIST = 
 			"UPDATE "+SqlConstants.TABLE_USER_GROUP+
 			" SET "+SqlConstants.COL_USER_GROUP_E_TAG+"=:"+ETAG_PARAM_NAME+
 			" WHERE "+SqlConstants.COL_USER_GROUP_ID+"=:"+ID_PARAM_NAME;
-
-	// the pattern is: select x.id, y.etag from g x LEFT OUTER JOIN p y on x.id=y.owner order by x.id
-	// the query is: select g.id, p.etag from user_group g LEFT OUTER JOIN user_profile p on g.id=p.owner_id order by g.id limit l offset o 
-	// private static final String SELECT_ALL_PAGINATED_WITH_ETAG = 
-	// 	"SELECT g."+COL_USER_GROUP_ID+", p."+COL_USER_PROFILE_ETAG+" FROM "+
-	// 	TABLE_USER_GROUP+" g LEFT OUTER JOIN "+TABLE_USER_PROFILE+
-	// 	" p ON g."+COL_USER_GROUP_ID+" = p."+COL_USER_PROFILE_ID+
-	// 	" ORDER BY g."+COL_USER_GROUP_ID+" LIMIT :"+LIMIT_PARAM_NAME+
-	// 	" OFFSET :"+OFFSET_PARAM_NAME;
-	
-	// the query above is an outer join. For non-individual groups there is no UserProfile and
-	// hence no etag.  The group is immutable and so it's Etag should always be 0.  The following
-	// is the default etag used in such a case.
-	public static final String DEFAULT_ETAG = UuidETagGenerator.ZERO_E_TAG;
 
 	private static final String SQL_COUNT_USER_GROUPS = "SELECT COUNT("+COL_USER_GROUP_ID+") FROM "+TABLE_USER_GROUP + " WHERE "+COL_USER_GROUP_ID+"=:"+ID_PARAM_NAME;
 
@@ -374,20 +359,14 @@ public class DBOUserGroupDAOImpl implements UserGroupDAO {
 
 	@Transactional(readOnly = false, propagation = Propagation.REQUIRED)
 	@Override
-	public void touchList(List<String> ids) {
-		// Convert all IDs to Longs and sort them to prevent deadlock
-		List<Long> livelocks = new ArrayList<Long>();
-		for (String id : ids) {
-			livelocks.add(Long.parseLong(id));
+	public void touch(String id) {
+		MapSqlParameterSource param = new MapSqlParameterSource();
+		param.addValue(ID_PARAM_NAME, id);
+		param.addValue(ETAG_PARAM_NAME, UUID.randomUUID().toString());
+		try {
+			simpleJdbcTemplate.update(UPDATE_ETAG_LIST, param);
+		} catch (DeadlockLoserDataAccessException e) {
+			// Deadlock is unavoidable here (?)
 		}
-		Collections.sort(livelocks);
-		
-		MapSqlParameterSource params[] = new MapSqlParameterSource[livelocks.size()];
-		for (int i = 0; i < params.length; i++) {
-			params[i] = new MapSqlParameterSource();
-			params[i].addValue(ID_PARAM_NAME, livelocks.get(i));
-			params[i].addValue(ETAG_PARAM_NAME, UUID.randomUUID().toString());
-		}
-		simpleJdbcTemplate.batchUpdate(UPDATE_ETAG_LIST, params);
 	}
 }

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/GroupMembersUtils.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/GroupMembersUtils.java
@@ -1,0 +1,59 @@
+package org.sagebionetworks.repo.model.dbo.dao;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.LongBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class GroupMembersUtils {
+
+	/**
+	 * Gzips the given list. 
+	 * @param longs Each element must be parsable as a long
+	 * @return A gzipped byte array of long ints 
+	 */
+	public static byte[] zip(List<String> longs) throws IOException {
+		// Convert the Strings into Longs into Bytes
+		ByteBuffer converter = ByteBuffer.allocate(Long.SIZE / 8 * longs.size());
+		for (int i = 0; i < longs.size(); i++) {
+			converter.putLong(Long.parseLong(longs.get(i)));
+		}
+		
+		// Zip up the bytes
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		GZIPOutputStream zipped = new GZIPOutputStream(out);
+		zipped.write(converter.array());
+		zipped.flush();
+		zipped.close();
+		return out.toByteArray();
+	}
+	
+	/**
+	 * Un-gzips the given array.  
+	 * @param zippedLongs Gzipped array of long ints
+	 * @return A list of longs in base 10 string form
+	 */
+	public static List<String> unzip(byte[] zippedLongs) throws IOException {
+		// Unzip the bytes
+		ByteArrayInputStream in = new ByteArrayInputStream(zippedLongs);
+		GZIPInputStream unzip = new GZIPInputStream(in);
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		while (unzip.available() > 0) {
+			out.write(unzip.read());
+		}
+		
+		// Convert to bytes
+		ByteBuffer converter = ByteBuffer.wrap(out.toByteArray());
+		LongBuffer converted = converter.asLongBuffer();
+		List<String> verbose = new ArrayList<String>();
+		while (converted.hasRemaining()) {
+			verbose.add(Long.toString(converted.get()));
+		}
+		return verbose;
+	}
+}

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOGroupMembersDAOImplDeadlockTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOGroupMembersDAOImplDeadlockTest.java
@@ -120,7 +120,7 @@ public class DBOGroupMembersDAOImplDeadlockTest {
         JOIN,
         LEAVE, 
         ANNEX, 
-        SUCCEED
+        SECEDE
     }
     
     private class SocialMonkey extends Thread {
@@ -195,7 +195,7 @@ public class DBOGroupMembersDAOImplDeadlockTest {
                             }
                             break;
                             
-                        case SUCCEED:
+                        case SECEDE:
                             barrel = barrelIds.get(rand.nextInt(barrelIds.size()));
                             List<UserGroup> monkeySardines = groupMembersDAO.getMembers(barrel);
                             if (monkeySardines.size() > 0) {

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOGroupMembersDAOImplDeadlockTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOGroupMembersDAOImplDeadlockTest.java
@@ -1,0 +1,250 @@
+package org.sagebionetworks.repo.model.dbo.dao;
+
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.sagebionetworks.repo.model.GroupMembersDAO;
+import org.sagebionetworks.repo.model.UserGroup;
+import org.sagebionetworks.repo.model.UserGroupDAO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath:jdomodels-test-context.xml" })
+public class DBOGroupMembersDAOImplDeadlockTest {
+	
+	@Autowired
+	private GroupMembersDAO groupMembersDAO;
+    
+	@Autowired
+	private UserGroupDAO userGroupDAO;
+	
+	@Autowired
+	private SimpleJdbcTemplate simpleJdbcTemplate;
+    
+    private static final Integer NUMBER_O_MONKEYS = 10;
+    private static final Integer NUMBER_O_BARRELS = 5;
+    private static final Integer PLAY_TIME = 10; // Seconds
+    private static final Integer INTERMEDIATE_CHECK_TIME = 1; // Seconds 
+    private List<String> monkeyIds;
+
+    // For the monkeys (read only)
+    private static final Integer ATTENTION_DEFICIT = 100; // Milliseconds
+    private static final String MONKEY_NAME_SUFFIX = "OhWhatFun@Barrel.O.Monkeys";
+    private static final String MONKEY_GROUP_PREFIX = "Barrel of Simians ";
+    private List<String> barrelIds;
+    private volatile boolean keepPlaying = true;
+
+	@Before
+	public void setUp() throws Exception {
+        // Create all the monkeys
+		monkeyIds = new ArrayList<String>(NUMBER_O_MONKEYS);
+        for (int i = 0; i < NUMBER_O_MONKEYS; i++) {
+            UserGroup monkey = new UserGroup();
+            monkey.setName(i + MONKEY_NAME_SUFFIX);
+            monkey.setIsIndividual(true);
+            monkeyIds.add(userGroupDAO.create(monkey));
+        }
+        
+        // Create all the barrels
+        barrelIds = new ArrayList<String>(NUMBER_O_BARRELS);
+        for (int i = 0; i < NUMBER_O_BARRELS; i++) {
+            UserGroup barrel = new UserGroup();
+            barrel.setName(MONKEY_GROUP_PREFIX + i);
+            barrel.setIsIndividual(false);
+            barrelIds.add(userGroupDAO.create(barrel));
+        }
+	}
+
+	@After
+	public void tearDown() throws Exception {
+        for (int i = 0; i < NUMBER_O_MONKEYS; i++) {
+        	userGroupDAO.deletePrincipal(i + MONKEY_NAME_SUFFIX);
+        }
+        for (int i = 0; i < NUMBER_O_BARRELS; i++) {
+            userGroupDAO.deletePrincipal(MONKEY_GROUP_PREFIX + i);
+        }
+	}
+    
+    @Test
+    public void testForDeadlock() throws Exception {
+        // Play time!!!
+        SocialMonkey monkeys[] = new SocialMonkey[NUMBER_O_MONKEYS];
+        for (int i = 0; i < NUMBER_O_MONKEYS; i++) {
+            monkeys[i] = new SocialMonkey(monkeyIds.get(i));
+            monkeys[i].start();
+        }
+        
+        // Check up on the playing monkeys a few times
+        int totalSleepTime = 0; 
+        while (totalSleepTime < PLAY_TIME) {
+        	for (int i = 0; i < NUMBER_O_MONKEYS; i++) {
+	        	if (monkeys[i].fatality != null) {
+	                fail();
+	            }
+        	}
+        	Thread.sleep(INTERMEDIATE_CHECK_TIME * 1000);
+        	totalSleepTime += INTERMEDIATE_CHECK_TIME;
+        }
+        
+        // Bed time...
+        System.out.println("Ending deadlock test");
+        keepPlaying = false;
+        int totalRaces = 0;
+        for (int i = 0; i < NUMBER_O_MONKEYS; i++) {
+            while (monkeys[i].isPlaying) {
+                Thread.sleep(ATTENTION_DEFICIT);
+            }
+            totalRaces += monkeys[i].racesDetected;
+            if (monkeys[i].fatality != null) {
+                throw new Exception(monkeys[i].fatality);
+            }
+        }
+        
+        // No deadlock detected :)
+        System.out.println("Monkeys collided " + totalRaces + " times");
+    }
+    
+    private enum MonkeyBehavior {
+        JOIN,
+        LEAVE, 
+        ANNEX, 
+        SUCCEED
+    }
+    
+    private class SocialMonkey extends Thread {
+        
+        public volatile boolean isPlaying = true;
+        public volatile int racesDetected = 0;
+        public volatile Exception fatality;
+    
+        private String monkeyId;
+        private Random rand;
+        private MonkeyBehavior action;
+        private String barrel;
+        private String member;
+        
+        SocialMonkey(String number) {
+            this.monkeyId = number;
+            rand = new Random();
+        }
+        
+        @Override
+        public void run() {
+            try {
+                while (keepPlaying) {
+                    List<String> memberList = new ArrayList<String>();
+                    
+                    // Decide what to do
+                    action = MonkeyBehavior.values()[rand.nextInt(MonkeyBehavior.values().length)];
+                    switch (action) {
+                        case JOIN:
+                        	barrel = barrelIds.get(rand.nextInt(barrelIds.size()));
+                        	member = monkeyId;
+                            memberList.add(member);
+                            groupMembersDAO.addMembers(barrel, memberList);
+                            
+                            // Check for the barrel
+                            List<UserGroup> funBarrels = groupMembersDAO.getUsersGroups(member);
+                            if (!checkListForEntry(funBarrels, barrel)) {
+                                racesDetected++;
+                            }
+                            break;
+                            
+                        case LEAVE:
+                            List<UserGroup> barrels = groupMembersDAO.getUsersGroups(monkeyId);
+                            if (barrels.size() > 0) {
+	                            barrel = barrels.get(rand.nextInt(barrels.size())).getId();
+	                        	member = monkeyId;
+	                            memberList.add(member);
+	                            groupMembersDAO.removeMembers(barrel, memberList);
+	                            
+	                            // Check for the barrel
+	                            List<UserGroup> boringBarrels = groupMembersDAO.getUsersGroups(member);
+	                            if (checkListForEntry(boringBarrels, barrel)) {
+	                                racesDetected++;
+	                            }
+                            }
+                            break;
+                            
+                        case ANNEX:
+                            barrel = barrelIds.get(rand.nextInt(barrelIds.size()));
+                            member = barrelIds.get(rand.nextInt(barrelIds.size()));
+                            memberList.add(member);
+                            try {
+                                groupMembersDAO.addMembers(barrel, memberList);
+                            
+                                // Check for the barrel
+                                List<UserGroup> members = groupMembersDAO.getUsersGroups(member);
+                                if (!checkListForEntry(members, barrel)) {
+                                    racesDetected++;
+                                }
+                            } catch (IllegalArgumentException e) {
+                                // Circularity exception ignored :P
+                            }
+                            break;
+                            
+                        case SUCCEED:
+                            barrel = barrelIds.get(rand.nextInt(barrelIds.size()));
+                            List<UserGroup> monkeySardines = groupMembersDAO.getMembers(barrel);
+                            if (monkeySardines.size() > 0) {
+	                            member = monkeySardines.get(rand.nextInt(monkeySardines.size())).getId();
+	                            memberList.add(member);
+	                            groupMembersDAO.removeMembers(barrel, memberList);
+	                            
+	                            // Check for the barrel
+	                            List<UserGroup> members = groupMembersDAO.getUsersGroups(member);
+	                            if (checkListForEntry(members, barrel)) {
+	                                racesDetected++;
+	                            }
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                    Thread.sleep(rand.nextInt(ATTENTION_DEFICIT));
+                }
+                
+            // Store exceptions so that the main thread can re-throw it
+            } catch (Exception e) {
+                if (e.getClass() != DataIntegrityViolationException.class) {
+	                fatality = e;
+	                
+	                // Print out some debug info
+	                System.out.println("!!! " + action + ": Barrel - " + barrel + ", Monkey - " + member);
+	                String errorMessage = e + "\n";
+	                for (StackTraceElement st : e.getStackTrace()) {
+	                	if (st.getClassName().contains("sagebionetworks")) {
+	                		errorMessage += "    " + st + "\n";
+	                	}
+	                }
+	                System.err.print(errorMessage);
+	            	
+	            }
+            }
+            isPlaying = false;
+        }
+    }
+
+    private boolean checkListForEntry(List<UserGroup> ugs, String entry) {
+        boolean detected = false;
+        for (UserGroup ug : ugs) {
+            if (ug.getId().equals(entry)) {
+                detected = true;
+                break;
+            }
+        }
+        return detected;
+    }
+}

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOGroupMembersDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOGroupMembersDAOImplTest.java
@@ -146,7 +146,7 @@ public class DBOGroupMembersDAOImplTest {
 			groupMembersDAO.addMembers(testGroup.getId(), adder);
 			assertTrue(false);
 		} catch (IllegalArgumentException e) {
-			assertTrue(e.getMessage().contains("member of itself"));
+			assertTrue(e.getMessage().contains("already a child"));
 		}
 		
 		// Add the child group to the parent group
@@ -216,23 +216,6 @@ public class DBOGroupMembersDAOImplTest {
 		// Verify that the parent group's etag has changed
 		updatedTestGroup = userGroupDAO.get(testGroup.getId());
 		assertTrue("Etag must have changed", !testGroup.getEtag().equals(updatedTestGroup.getEtag()));
-	}
-	
-	@Test
-	public void testZipUnzip() throws Exception {
-		List<String> original = new ArrayList<String>();
-		original.add("1");
-		original.add("2");
-		original.add("34");
-		original.add("567");
-		original.add("8901");
-		original.add("23456789");
-		original.add(Long.toString(Long.MIN_VALUE));
-		original.add(Long.toString(Long.MAX_VALUE));
-		
-		List<String> processed = DBOGroupMembersDAOImpl.unzipParents(DBOGroupMembersDAOImpl.zipParents(original));
-		assertTrue(original.containsAll(processed));
-		assertTrue(processed.containsAll(original));
 	}
 	
 	@Test

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/GroupMembersUtilsTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/GroupMembersUtilsTest.java
@@ -1,0 +1,29 @@
+package org.sagebionetworks.repo.model.dbo.dao;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+public class GroupMembersUtilsTest {
+
+	@Test
+	public void testZipUnzip() throws Exception {
+		List<String> original = new ArrayList<String>();
+		original.add("1");
+		original.add("2");
+		original.add("34");
+		original.add("567");
+		original.add("8901");
+		original.add("23456789");
+		original.add(Long.toString(Long.MIN_VALUE));
+		original.add(Long.toString(Long.MAX_VALUE));
+		
+		List<String> processed = GroupMembersUtils.unzip(GroupMembersUtils.zip(original));
+		assertTrue(original.containsAll(processed));
+		assertTrue(processed.containsAll(original));
+	}
+
+}

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/GroupMembersDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/GroupMembersDAO.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.repo.model;
 
 import java.util.List;
-import java.util.Set;
 
 import org.sagebionetworks.repo.web.NotFoundException;
 
@@ -38,13 +37,5 @@ public interface GroupMembersDAO {
 	 */
 	public List<UserGroup> getUsersGroups(String principalId) 
 			throws DatastoreException, NotFoundException;
-	
-	/**
-	 * Changes the etag of the parent group (for migration purposes)
-	 * and nullifies cached parents of all children and their children
-	 * @return All IDs where the cache has been cleared
-	 */
-	public Set<String> markAsUpdated(String groupId, List<String> memberIds)
-			throws DatastoreException;
 
 }

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/UserGroupDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/UserGroupDAO.java
@@ -76,9 +76,8 @@ public interface UserGroupDAO extends BaseDAO<UserGroup>{
 	public void bootstrapUsers() throws Exception;
 
 	/**
-	 * Updates the etags of all groups with the given IDs
-	 * @param ids
+	 * Updates the etag the group with the given ID
 	 */
-	public void touchList(List<String> ids);
+	public void touch(String id);
 
 }

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/UserGroupDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/UserGroupDAO.java
@@ -74,6 +74,11 @@ public interface UserGroupDAO extends BaseDAO<UserGroup>{
 	 * @throws Exception 
 	 */
 	public void bootstrapUsers() throws Exception;
+	
+	/**
+	 * Gets and locks a row of the table
+	 */
+	public UserGroup getForUpdate(String id);
 
 	/**
 	 * Updates the etag the group with the given ID

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserManagerImpl.java
@@ -59,6 +59,7 @@ public class UserManagerImpl implements UserManager {
 		} else {
 			cacheTimeout = AuthorizationConstants.AUTH_CACHE_TIMEOUT_DEFAULT;
 		}
+		cacheTimeout = new Long(-1); // Disable caching
 	}
 
 	// for testing

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserManagerImplTest.java
@@ -13,22 +13,11 @@ import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_GROUPS;
-import org.sagebionetworks.repo.model.jdo.KeyFactory;
-import org.sagebionetworks.repo.model.query.BasicQuery;
-import org.sagebionetworks.repo.model.query.Comparator;
-import org.sagebionetworks.repo.model.query.CompoundId;
-import org.sagebionetworks.repo.model.query.Expression;
 import org.sagebionetworks.repo.model.DatastoreException;
-import org.sagebionetworks.repo.model.EntityType;
-import org.sagebionetworks.repo.model.NodeConstants;
-import org.sagebionetworks.repo.model.NodeDAO;
-import org.sagebionetworks.repo.model.NodeQueryDao;
-import org.sagebionetworks.repo.model.NodeQueryResults;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserGroupDAO;
 import org.sagebionetworks.repo.model.UserInfo;
@@ -45,12 +34,6 @@ public class UserManagerImplTest {
 	
 	@Autowired
 	UserGroupDAO userGroupDAO;
-	
-	@Autowired
-	NodeDAO nodeDao;
-	
-	@Autowired
-	NodeQueryDao nodeQueryDao;
 	
 	private static final String TEST_USER = "test-user";
 	

--- a/services/workers/src/main/java/org/sagebionetworks/crowd/workers/CrowdGroupSynchronizer.java
+++ b/services/workers/src/main/java/org/sagebionetworks/crowd/workers/CrowdGroupSynchronizer.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.crowd.workers;
 
 import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -81,7 +83,7 @@ public class CrowdGroupSynchronizer implements Runnable {
 					} catch (NotFoundException e) {
 						// Must make a new profile
 						try {
-							User user = userDAO.getUser(name);
+							User user = userDAO.getUser(URLEncoder.encode(name, "UTF-8"));
 							UserProfile userProfile = new UserProfile();
 							userProfile.setOwnerId(principalId);
 							userProfile.setFirstName(user.getFname());
@@ -92,6 +94,8 @@ public class CrowdGroupSynchronizer implements Runnable {
 							throw new RuntimeException(nfe);
 						} catch (InvalidModelException ime) {
 							throw new RuntimeException(ime);
+						} catch (UnsupportedEncodingException uee) {
+							throw new RuntimeException(uee);
 						}
 					}
 				}

--- a/services/workers/src/test/java/org/sagebionetworks/crowd/workers/CrowdGroupSynchronizerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/crowd/workers/CrowdGroupSynchronizerTest.java
@@ -5,7 +5,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -45,12 +48,18 @@ public class CrowdGroupSynchronizerTest {
 	
 	private static final Log log = LogFactory.getLog(CrowdGroupSynchronizerTest.class);
 	
+	Set<String> originalGroupsInRDS;
 	List<String> groupsToDeleteFromRDS;
 	List<String> groupsToDeleteFromCrowd;
 	List<String> usersToDeleteFromCrowd;
 	
 	@Before
 	public void setUp() throws Exception {
+		originalGroupsInRDS = new HashSet<String>();
+		Collection<UserGroup> originals = userGroupDAO.getAll();
+		for (UserGroup ug : originals) {
+			originalGroupsInRDS.add(ug.getId());
+		}
 		groupsToDeleteFromRDS = new ArrayList<String>();
 		groupsToDeleteFromCrowd = new ArrayList<String>();
 		usersToDeleteFromCrowd = new ArrayList<String>();
@@ -58,6 +67,13 @@ public class CrowdGroupSynchronizerTest {
 
 	@After
 	public void tearDown() throws Exception {
+		Collection<UserGroup> polluted = userGroupDAO.getAll();
+		for (UserGroup ug : polluted) {
+			if (!originalGroupsInRDS.contains(ug.getId())) {
+				groupsToDeleteFromRDS.add(ug.getId());
+			}
+		}
+		
 		if(groupsToDeleteFromRDS != null) {
 			for(String todelete: groupsToDeleteFromRDS){
 				deleteTestGroupFromRDS(todelete);


### PR DESCRIPTION
- Moved zip/unzip into a utility
- Rearranged some logic within DBOGroupMembersDAOImpl to remove deadlocks
- Two methods with possible concurrent-update now catch and ignore deadlock
- Fix for failure of IT510SynapseJavaClientSearchTest.testAllReturnFields
