### PR TITLE
Small fix for UserProfileManager and its tests.

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserProfileManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserProfileManagerImpl.java
@@ -48,7 +48,7 @@ public class UserProfileManagerImpl implements UserProfileManager {
 	@Autowired
 	private S3TokenManager s3TokenManager;
 	@Autowired
-	AttachmentManager attachmentManager;
+	private AttachmentManager attachmentManager;
 	@Autowired
 	private FavoriteDAO favoriteDAO;
 	@Autowired 
@@ -65,12 +65,13 @@ public class UserProfileManagerImpl implements UserProfileManager {
 	 * @param s3TokenManager
 	 */
 	public UserProfileManagerImpl(UserProfileDAO userProfileDAO, UserGroupDAO userGroupDAO,
-			S3TokenManager s3TokenManager, FavoriteDAO favoriteDAO) {
+			S3TokenManager s3TokenManager, FavoriteDAO favoriteDAO, AttachmentManager attachmentManager) {
 		super();
 		this.userProfileDAO = userProfileDAO;
 		this.userGroupDAO = userGroupDAO;
 		this.s3TokenManager = s3TokenManager;
 		this.favoriteDAO = favoriteDAO;
+		this.attachmentManager = attachmentManager;
 	}
 
 	@Override
@@ -82,10 +83,9 @@ public class UserProfileManagerImpl implements UserProfileManager {
 		ObjectSchema schema = SchemaCache.getSchema(UserProfile.class);
 		UserProfile userProfile = userProfileDAO.get(ownerId, schema);
 		UserGroup userGroup = userGroupDAO.get(ownerId);
-		if (userInfo != null && userInfo.getUser() != null) {
-			userProfile.setUserName(userInfo.getUser().getUserId());
-			if (userGroup != null)
-				userProfile.setEmail(userGroup.getName());
+		if (userGroup != null) {
+			userProfile.setEmail(userGroup.getName());
+			userProfile.setUserName(userGroup.getName());
 		}
 		return userProfile;
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserProfileManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserProfileManagerImplTest.java
@@ -1,42 +1,32 @@
 package org.sagebionetworks.repo.manager;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import java.util.Date;
-import java.util.Random;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.sagebionetworks.ids.IdGenerator;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.InvalidModelException;
-import org.sagebionetworks.repo.model.SchemaCache;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserGroupDAO;
 import org.sagebionetworks.repo.model.UserInfo;
-import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.UserProfileDAO;
-import org.sagebionetworks.repo.model.attachment.PresignedUrl;
 import org.sagebionetworks.repo.model.attachment.S3AttachmentToken;
-import org.sagebionetworks.repo.util.LocationHelper;
 import org.sagebionetworks.repo.web.NotFoundException;
-import org.sagebionetworks.schema.ObjectSchema;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:manager-test-context.xml" })
-@Ignore // This test is unstable and has been removed https://sagebionetworks.jira.com/browse/PLFM-1750.
 public class UserProfileManagerImplTest {
 	
 	@Autowired
@@ -48,13 +38,10 @@ public class UserProfileManagerImplTest {
 	@Autowired
 	private UserProfileManager userProfileManager;
 
-	private LocationHelper mockLocationHelper;
 	private IdGenerator mockIdGenerator;
 	private static final String TEST_USER_NAME = "test-user";
-	private static final String TEST_USER_DISPLAY_NAME = "test-user display-name";
 	
 	private UserGroup individualGroup = null;
-	private UserProfile userProfile = null;
 	
 	
 	@Before
@@ -69,18 +56,8 @@ public class UserProfileManagerImplTest {
 		}
 		individualGroup = userGroupDAO.findGroup(TEST_USER_NAME, true);
 		assertNotNull(individualGroup);
-		// we also make an user profile for this individual
-		ObjectSchema schema = SchemaCache.getSchema(UserProfile.class);
-		userProfile = new UserProfile();
-		userProfile.setOwnerId(individualGroup.getId());
-		userProfile.setDisplayName(TEST_USER_DISPLAY_NAME);
-		userProfile.setRStudioUrl("myPrivateRStudioUrl");
-		String id = userProfileDAO.create(userProfile, schema);
-		userProfile = userProfileDAO.get(id, schema);
-		assertNotNull(userProfile);
 
 		mockIdGenerator = Mockito.mock(IdGenerator.class);
-		mockLocationHelper = Mockito.mock(LocationHelper.class);
 	}
 
 	@After
@@ -88,96 +65,11 @@ public class UserProfileManagerImplTest {
 		UserGroup individualGroup = userGroupDAO.findGroup(TEST_USER_NAME, true);
 		userGroupDAO.delete(individualGroup.getId());
 		individualGroup = null;
-		if(userProfile != null && userProfile.getOwnerId() != null){
-			userProfileDAO.delete(userProfile.getOwnerId());
-		}
-	}
-	
-	@Test
-	public void testGetOwnUserProfle() throws Exception {
-		assertNotNull(individualGroup);
-		assertNotNull(userProfile);
-		UserInfo userInfo = new UserInfo(false); // not an admin
-		userInfo.setIndividualGroup(individualGroup);
-		String ownerId = userProfile.getOwnerId();
-		assertEquals(ownerId, individualGroup.getId());
-		UserProfile upClone = userProfileManager.getUserProfile(userInfo, ownerId);
-		assertEquals(userProfile, upClone);
-	}
-	
-	@Test
-	public void testgetOthersUserProfle() throws Exception {
-		assertNotNull(individualGroup);
-		assertNotNull(userProfile);
-		UserInfo userInfo = new UserInfo(false); // not an admin
-		UserGroup otherIndividualGroup = new UserGroup();
-		otherIndividualGroup.setId("-100");
-		userInfo.setIndividualGroup(otherIndividualGroup);
-		String ownerId = userProfile.getOwnerId();
-		assertEquals(ownerId, individualGroup.getId());
-		// there will be missing fields, intentionally 'blanked out'
-		UserProfile upClone = userProfileManager.getUserProfile(userInfo, ownerId);
-		assertFalse(userProfile.equals(upClone));
-		assertEquals(userProfile.getDisplayName(), upClone.getDisplayName());
-	}
-	
-	@Test
-	public void testgetOthersUserProfleByAdmin() throws Exception {
-		assertNotNull(individualGroup);
-		assertNotNull(userProfile);
-		UserInfo userInfo = new UserInfo(true); // IS an admin
-		UserGroup otherIndividualGroup = new UserGroup();
-		otherIndividualGroup.setId("-100");
-		userInfo.setIndividualGroup(otherIndividualGroup);
-		String ownerId = userProfile.getOwnerId();
-		assertEquals(ownerId, individualGroup.getId());
-
-		UserProfile upClone = userProfileManager.getUserProfile(userInfo, ownerId);
-		assertEquals(userProfile, upClone);
-	}
-	
-	private Random rand = new Random();
-	
-	@Test
-	public void testUpdateOwnUserProfle() throws Exception {
-		assertNotNull(individualGroup);
-		assertNotNull(userProfile);
-		UserInfo userInfo = new UserInfo(false); // not an admin
-		userInfo.setIndividualGroup(individualGroup);
-		String ownerId = userProfile.getOwnerId();
-		assertEquals(ownerId, individualGroup.getId());
-		UserProfile upClone = userProfileManager.getUserProfile(userInfo, ownerId);
-		assertEquals(userProfile, upClone);
-		
-		String newURL = "http://"+rand.nextLong(); // just a random long number
-		upClone.setRStudioUrl(newURL);
-		userProfileManager.updateUserProfile(userInfo, upClone);
-		upClone = userProfileManager.getUserProfile(userInfo, ownerId);
-		assertEquals(newURL, upClone.getRStudioUrl());
-	}
-	
-	@Test(expected=UnauthorizedException.class)
-	public void testUpdateOthersUserProfle() throws Exception {
-		assertNotNull(individualGroup);
-		assertNotNull(userProfile);
-		UserInfo userInfo = new UserInfo(false); // not an admin
-		UserGroup otherIndividualGroup = new UserGroup();
-		otherIndividualGroup.setId("-100");
-		userInfo.setIndividualGroup(otherIndividualGroup);
-		String ownerId = userProfile.getOwnerId();
-		
-		UserProfile upClone = userProfileManager.getUserProfile(userInfo, ownerId);
-		// so we get back the UserProfile for the specified owner...
-		assertEquals(ownerId, upClone.getOwnerId());
-		// ... but we can't update it, since we are not the owner or an admin
-		// the following step will fail
-		userProfileManager.updateUserProfile(userInfo, upClone);
 	}
 
 	@Test
 	public void testGetAttachmentUrl() throws Exception{
 		assertNotNull(individualGroup);
-		assertNotNull(userProfile);
 		UserInfo userInfo = new UserInfo(false); // not an admin
 		userInfo.setIndividualGroup(individualGroup);
 		
@@ -185,7 +77,7 @@ public class UserProfileManagerImplTest {
 		String otherUserProfileId = "12345";
 		
 		// Make the actual call
-		PresignedUrl url = userProfileManager.getUserProfileAttachmentUrl(userInfo, otherUserProfileId, tokenId.toString());
+		userProfileManager.getUserProfileAttachmentUrl(userInfo, otherUserProfileId, tokenId.toString());
 	}
 	
 	@Test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserProfileManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserProfileManagerImplUnitTest.java
@@ -1,18 +1,25 @@
 package org.sagebionetworks.repo.manager;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Random;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.Favorite;
 import org.sagebionetworks.repo.model.FavoriteDAO;
 import org.sagebionetworks.repo.model.InvalidModelException;
-import org.sagebionetworks.repo.model.SchemaCache;
 import org.sagebionetworks.repo.model.UnauthorizedException;
+import org.sagebionetworks.repo.model.User;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserGroupDAO;
 import org.sagebionetworks.repo.model.UserInfo;
@@ -20,38 +27,94 @@ import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.UserProfileDAO;
 import org.sagebionetworks.repo.model.attachment.PresignedUrl;
 import org.sagebionetworks.repo.model.attachment.S3AttachmentToken;
+import org.sagebionetworks.repo.model.dbo.dao.UserProfileUtils;
+import org.sagebionetworks.repo.model.dbo.persistence.DBOUserProfile;
 import org.sagebionetworks.repo.util.LocationHelper;
 import org.sagebionetworks.repo.web.NotFoundException;
+import org.sagebionetworks.schema.ObjectSchema;
 
 public class UserProfileManagerImplUnitTest {
 
-	UserProfileManager userProfileManager;
+	LocationHelper mocKLocationHelper;
 	UserProfileDAO mockProfileDAO;
 	UserGroupDAO mockUserGroupDAO;
 	S3TokenManager mockS3TokenManager;
+	UserManager mockUserManager;
+	FavoriteDAO mockFavoriteDAO;
+	AttachmentManager mockAttachmentManager;
+	
+	UserProfileManager userProfileManager;
+	
 	UserInfo userInfo;
 	UserGroup user;
 	UserInfo adminUserInfo;
-	UserManager mockUserManager;
-	LocationHelper mocKLocationHelper;
+	UserProfile userProfile;
 	S3AttachmentToken testToken;
-	FavoriteDAO mockFavoriteDAO;
+	
+	private Random rand = new Random();
+	private static final String TEST_USER_NAME = "TruncatableName@test.com";
 	
 	@Before
-	public void before() {
+	public void before() throws Exception {
 		mocKLocationHelper = Mockito.mock(LocationHelper.class);
 		mockProfileDAO = Mockito.mock(UserProfileDAO.class);
 		mockUserGroupDAO = Mockito.mock(UserGroupDAO.class);
 		mockS3TokenManager = Mockito.mock(S3TokenManager.class);
 		mockUserManager = Mockito.mock(UserManager.class);
-		mockFavoriteDAO = mock(FavoriteDAO.class);
-		userProfileManager = new UserProfileManagerImpl(mockProfileDAO, mockUserGroupDAO, mockS3TokenManager, mockFavoriteDAO);
-		userInfo = new UserInfo(false);
-		adminUserInfo = new UserInfo(true);
+		mockFavoriteDAO = Mockito.mock(FavoriteDAO.class);
+		mockAttachmentManager = Mockito.mock(AttachmentManager.class);
+		userProfileManager = new UserProfileManagerImpl(mockProfileDAO, mockUserGroupDAO, mockS3TokenManager, mockFavoriteDAO, mockAttachmentManager);
+		
 		user = new UserGroup();
 		user.setId("111");
+		user.setName(TEST_USER_NAME);
+		user.setIsIndividual(true);
+		
+		userInfo = new UserInfo(false);
 		userInfo.setIndividualGroup(user);
+		
+		adminUserInfo = new UserInfo(true);
 		adminUserInfo.setIndividualGroup(user);
+		adminUserInfo.setUser(new User());
+		adminUserInfo.getUser().setUserId("This should not appear in the profiles");
+		
+		userProfile = new UserProfile();
+		userProfile.setOwnerId(user.getId());
+		userProfile.setDisplayName("test-user display-name");
+		userProfile.setRStudioUrl("myPrivateRStudioUrl");
+		userProfile.setEmail(TEST_USER_NAME);
+		userProfile.setLocation("I'm guessing this is private");
+		
+		// UserProfileDAO should return a copy of the mock UserProfile when getting
+		Mockito.doAnswer(new Answer<UserProfile>() {
+			@Override
+			public UserProfile answer(InvocationOnMock invocation) throws Throwable {
+				Object[] args = invocation.getArguments();
+				ObjectSchema schema = (ObjectSchema) args[1];
+				
+				DBOUserProfile intermediate = new DBOUserProfile();
+				UserProfile copy = new UserProfile();
+				UserProfileUtils.copyDtoToDbo(userProfile, intermediate, schema);
+				UserProfileUtils.copyDboToDto(intermediate, copy, schema);
+				return copy;
+			}
+		}).when(mockProfileDAO).get(Mockito.anyString(), (ObjectSchema) Mockito.any());
+		
+		// UserProfileDAO should return a copy of the argument when updating
+		Mockito.doAnswer(new Answer<UserProfile>() {
+			@Override
+			public UserProfile answer(InvocationOnMock invocation) throws Throwable {
+				Object[] args = invocation.getArguments();
+				UserProfile copy = (UserProfile) args[0];
+				ObjectSchema schema = (ObjectSchema) args[1];
+				
+				DBOUserProfile intermediate = new DBOUserProfile();
+				UserProfileUtils.copyDtoToDbo(copy, intermediate, schema);
+				UserProfileUtils.copyDboToDto(intermediate, copy, schema);
+				return copy;
+			}
+		}).when(mockProfileDAO).update((UserProfile) Mockito.any(), (ObjectSchema) Mockito.any());
+		
 		testToken = new S3AttachmentToken();
 		testToken.setFileName("testonly.jpg");
 	}
@@ -129,5 +192,60 @@ public class UserProfileManagerImplUnitTest {
 		fav.setEntityId(entityId);
 		verify(mockFavoriteDAO).add(fav);
 	}
-
+	
+	
+	/* Tests moved and mocked from UserProfileManagerImplTest */
+	
+	@Test
+	public void testGetOwnUserProfle() throws Exception {
+		String ownerId = userInfo.getIndividualGroup().getId();
+		UserProfile upClone = userProfileManager.getUserProfile(userInfo, ownerId);
+		assertEquals(userProfile, upClone);
+	}
+	
+	@Test
+	@Ignore // Private fields are removed in the service layer
+	public void testgetOthersUserProfle() throws Exception {
+		String ownerId = userInfo.getIndividualGroup().getId();
+		userInfo.getIndividualGroup().setId("-100");
+		
+		// There should be missing fields, intentionally blanked-out
+		UserProfile upClone = userProfileManager.getUserProfile(userInfo, ownerId);
+		assertFalse(userProfile.equals(upClone));
+		assertEquals(userProfile.getDisplayName(), upClone.getDisplayName());
+	}
+	
+	@Test
+	public void testgetOthersUserProfleByAdmin() throws Exception {
+		String ownerId = userInfo.getIndividualGroup().getId();
+		UserProfile upClone = userProfileManager.getUserProfile(adminUserInfo, ownerId);
+		assertEquals(userProfile, upClone);
+	}
+	
+	@Test
+	public void testUpdateOwnUserProfle() throws Exception {
+		// Get a copy of a UserProfile to update
+		String ownerId = userInfo.getIndividualGroup().getId();
+		UserProfile upClone = userProfileManager.getUserProfile(userInfo, ownerId);
+		assertEquals(userProfile, upClone);
+		
+		// Change a field
+		String newURL = "http://"+rand.nextLong(); // just a random long number
+		upClone.setRStudioUrl(newURL);
+		upClone = userProfileManager.updateUserProfile(userInfo, upClone);
+		assertEquals(newURL, upClone.getRStudioUrl());
+	}
+	
+	@Test(expected=UnauthorizedException.class)
+	public void testUpdateOthersUserProfle() throws Exception {
+		String ownerId = userInfo.getIndividualGroup().getId();
+		userInfo.getIndividualGroup().setId("-100");
+		
+		UserProfile upClone = userProfileManager.getUserProfile(userInfo, ownerId);
+		// so we get back the UserProfile for the specified owner...
+		assertEquals(ownerId, upClone.getOwnerId());
+		// ... but we can't update it, since we are not the owner or an admin
+		// the following step will fail
+		userProfileManager.updateUserProfile(userInfo, upClone);
+	}
 }


### PR DESCRIPTION
PLFM-1750 & PLFM-2126/PLFM-1893
- Moved a few UserProfile tests from integration into unit
- Changed the source of some UserProfile fields from the UserInfo object (the asker) to the UserGroup object (the requested)
