### PR TITLE
Replacement for the RepositoryMessagePublisher.timerFiredFindUnsentMessages() worker

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAO.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAO.java
@@ -83,5 +83,12 @@ public interface DBOChangeDAO {
 	 * @return
 	 */
 	public List<ChangeMessage> listUnsentMessages(long limit);
+	
+	/** 
+	 * List messages that have been created but not registered as sent (see {@link #registerMessageSent(long)}).
+	 * Limits results to change numbers between (inclusive) the specified bounds.
+	 * This is used to detect messages that need to be sent either for the first time or re-sent on a new stacks.
+	 */
+	public List<ChangeMessage> listUnsentMessages(long lowerBound, long upperBound);
 
 }

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAO.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAO.java
@@ -29,10 +29,20 @@ public interface DBOChangeDAO {
 	
 	
 	/**
-	 * Get the current application change number;
+	 * @return The minimum change number
+	 */
+	public long getMinimumChangeNumber();
+	
+	/**
+	 * Get the current (maximum) application change number.
 	 * @return
 	 */
 	public long getCurrentChangeNumber();
+	
+	/**
+	 * @return The count of change numbers.
+	 */
+	public long getCount();
 
 	/**
 	 * Completely remove a change from the DB.
@@ -63,6 +73,7 @@ public interface DBOChangeDAO {
 	 * @param changeNumber
 	 */
 	public void registerMessageSent(long changeNumber);
+
 	
 	/**
 	 * List messages that have been created but not registered as sent (see {@link #registerMessageSent(long)}).

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAOImpl.java
@@ -40,19 +40,38 @@ public class DBOChangeDAOImpl implements DBOChangeDAO {
 	
 	static private Logger log = LogManager.getLogger(DBOChangeDAOImpl.class);
 	
-	private static final String SQL_INSERT_SENT_ON_DUPLICATE_UPDATE = "INSERT INTO "+TABLE_SENT_MESSAGES+" ( "+COL_SENT_MESSAGES_CHANGE_NUM+", "+COL_SENT_MESSAGES_TIME_STAMP+") VALUES ( ?, ?) ON DUPLICATE KEY UPDATE "+COL_SENT_MESSAGES_TIME_STAMP+" = ?";
+	private static final String SQL_INSERT_SENT_ON_DUPLICATE_UPDATE = 
+			"INSERT INTO "+TABLE_SENT_MESSAGES+" ( "+COL_SENT_MESSAGES_CHANGE_NUM+", "+COL_SENT_MESSAGES_TIME_STAMP+")"+
+			" VALUES ( ?, ?) ON DUPLICATE KEY UPDATE "+COL_SENT_MESSAGES_TIME_STAMP+" = ?";
 	
-	private static final String SQL_SELECT_CHANGES_NOT_SENT = "SELECT C.* FROM "+TABLE_CHANGES+" C LEFT OUTER JOIN "+TABLE_SENT_MESSAGES+" S ON (C."+COL_CHANGES_CHANGE_NUM+" = S."+COL_SENT_MESSAGES_CHANGE_NUM+") WHERE S."+COL_SENT_MESSAGES_CHANGE_NUM+" IS NULL LIMIT ?";
+	private static final String SQL_SELECT_CHANGES_NOT_SENT = 
+			"SELECT C.* FROM "+TABLE_CHANGES+
+			" C LEFT OUTER JOIN "+TABLE_SENT_MESSAGES+" S ON (C."+COL_CHANGES_CHANGE_NUM+" = S."+COL_SENT_MESSAGES_CHANGE_NUM+")"+
+			"WHERE S."+COL_SENT_MESSAGES_CHANGE_NUM+" IS NULL LIMIT ?";
 	
-	private static final String SELECT_CHANGE_NUMBER_FOR_OBJECT_ID_AND_TYPE = "SELECT "+COL_CHANGES_CHANGE_NUM+" FROM "+TABLE_CHANGES+" WHERE "+COL_CHANGES_OBJECT_ID+" = ? AND "+COL_CHANGES_OBJECT_TYPE+" = ?";
+	private static final String SELECT_CHANGE_NUMBER_FOR_OBJECT_ID_AND_TYPE = 
+			"SELECT "+COL_CHANGES_CHANGE_NUM+" FROM "+TABLE_CHANGES+
+			" WHERE "+COL_CHANGES_OBJECT_ID+" = ? AND "+COL_CHANGES_OBJECT_TYPE+" = ?";
 
-	private static final String SQL_SELECT_ALL_GREATER_THAN_OR_EQUAL_TO_CHANGE_NUMBER_FILTER_BY_OBJECT_TYPE = "SELECT * FROM "+TABLE_CHANGES+" WHERE "+COL_CHANGES_CHANGE_NUM+" >= ? AND "+COL_CHANGES_OBJECT_TYPE+" = ? ORDER BY "+COL_CHANGES_CHANGE_NUM+" ASC LIMIT ?";
+	private static final String SQL_SELECT_ALL_GREATER_THAN_OR_EQUAL_TO_CHANGE_NUMBER_FILTER_BY_OBJECT_TYPE = 
+			"SELECT * FROM "+TABLE_CHANGES+
+			" WHERE "+COL_CHANGES_CHANGE_NUM+" >= ? AND "+COL_CHANGES_OBJECT_TYPE+" = ?"+
+			" ORDER BY "+COL_CHANGES_CHANGE_NUM+" ASC LIMIT ?";
 
-	private static final String SQL_SELECT_ALL_GREATER_THAN_OR_EQUAL_TO_CHANGE_NUMBER = "SELECT * FROM "+TABLE_CHANGES+" WHERE "+COL_CHANGES_CHANGE_NUM+" >= ? ORDER BY "+COL_CHANGES_CHANGE_NUM+" ASC LIMIT ?";
+	private static final String SQL_SELECT_ALL_GREATER_THAN_OR_EQUAL_TO_CHANGE_NUMBER = 
+			"SELECT * FROM "+TABLE_CHANGES+" WHERE "+COL_CHANGES_CHANGE_NUM+" >= ? ORDER BY "+COL_CHANGES_CHANGE_NUM+" ASC LIMIT ?";
 
-	private static final String SQL_SELECT_MAX_CHANGE_NUMBER = "SELECT MAX("+COL_CHANGES_CHANGE_NUM+") FROM "+TABLE_CHANGES;
+	private static final String SQL_SELECT_MIN_CHANGE_NUMBER = 
+			"SELECT MIN("+COL_CHANGES_CHANGE_NUM+") FROM "+TABLE_CHANGES;
+	
+	private static final String SQL_SELECT_MAX_CHANGE_NUMBER = 
+			"SELECT MAX("+COL_CHANGES_CHANGE_NUM+") FROM "+TABLE_CHANGES;
+	
+	private static final String SQL_SELECT_COUNT_CHANGE_NUMBER = 
+			"SELECT COUNT("+COL_CHANGES_CHANGE_NUM+") FROM "+TABLE_CHANGES;
 
-	private static final String SQL_DELETE_BY_CHANGE_NUM = "DELETE FROM "+TABLE_CHANGES+" WHERE "+COL_CHANGES_CHANGE_NUM+" = ?";
+	private static final String SQL_DELETE_BY_CHANGE_NUM = 
+			"DELETE FROM "+TABLE_CHANGES+" WHERE "+COL_CHANGES_CHANGE_NUM+" = ?";
 
 	@Autowired
 	private DBOBasicDao basicDao;
@@ -124,8 +143,18 @@ public class DBOChangeDAOImpl implements DBOChangeDAO {
 	}
 
 	@Override
+	public long getMinimumChangeNumber() {
+		return simpleJdbcTemplate.queryForLong(SQL_SELECT_MIN_CHANGE_NUMBER);
+	}
+	
+	@Override
 	public long getCurrentChangeNumber() {
 		return simpleJdbcTemplate.queryForLong(SQL_SELECT_MAX_CHANGE_NUMBER);
+	}
+	
+	@Override
+	public long getCount() {
+		return simpleJdbcTemplate.queryForLong(SQL_SELECT_COUNT_CHANGE_NUMBER);
 	}
 
 	@Transactional(readOnly = false, propagation = Propagation.REQUIRED)
@@ -155,15 +184,10 @@ public class DBOChangeDAOImpl implements DBOChangeDAO {
 		simpleJdbcTemplate.update(SQL_INSERT_SENT_ON_DUPLICATE_UPDATE, changeNumber, null, null);
 	}
 
-
-	/**
-	 * List
-	 */
+	
 	@Override
 	public List<ChangeMessage> listUnsentMessages(long limit) {
 		List<DBOChange> dboList = simpleJdbcTemplate.query(SQL_SELECT_CHANGES_NOT_SENT, new DBOChange().getTableMapping(), limit);
 		return ChangeMessageUtils.createDTOList(dboList);
 	}
-	
-
 }

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAOImplAutowiredTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAOImplAutowiredTest.java
@@ -22,10 +22,10 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.message.ChangeMessage;
 import org.sagebionetworks.repo.model.message.ChangeMessageUtils;
 import org.sagebionetworks.repo.model.message.ChangeType;
-import org.sagebionetworks.repo.model.ObjectType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.test.context.ContextConfiguration;
@@ -55,7 +55,19 @@ public class DBOChangeDAOImplAutowiredTest {
 	@Test
 	public void testGetCurrentChangeNumberEmpty() {
 		long ccn = changeDAO.getCurrentChangeNumber();
-		assertEquals(0l, ccn);
+		assertEquals(0L, ccn);
+	}
+	
+	@Test
+	public void testGetMinimumChangeNumberEmpty() {
+		long mcn = changeDAO.getMinimumChangeNumber();
+		assertEquals(0L, mcn);
+	}
+	
+	@Test
+	public void testGetCountEmpty() {
+		long count = changeDAO.getCount();
+		assertEquals(0L, count);
 	}
 	
 	@Test
@@ -93,14 +105,16 @@ public class DBOChangeDAOImplAutowiredTest {
 		changeOne.setObjectEtag("myEtag");
 		changeOne.setChangeType(ChangeType.CREATE);
 		changeOne.setObjectType(ObjectType.ACTIVITY);
-		ChangeMessage clone = changeDAO.replaceChange(changeOne);
+		changeDAO.replaceChange(changeOne);
+		
 		// Now create a second change with the same id but different type.
 		ChangeMessage changeTwo = new ChangeMessage();
 		changeTwo.setObjectId(changeOne.getObjectId());
 		changeTwo.setObjectEtag("myEtag");
 		changeTwo.setChangeType(ChangeType.CREATE);
 		changeTwo.setObjectType(ObjectType.PRINCIPAL);
-		ChangeMessage clonetwo = changeDAO.replaceChange(changeTwo);
+		changeDAO.replaceChange(changeTwo);
+		
 		// Now we should see both changes listed
 		List<ChangeMessage> list = changeDAO.listChanges(0, ObjectType.ACTIVITY, 100);
 		assertNotNull(list);
@@ -123,7 +137,7 @@ public class DBOChangeDAOImplAutowiredTest {
 		change.setObjectEtag("myEtag");
 		change.setChangeType(ChangeType.CREATE);
 		change.setObjectType(ObjectType.ENTITY);
-		ChangeMessage clone = changeDAO.replaceChange(change);
+		changeDAO.replaceChange(change);
 	}
 	
 	@Test (expected=IllegalArgumentException.class)
@@ -133,8 +147,9 @@ public class DBOChangeDAOImplAutowiredTest {
 		change.setObjectEtag("myEtag");
 		change.setChangeType(null);
 		change.setObjectType(ObjectType.ENTITY);
-		ChangeMessage clone = changeDAO.replaceChange(change);
+		changeDAO.replaceChange(change);
 	}
+	
 	@Test (expected=IllegalArgumentException.class)
 	public void tesNullObjectTypeType(){
 		ChangeMessage change = new ChangeMessage();
@@ -142,7 +157,7 @@ public class DBOChangeDAOImplAutowiredTest {
 		change.setObjectEtag("myEtag");
 		change.setChangeType(ChangeType.CREATE);
 		change.setObjectType(null);
-		ChangeMessage clone = changeDAO.replaceChange(change);
+		changeDAO.replaceChange(change);
 	}
 	
 	/**
@@ -277,8 +292,14 @@ public class DBOChangeDAOImplAutowiredTest {
 		
 		// Check the change numbers
 		long endChangeNumber = changeDAO.getCurrentChangeNumber();
-		assertEquals(startChangeNumber + numChangesInBatch , endChangeNumber);
-
+		assertEquals(startChangeNumber + numChangesInBatch, endChangeNumber);
+		
+		// The element inserted by startChangeNumber() will be replaced by an element created in createList(5, ...)
+		long minChangeNumber = changeDAO.getMinimumChangeNumber();
+		assertEquals(startChangeNumber + 1, minChangeNumber);
+		
+		long countChangeNumber = changeDAO.getCount();
+		assertEquals(numChangesInBatch, countChangeNumber);
 	}
 	
 	@Test

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAOImplAutowiredTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAOImplAutowiredTest.java
@@ -372,6 +372,32 @@ public class DBOChangeDAOImplAutowiredTest {
 		assertEquals(0, unSent.size());
 	}
 	
+	@Test
+	public void testListUnsentRange() {
+		List<ChangeMessage> batch = createList(10, ObjectType.ENTITY);
+		batch = changeDAO.replaceChange(batch);
+		
+		long min = changeDAO.getMinimumChangeNumber();
+		long max = changeDAO.getCurrentChangeNumber();
+		
+		// Get everything
+		List<ChangeMessage> unSent = changeDAO.listUnsentMessages(min, max); 
+		assertEquals(batch, unSent);
+		
+		// Shrink the range and check each iteration for correctness
+		for (int i = 0; i < batch.size(); i++) {
+			if (i % 2 == 0) {
+				ChangeMessage removed = batch.remove(0);
+				min = removed.getChangeNumber() + 1;
+			} else {
+				ChangeMessage removed = batch.remove(batch.size() - 1);
+				max = removed.getChangeNumber() - 1;
+			}
+			unSent = changeDAO.listUnsentMessages(min, max); 
+			assertEquals(batch, unSent);
+		}
+	}
+	
 	/**
 	 * Will add a row to start the a test.
 	 * @return

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAOImplAutowiredTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAOImplAutowiredTest.java
@@ -374,8 +374,12 @@ public class DBOChangeDAOImplAutowiredTest {
 	
 	@Test
 	public void testListUnsentRange() {
-		List<ChangeMessage> batch = createList(10, ObjectType.ENTITY);
+		// Create a set of changes with change numbers like:
+		// 0 _ 2 3 _ 5 6
+		List<ChangeMessage> batch = createList(5, ObjectType.ENTITY);
 		batch = changeDAO.replaceChange(batch);
+		batch.add(changeDAO.replaceChange(batch.remove(1)));
+		batch.add(changeDAO.replaceChange(batch.remove(3)));
 		
 		long min = changeDAO.getMinimumChangeNumber();
 		long max = changeDAO.getCurrentChangeNumber();

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAOImplExperiment.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOChangeDAOImplExperiment.java
@@ -1,0 +1,236 @@
+package org.sagebionetworks.repo.model.dbo.dao;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.sagebionetworks.repo.model.ObjectType;
+import org.sagebionetworks.repo.model.dbo.TableMapping;
+import org.sagebionetworks.repo.model.dbo.persistence.DBOChange;
+import org.sagebionetworks.repo.model.message.ChangeMessage;
+import org.sagebionetworks.repo.model.message.ChangeMessageUtils;
+import org.sagebionetworks.repo.model.message.ChangeType;
+import org.sagebionetworks.repo.model.query.jdo.SqlConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcTemplate;
+import org.springframework.test.annotation.Repeat;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.sun.tools.javac.util.Pair;
+
+/**
+ * Note: this "test" is used to gather timing profiles.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath:jdomodels-test-context.xml" })
+public class DBOChangeDAOImplExperiment {
+	
+	@Autowired
+	private DBOChangeDAO changeDAO;
+	
+	@Autowired
+	private SimpleJdbcTemplate simpleJdbcTemplate;
+	private static final String SELECT_CHANGE_NUM_IN_RANGE_FROM_CHANGES = 
+			"SELECT "+SqlConstants.COL_CHANGES_CHANGE_NUM+" FROM "+SqlConstants.TABLE_CHANGES+
+			" WHERE "+SqlConstants.COL_CHANGES_CHANGE_NUM+" >= ?"+
+			" AND "+SqlConstants.COL_CHANGES_CHANGE_NUM+" <= ?";
+	
+	private static final String SELECT_CHANGE_NUM_IN_RANGE_FROM_SENT = 
+			"SELECT "+SqlConstants.COL_SENT_MESSAGES_CHANGE_NUM+" FROM "+SqlConstants.TABLE_SENT_MESSAGES+
+			" WHERE "+SqlConstants.COL_SENT_MESSAGES_CHANGE_NUM+" >= ?"+
+			" AND "+SqlConstants.COL_SENT_MESSAGES_CHANGE_NUM+" <= ?";
+	
+	private static final String SELECT_CHANGES_BY_CHANGE_NUM = 
+			"SELECT * FROM "+SqlConstants.TABLE_SENT_MESSAGES+
+			" WHERE "+SqlConstants.COL_CHANGES_CHANGE_NUM+" IN (?)";
+	
+	private TableMapping<DBOChange> rowMapper = new DBOChange().getTableMapping();
+	
+	private static final long UNSENT_MESSAGE_QUEUER_TEST_SEED = 5330L;
+	private static final long APPROX_RANGE_SIZE = 10000L;
+	private static Random random;
+
+	@Before
+	public void initialize() {
+		random = new Random(UNSENT_MESSAGE_QUEUER_TEST_SEED);
+	}
+	
+	@Ignore
+	@Test
+	public void testCleanup() {
+		// Delete all the changes
+		changeDAO.deleteAllChanges();
+	}
+	
+	@Ignore
+	@Test
+	public void testSetupChanges() {
+		final long start = System.currentTimeMillis();
+		
+		// Insert 1 million entries, 10000 at a time so that the transaction doesn't get too big
+		for (int i = 0; i < 100; i++) {
+			List<ChangeMessage> batch = createList(10000, ObjectType.ENTITY, 0, 2000000);
+			changeDAO.replaceChange(batch);
+			System.out.print(".");
+		}
+		System.out.println();
+		System.out.println("Time taken to insert all messages:");
+		System.out.println(System.currentTimeMillis() - start);
+	}
+	
+	@Ignore
+	@Test
+	public void testSetupSent() {
+		final long start = System.currentTimeMillis();
+		
+		// Blindly fetch all the changes
+		List<ChangeMessage> messages = changeDAO.listUnsentMessages(1000000);
+		
+		final long doneFetch = System.currentTimeMillis();
+		System.out.println("Time taken to fetch all messages:");
+		System.out.println(doneFetch - start);
+		
+		// Insert about 90% of the items into the sent table
+		Collections.shuffle(messages, random);
+		for (int i = 0; i < messages.size() * 0.9; i++) {
+			changeDAO.registerMessageSent(messages.get(i).getChangeNumber());
+			if (i % 1000 == 0) {
+				System.out.println(i);
+			}
+		}
+		System.out.println("Time taken to insert 90% of sent messages:");
+		System.out.println(System.currentTimeMillis() - doneFetch);
+	}
+	
+	@Ignore
+	@Test
+	@Repeat(10)
+	public void testTimeFetchAllAtOnce() {
+		final long start = System.currentTimeMillis();
+		
+		// Blindly fetch all the changes
+		changeDAO.listUnsentMessages(1000000);
+		
+		System.out.println("Time taken to fetch all unsent messages:");
+		System.out.println(System.currentTimeMillis() - start);
+	}
+
+	@Ignore
+	@Test
+	@Repeat(10)
+	public void testTimeFetchAllOverRange() {
+		long totalTime = 0L;
+		List<Pair<Long, Long>> ranges = getRanges();
+		
+		for (int i = 0; i < ranges.size(); i++) {
+			final long start = System.currentTimeMillis();
+			
+			changeDAO.listUnsentMessages(ranges.get(i).fst, ranges.get(i).snd);
+			
+			final long fetchTime = System.currentTimeMillis() - start;
+			totalTime += fetchTime;
+			// System.out.println(fetchTime);
+			
+		}
+		
+		System.out.println("Time taken to fetch all unsent messages via ranges:");
+		System.out.println(totalTime);
+	}
+
+	@Ignore
+	@Test
+	@Repeat(10)
+	public void testTimeFetchAllOverRangeInMemory() {
+		long totalTime = 0L;
+		List<Pair<Long, Long>> ranges = getRanges();
+		
+		for (int i = 0; i < ranges.size(); i++) {
+			final long start = System.currentTimeMillis();
+			final Set<Long> changes = new HashSet<Long>((int) APPROX_RANGE_SIZE);
+			
+			// Fetch the changes
+			simpleJdbcTemplate.query(SELECT_CHANGE_NUM_IN_RANGE_FROM_CHANGES, new RowMapper<Long>() {
+				@Override
+				public Long mapRow(ResultSet rs, int rowNum)
+						throws SQLException {
+					Long value = rs.getLong(SqlConstants.COL_CHANGES_CHANGE_NUM);
+					changes.add(value);
+					return value;
+				}
+				
+			}, ranges.get(i).fst, ranges.get(i).snd);
+			
+			// Remove the sent messages
+			simpleJdbcTemplate.query(SELECT_CHANGE_NUM_IN_RANGE_FROM_SENT, new RowMapper<Long>() {
+				@Override
+				public Long mapRow(ResultSet rs, int rowNum)
+						throws SQLException {
+					Long value = rs.getLong(SqlConstants.COL_SENT_MESSAGES_CHANGE_NUM);
+					changes.remove(value);
+					return value;
+				}
+				
+			}, ranges.get(i).fst, ranges.get(i).snd);
+			
+			// Fetch the changes and convert them to DTOs
+			List<DBOChange> dboList = simpleJdbcTemplate.query(SELECT_CHANGES_BY_CHANGE_NUM, rowMapper, changes);
+			ChangeMessageUtils.createDTOList(dboList);
+			
+			final long fetchTime = System.currentTimeMillis() - start;
+			totalTime += fetchTime;
+			// System.out.println(fetchTime);
+			
+		}
+		
+		System.out.println("Time taken to fetch all unsent messages via ranges in memory:");
+		System.out.println(totalTime);
+	}
+
+	private List<Pair<Long, Long>> getRanges() {
+		final long min = changeDAO.getMinimumChangeNumber();
+		final long max = changeDAO.getCurrentChangeNumber();
+		final long count = changeDAO.getCount();
+		final long rangeSize = APPROX_RANGE_SIZE;
+		final long chunks = 1 + count / rangeSize;
+		final long chunkSize = 1 + (max - min) / chunks;
+		
+		// Copied and modified from UnsentMessageQueuer
+		List<Pair<Long, Long>> ranges = new ArrayList<Pair<Long, Long>>();
+		for (int i = 0; i < chunks; i++) {
+			ranges.add(new Pair<Long, Long>(min + i * chunkSize, min + (i + 1) * chunkSize));
+		}
+		if (min + chunks * chunkSize < max) {
+			ranges.add(new Pair<Long, Long>(min + chunks * chunkSize, max));
+		}
+		return ranges;
+	}
+
+	private List<ChangeMessage> createList(int numChangesInBatch, ObjectType type, long lowerBound, long upperBound) {
+		List<ChangeMessage> batch = new ArrayList<ChangeMessage>(numChangesInBatch);
+		for(int i = 0; i < numChangesInBatch; i++){
+			ChangeMessage change = new ChangeMessage();
+			long changeNum = lowerBound + (random.nextLong() % (upperBound - lowerBound + 1));
+			if(ObjectType.ENTITY == type){
+				change.setObjectId("syn" + changeNum);
+			}else{
+				change.setObjectId("" + changeNum);
+			}
+			change.setObjectEtag("etag" + changeNum);
+			change.setChangeType(ChangeType.UPDATE);
+			change.setObjectType(type);
+			batch.add(change);
+		}
+		return batch;
+	}
+}

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/message/StubDBOChangeDAO.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/message/StubDBOChangeDAO.java
@@ -69,7 +69,7 @@ public class StubDBOChangeDAO implements DBOChangeDAO {
 
 	@Override
 	public List<ChangeMessage> listChanges(long greaterOrEqualChangeNumber,	ObjectType type, long limit) {
-		return new LinkedList(map.values());
+		return new LinkedList<ChangeMessage>(map.values());
 	}
 
 	@Override
@@ -82,6 +82,18 @@ public class StubDBOChangeDAO implements DBOChangeDAO {
 	public List<ChangeMessage> listUnsentMessages(long limit) {
 		// TODO Auto-generated method stub
 		return null;
+	}
+
+	@Override
+	public long getMinimumChangeNumber() {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+	@Override
+	public long getCount() {
+		// TODO Auto-generated method stub
+		return 0;
 	}
 
 }

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/message/StubDBOChangeDAO.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/message/StubDBOChangeDAO.java
@@ -96,4 +96,11 @@ public class StubDBOChangeDAO implements DBOChangeDAO {
 		return 0;
 	}
 
+	@Override
+	public List<ChangeMessage> listUnsentMessages(long lowerBound,
+			long upperBound) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/message/UnsentMessageRange.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/message/UnsentMessageRange.json
@@ -1,0 +1,14 @@
+{
+	"title": "UnsentMessageRange",
+	"description": "JSON schema for a range of change message numbers to recheck",
+	"properties": {
+		"lowerBound": {
+			"type": "integer",
+			"description":"The lower bound (inclusive) of the range of application change numbers to check."
+		},
+		"upperBound": {
+			"type": "integer",
+			"description":"The upper bound (inclusive) of the range of application change numbers to check."
+		}
+	}
+}

--- a/lib/lib-worker/src/main/java/org/sagebionetworks/asynchronous/workers/sqs/MessageQueueSimpleImpl.java
+++ b/lib/lib-worker/src/main/java/org/sagebionetworks/asynchronous/workers/sqs/MessageQueueSimpleImpl.java
@@ -1,0 +1,46 @@
+package org.sagebionetworks.asynchronous.workers.sqs;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.CreateQueueResult;
+
+/**
+ * The stripped-bare implementation of a message queue.
+ */
+public class MessageQueueSimpleImpl implements MessageQueue {
+
+	@Autowired
+	private AmazonSQSClient awsSQSClient;
+
+	private final String queueName;
+	private String queueUrl;
+
+	public MessageQueueSimpleImpl(final String queueName) {
+		if (queueName == null) {
+			throw new NullPointerException();
+		}
+		this.queueName = queueName;
+	}
+
+	@PostConstruct
+	private void init() {
+		// Create the queue if it does not already exist
+		CreateQueueRequest cqRequest = new CreateQueueRequest(queueName);
+		CreateQueueResult cqResult = this.awsSQSClient.createQueue(cqRequest);
+		this.queueUrl = cqResult.getQueueUrl();
+	}
+
+	@Override
+	public String getQueueUrl() {
+		return this.queueUrl;
+	}
+
+	@Override
+	public String getQueueName(){
+		return this.queueName;
+	}
+}

--- a/lib/lib-worker/src/main/java/org/sagebionetworks/asynchronous/workers/sqs/MessageReceiverImpl.java
+++ b/lib/lib-worker/src/main/java/org/sagebionetworks/asynchronous/workers/sqs/MessageReceiverImpl.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.asynchronous.workers.sqs;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -192,13 +193,30 @@ public class MessageReceiverImpl implements MessageReceiver {
 		verifyConfig();
 		// When the timer is fired we receive messages from AWS SQS.
 		// Note: The max number of messages is the maxNumberOfWorkerThreads*maxMessagePerWorker as each worker is expected to handle a batch of messages.
+		// Note: Messages must be requested in batches of 10 or less (otherwise SQS will complain)
 		int maxMessages = maxNumberOfWorkerThreads*maxMessagePerWorker;
-		ReceiveMessageResult result = awsSQSClient.receiveMessage(new ReceiveMessageRequest(messageQueue.getQueueUrl()).withMaxNumberOfMessages(maxMessages).withVisibilityTimeout(visibilityTimeoutSec));
-		if(result.getMessages().size() < 1) return 0;
+		List<Message> toBeProcessed = new ArrayList<Message>();
+		for (int i = 0; i < maxMessages; i += 10) {
+			ReceiveMessageRequest rmRequest = new ReceiveMessageRequest(messageQueue.getQueueUrl()).withVisibilityTimeout(visibilityTimeoutSec);
+			if (maxMessages - i > 10) {
+				rmRequest.setMaxNumberOfMessages(10);
+			} else {
+				rmRequest.setMaxNumberOfMessages(maxMessages % 11);
+			}
+			ReceiveMessageResult result = awsSQSClient.receiveMessage(rmRequest);
+			if (result.getMessages().size() <= 0) {
+				break;
+			}
+			toBeProcessed.addAll(result.getMessages());
+		}
+		if (toBeProcessed.size() < 1) {
+			return 0;
+		}
+		
 		// Process all of the messages.
 		List<Future<List<Message>>> currentWorkers = new LinkedList<Future<List<Message>>>();
 		List<Message> messageBatch = new LinkedList<Message>();
-		for(Message message: result.getMessages()){
+		for (Message message: toBeProcessed) {
 			// Add this message to a batch
 			messageBatch.add(message);
 			if(messageBatch.size() >= maxMessagePerWorker){
@@ -263,7 +281,7 @@ public class MessageReceiverImpl implements MessageReceiver {
 			Thread.yield();
 		}
 		// Return the number of messages that were on the queue.
-		return result.getMessages().size();
+		return toBeProcessed.size();
 	}
 
 

--- a/lib/lib-worker/src/main/java/org/sagebionetworks/asynchronous/workers/sqs/MessageUtils.java
+++ b/lib/lib-worker/src/main/java/org/sagebionetworks/asynchronous/workers/sqs/MessageUtils.java
@@ -4,6 +4,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.sagebionetworks.repo.model.message.ChangeMessage;
 import org.sagebionetworks.repo.model.message.ChangeType;
+import org.sagebionetworks.repo.model.message.UnsentMessageRange;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.sagebionetworks.schema.adapter.org.json.EntityFactory;
@@ -39,6 +40,22 @@ public class MessageUtils {
 			}else{
 				throw new IllegalArgumentException("Unknown message type: "+message.getBody());
 			}
+		} catch (JSONException e) {
+			throw new RuntimeException(e);
+		} catch (JSONObjectAdapterException e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	/**
+	 * Extracts a UnsentMessageRange from an Amazon Message
+	 */
+	public static UnsentMessageRange extractUnsentMessageBody(Message message) {
+		if(message == null) throw new IllegalArgumentException("Message cannot be null");
+		try {
+			JSONObject object = new JSONObject(message.getBody());
+			JSONObjectAdapterImpl adapter = new JSONObjectAdapterImpl(object);
+			return new UnsentMessageRange(adapter);
 		} catch (JSONException e) {
 			throw new RuntimeException(e);
 		} catch (JSONObjectAdapterException e) {

--- a/lib/lib-worker/src/test/java/org/sagebionetworks/asynchronous/workers/sqs/MessageReceiverImplTest.java
+++ b/lib/lib-worker/src/test/java/org/sagebionetworks/asynchronous/workers/sqs/MessageReceiverImplTest.java
@@ -1,14 +1,20 @@
 package org.sagebionetworks.asynchronous.workers.sqs;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 import java.util.Stack;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import com.amazonaws.services.sqs.AmazonSQSClient;
 import com.amazonaws.services.sqs.model.DeleteMessageBatchRequest;
@@ -34,7 +40,7 @@ public class MessageReceiverImplTest {
 	MessageWorkerFactory stubFactory;
 	AmazonSQSClient mockSQSClient;
 	List<Message> messageList;
-	ReceiveMessageResult results;
+	Queue<Message> messageQueue;
 	
 	@Before
 	public void before(){
@@ -52,11 +58,21 @@ public class MessageReceiverImplTest {
 			messageList.add(new Message().withMessageId("id"+i).withReceiptHandle("handle1"+i));
 		}
 		// Setup the messages
-		results = new ReceiveMessageResult();
-		for(Message message: messageList){
-			results.withMessages(message);
-		}
-		when(mockSQSClient.receiveMessage(new ReceiveMessageRequest(queueUrl).withMaxNumberOfMessages(maxMessages).withVisibilityTimeout(visibilityTimeout))).thenReturn(results);
+		messageQueue = new LinkedList<Message>(messageList);
+		when(mockSQSClient.receiveMessage(any(ReceiveMessageRequest.class))).thenAnswer(new Answer<ReceiveMessageResult>() {
+
+			@Override
+			public ReceiveMessageResult answer(InvocationOnMock invocation)
+					throws Throwable {
+				ReceiveMessageRequest rmRequest = (ReceiveMessageRequest) invocation.getArguments()[0];
+				ReceiveMessageResult results = new ReceiveMessageResult();
+				for (int i = 0; i < rmRequest.getMaxNumberOfMessages() && !messageQueue.isEmpty(); i++) {
+					results.withMessages(messageQueue.poll());
+				}
+				return results;
+			}
+			
+		});
 
 	}
 	

--- a/lib/stackConfiguration/src/main/java/org/sagebionetworks/StackConfiguration.java
+++ b/lib/stackConfiguration/src/main/java/org/sagebionetworks/StackConfiguration.java
@@ -1020,6 +1020,24 @@ public class StackConfiguration {
 						.getProperty("org.sagebionetworks.semaphore.gated.max.runners.crowd.synchronize"));
 	}
 
+	
+	/**
+	 * The maximum number of workers in the cluster that will push UnsentMessageRanges to SQS
+	 */
+	public Integer getSemaphoreGatedMaxRunnersUnsentMessageQueuer() {
+		return Integer
+				.parseInt(configuration
+						.getProperty("org.sagebionetworks.semaphore.gated.max.runners.unsent.message.queuer"));
+	}
+	
+	/**
+	 * The maximum number of workers in the cluster that will pop UnsentMessageRanges from SQS
+	 */
+	public Integer getSemaphoreGatedMaxRunnersUnsentMessagePoppers() {
+		return Integer
+				.parseInt(configuration
+						.getProperty("org.sagebionetworks.semaphore.gated.max.runners.unsent.message.poppers"));
+	}
 	/**
 	 * The maximum number of workers in the cluster that will process
 	 * Annotations

--- a/lib/stackConfiguration/src/main/java/org/sagebionetworks/StackConfiguration.java
+++ b/lib/stackConfiguration/src/main/java/org/sagebionetworks/StackConfiguration.java
@@ -780,6 +780,15 @@ public class StackConfiguration {
 				StackConfiguration.getStack(),
 				StackConfiguration.getStackInstance());
 	}
+	
+	/**
+	 * @return The name of the AWS SQS where ranges of change messages are pushed. 
+	 */
+	public static String getUnsentMessagesQueueName() {
+		return String.format(StackConstants.UNSENT_MESSAGES_QUEUE_NAME_TEMPLATE,
+				StackConfiguration.getStack(),
+				StackConfiguration.getStackInstance());
+	}
 
 	/**
 	 * This is the size of a single file transfer memory block used as a buffer.

--- a/lib/stackConfiguration/src/main/java/org/sagebionetworks/StackConfiguration.java
+++ b/lib/stackConfiguration/src/main/java/org/sagebionetworks/StackConfiguration.java
@@ -784,7 +784,7 @@ public class StackConfiguration {
 	/**
 	 * @return The name of the AWS SQS where ranges of change messages are pushed. 
 	 */
-	public static String getUnsentMessagesQueueName() {
+	public String getUnsentMessagesQueueName() {
 		return String.format(StackConstants.UNSENT_MESSAGES_QUEUE_NAME_TEMPLATE,
 				StackConfiguration.getStack(),
 				StackConfiguration.getStackInstance());

--- a/lib/stackConfiguration/src/main/java/org/sagebionetworks/StackConstants.java
+++ b/lib/stackConfiguration/src/main/java/org/sagebionetworks/StackConstants.java
@@ -63,6 +63,11 @@ public class StackConstants {
 	public static final String ANNOTATIONS_QUEUE_NAME_TEMPLATE = "%1$s-%2$s-annotations-update-queue";
 	
 	/**
+	 * Template used for the name of the AWS SQS where ranges of change messages are pushed.
+	 */
+	public static final String UNSENT_MESSAGES_QUEUE_NAME_TEMPLATE = "%1$s-%2$s-unsent-messages-update-queue";
+	
+	/**
 	 * The bucket containing all access record data.
 	 */
 	public static final String ACCESS_RECORD_BUCKET = "%1$s.access.record.sagebase.org";

--- a/lib/stackConfiguration/src/main/resources/stack-configuration.spb.xml
+++ b/lib/stackConfiguration/src/main/resources/stack-configuration.spb.xml
@@ -48,6 +48,7 @@
 	<bean id="stackConfiguration.rdsUpdateQueueName" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />
 	<bean id="stackConfiguration.fileUpdateQueueName" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />
 	<bean id="stackConfiguration.annotationsUpdateQueueName" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />
+	<bean id="stackConfiguration.unsentMessagesQueueName" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />
 	
 	<bean id="stackConfiguration.maxFileTransferMemoryPoolBytes" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />
 	<bean id="stackConfiguration.maxFilePreviewMemoryPoolBytes" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />
@@ -67,6 +68,8 @@
 	<bean id="stackConfiguration.semaphoreGatedMaxRunnersDynamoSynchronize" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />	
 	<bean id="stackConfiguration.semaphoreGatedMaxRunnersAnnotations" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />
 	<bean id="stackConfiguration.semaphoreGatedMaxRunnersCrowdGroupSynchronize" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />		
+	<bean id="stackConfiguration.semaphoreGatedMaxRunnersUnsentMessageQueuer" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />	
+	<bean id="stackConfiguration.semaphoreGatedMaxRunnersUnsentMessagePoppers" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />		
 	
 	<!-- Configuration for multi-part upload daemons. -->
 	<bean id="stackConfiguration.fileMultipartUploadDaemonTimeoutMS" class="org.springframework.beans.factory.config.PropertyPathFactoryBean" />	

--- a/lib/stackConfiguration/src/main/resources/stack.properties
+++ b/lib/stackConfiguration/src/main/resources/stack.properties
@@ -219,6 +219,10 @@ org.sagebionetworks.semaphore.gated.max.runners.dynamo.synchronize=1
 org.sagebionetworks.semaphore.gated.max.runners.annotations=2
 # The maximum number of workers in the cluster that will synchronize Crowd with RDS
 org.sagebionetworks.semaphore.gated.max.runners.crowd.synchronize=1
+# The maximum number of workers in the cluster that will push UnsentMessageRanges to SQS
+org.sagebionetworks.semaphore.gated.max.runners.unsent.message.queuer=1
+# The maximum number of workers in the cluster that will pop UnsentMessageRanges from SQS
+org.sagebionetworks.semaphore.gated.max.runners.unsent.message.poppers=2
 
 #The maximum amount of time the multipart upload daemons are allowed to take before timing out.
 org.sagebionetworks.repo.manager.file.multipart.upload.daemon.timeout.ms=60000

--- a/lib/stackConfiguration/src/main/resources/stack.properties
+++ b/lib/stackConfiguration/src/main/resources/stack.properties
@@ -222,7 +222,7 @@ org.sagebionetworks.semaphore.gated.max.runners.crowd.synchronize=1
 # The maximum number of workers in the cluster that will push UnsentMessageRanges to SQS
 org.sagebionetworks.semaphore.gated.max.runners.unsent.message.queuer=1
 # The maximum number of workers in the cluster that will pop UnsentMessageRanges from SQS
-org.sagebionetworks.semaphore.gated.max.runners.unsent.message.poppers=2
+org.sagebionetworks.semaphore.gated.max.runners.unsent.message.poppers=1
 
 #The maximum amount of time the multipart upload daemons are allowed to take before timing out.
 org.sagebionetworks.repo.manager.file.multipart.upload.daemon.timeout.ms=60000

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/message/RepositoryMessagePublisher.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/message/RepositoryMessagePublisher.java
@@ -38,9 +38,4 @@ public interface RepositoryMessagePublisher extends TransactionalMessengerObserv
 	 * Quartz will fire this method on a timer.  This is where we actually publish the data. 
 	 */
 	public void timerFired();
-
-	/**
-	 * Quartz will fire this method on a timer.
-	 */
-	public void timerFiredFindUnsentMessages();
 }

--- a/services/repository-managers/src/main/resources/aws-topic-publisher.spb.xml
+++ b/services/repository-managers/src/main/resources/aws-topic-publisher.spb.xml
@@ -38,12 +38,6 @@
 		</constructor-arg>
 		<property name="shouldMessagesBePublishedToTopic"
 			ref="stackConfiguration.shouldMessagesBePublishedToTopic"></property>
-		<property name="listUnsentMessagePageSize" value="25000" />
-		<!-- This will determine how long the worker can hold the semaphore lock 
-			while processing un-sent messages We want to give the worker plenty of time 
-			to do its job before attempting a forced lock release so this is currently 
-			set to 30 Minutes (1000*60*30). -->
-		<property name="lockTimeoutMS" value="1800000" />
 	</bean>
 
 	<!-- This is how messages get rebroadcast -->
@@ -62,21 +56,6 @@
 		</property>
 		<property name="startDelay" value="0" />
 		<property name="repeatInterval" value="1000" />
-	</bean>
-
-	<!-- This trigger is used to find any unsent messages. It is fired once 
-		every 10 seconds -->
-	<bean id="unsentMessagesTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerBean">
-		<property name="jobDetail">
-			<bean
-				class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
-				<property name="targetObject" ref="messagePublisher" />
-				<property name="targetMethod" value="timerFiredFindUnsentMessages" />
-				<property name="concurrent" value="false" />
-			</bean>
-		</property>
-		<property name="startDelay" value="10000" />
-		<property name="repeatInterval" value="10000" />
 	</bean>
 
 </beans>

--- a/services/repository-managers/src/main/resources/shared-scheduler-spb.xml
+++ b/services/repository-managers/src/main/resources/shared-scheduler-spb.xml
@@ -20,7 +20,6 @@
 		<property name="triggers">
 			<list>
 				<ref bean="messagePublisherTrigger" />
-				<ref bean="unsentMessagesTrigger" />
 				<ref bean="accessRecorderTrigger" />
 			</list>
 		</property>

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/message/RepositoryMessagePublisherImplAutowireTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/message/RepositoryMessagePublisherImplAutowireTest.java
@@ -39,8 +39,6 @@ import com.amazonaws.services.sns.model.PublishRequest;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:shared-scheduler-spb.xml" })
 public class RepositoryMessagePublisherImplAutowireTest {
-
-	public static long MAX_WAIT = 1000*15; // 15 seconds
 	
 	@Autowired
 	TransactionalMessenger transactionalMessanger;
@@ -147,32 +145,5 @@ public class RepositoryMessagePublisherImplAutowireTest {
 			verify(mockSNSClient, times(1)).publish(new PublishRequest(messagePublisher.getTopicArn(), messageBody));
 		}
 
-	}
-	
-	@Test
-	public void testUnsentMessages() throws InterruptedException{
-		// Create a change message.
-		ChangeMessage message = new ChangeMessage();
-		message.setChangeType(ChangeType.CREATE);
-		message.setObjectType(ObjectType.ENTITY);
-		message.setObjectId("1");
-		message.setObjectEtag("ABCDEFG");
-		message.setChangeNumber(1l);
-		message.setTimestamp(new Date());
-		// This will added the message to the change table, but will not sent it.
-		message = changeDao.replaceChange(message);
-		// List the unsent messages.
-		List<ChangeMessage> unsent = changeDao.listUnsentMessages(Long.MAX_VALUE);
-		assertEquals(1, unsent.size());
-		// Wait for message to be fired
-		long start = System.currentTimeMillis();
-		do{
-			System.out.println("Waiting for quartz timer to fire for RepositoryMessagePublisherImplAutowireTest.testUnsentMessages()...");
-			Thread.sleep(2000);
-			long elpase = System.currentTimeMillis()-start;
-			assertTrue("Timed out waiting for quartz timer to fire.",elpase < MAX_WAIT);
-			// Get the messages
-			unsent = changeDao.listUnsentMessages(Long.MAX_VALUE);
-		}while(unsent.size() > 0);
 	}
 }

--- a/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessagePopper.java
+++ b/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessagePopper.java
@@ -1,0 +1,70 @@
+package org.sagebionetworks.message.workers;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sagebionetworks.asynchronous.workers.sqs.MessageUtils;
+import org.sagebionetworks.repo.model.dbo.dao.DBOChangeDAO;
+import org.sagebionetworks.repo.model.message.ChangeMessage;
+import org.sagebionetworks.repo.model.message.UnsentMessageRange;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.sagebionetworks.schema.adapter.org.json.EntityFactory;
+
+import com.amazonaws.services.sns.AmazonSNSClient;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sqs.model.Message;
+
+/**
+ * Gets UnsentMessageRange messages from a queue and processes them
+ */
+public class UnsentMessagePopper implements Callable<List<Message>> {
+	
+	private Log log = LogFactory.getLog(UnsentMessagePopper.class);
+	
+	private AmazonSNSClient awsSNSClient;
+	private DBOChangeDAO changeDAO;
+	private String topicArn;
+	private List<Message> messages;
+	
+	public UnsentMessagePopper(AmazonSNSClient awsSNSClient, DBOChangeDAO changeDAO, String topicArn, List<Message> messages) {
+		this.awsSNSClient = awsSNSClient;
+		this.changeDAO = changeDAO;
+		this.topicArn = topicArn;
+		this.messages = messages;
+	}
+
+	@Override
+	public List<Message> call() throws Exception {
+		List<Message> processedMessages = new LinkedList<Message>();
+		for (Message message: messages) {
+			// Get all the unsent ChangeMessages in a range and publish them
+			UnsentMessageRange range = MessageUtils.extractUnsentMessageBody(message);
+			List<ChangeMessage> changes = changeDAO.listUnsentMessages(range.getLowerBound(), range.getUpperBound());
+			for (int i = 0; i < changes.size(); i++) {
+				publishMessage(changes.get(i));
+			}
+			
+			processedMessages.add(message);
+		}
+		return processedMessages;
+	}
+	
+	/**
+	 * Publish the ChangeMessage and record it as "sent"
+	 */
+	private void publishMessage(ChangeMessage message) {
+		try {
+			String json = EntityFactory.createJSONStringForEntity(message);
+			awsSNSClient.publish(new PublishRequest(this.topicArn, json));
+			changeDAO.registerMessageSent(message.getChangeNumber());
+		} catch (JSONObjectAdapterException e) {
+			// This should not occur.
+			// If it does we want to log it but continue to send messages
+			//   as this is called from a timer and not a web-service.
+			log.error("Failed to parse ChangeMessage:", e);
+		}
+	}
+}

--- a/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessagePopperFactory.java
+++ b/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessagePopperFactory.java
@@ -1,0 +1,43 @@
+package org.sagebionetworks.message.workers;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.sagebionetworks.asynchronous.workers.sqs.MessageWorkerFactory;
+import org.sagebionetworks.repo.model.dbo.dao.DBOChangeDAO;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.amazonaws.services.sns.AmazonSNSClient;
+import com.amazonaws.services.sns.model.CreateTopicRequest;
+import com.amazonaws.services.sns.model.CreateTopicResult;
+import com.amazonaws.services.sqs.model.Message;
+
+public class UnsentMessagePopperFactory implements MessageWorkerFactory {
+
+	@Autowired
+	private AmazonSNSClient awsSNSClient;
+	private String topicName;
+	private String topicArn;
+	
+	@Autowired
+	private DBOChangeDAO changeDAO;
+	
+	public void setTopicName(String topicName) {
+		this.topicName = topicName;
+	}
+
+	/**
+	 * This is called by Spring when this bean is created
+	 */
+	public void initialize() {
+		// Make sure the topic exists, if not create it
+		CreateTopicResult result = awsSNSClient.createTopic(new CreateTopicRequest(topicName));
+		topicArn = result.getTopicArn();
+	}
+	
+	@Override
+	public Callable<List<Message>> createWorker(List<Message> messages) {
+		return new UnsentMessagePopper(awsSNSClient, changeDAO, topicArn, messages);
+	}
+
+}

--- a/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessagePopperFactory.java
+++ b/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessagePopperFactory.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.sagebionetworks.asynchronous.workers.sqs.MessageWorkerFactory;
+import org.sagebionetworks.cloudwatch.Consumer;
 import org.sagebionetworks.repo.model.dbo.dao.DBOChangeDAO;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -18,6 +19,9 @@ public class UnsentMessagePopperFactory implements MessageWorkerFactory {
 	private AmazonSNSClient awsSNSClient;
 	private String topicName;
 	private String topicArn;
+	
+	@Autowired
+	private Consumer consumer;
 	
 	@Autowired
 	private DBOChangeDAO changeDAO;
@@ -37,7 +41,7 @@ public class UnsentMessagePopperFactory implements MessageWorkerFactory {
 	
 	@Override
 	public Callable<List<Message>> createWorker(List<Message> messages) {
-		return new UnsentMessagePopper(awsSNSClient, changeDAO, topicArn, messages);
+		return new UnsentMessagePopper(awsSNSClient, consumer, changeDAO, topicArn, messages);
 	}
 
 }

--- a/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessageQueuer.java
+++ b/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessageQueuer.java
@@ -1,0 +1,103 @@
+package org.sagebionetworks.message.workers;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.sagebionetworks.StackConfiguration;
+import org.sagebionetworks.repo.model.dbo.dao.DBOChangeDAO;
+import org.sagebionetworks.repo.model.message.UnsentMessageRange;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.sagebionetworks.schema.adapter.org.json.EntityFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.CreateQueueResult;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
+
+/**
+ * The basic implementation of the RepositoryUnsentMessageQueuer.  
+ * This implementation will push a sequential list of ranges to coordinate workers sending unsent messages.  
+ */
+public class UnsentMessageQueuer implements Runnable {
+
+	static private Log log = LogFactory.getLog(UnsentMessageQueuerTest.class);
+	
+	@Autowired
+	private AmazonSQSClient awsSQSClient;
+	
+	@Autowired
+	private DBOChangeDAO changeDAO;
+	
+	private Long approxRangeSize;
+	private String queueURL;
+	
+	public void setApproxRangeSize(long approxRangeSize) {
+		if (approxRangeSize <= 0) {
+			throw new IllegalArgumentException("Range size must be greater than zero");
+		}
+		this.approxRangeSize = approxRangeSize;
+	}
+	
+	public String getQueueURL() {
+		return queueURL;
+	}
+	
+	/**
+	 * Called by Spring after bean creation
+	 */
+	public void initialize() {
+		// Make or get the SQS URL
+		String queueName = StackConfiguration.getUnsentMessagesQueueName();
+		CreateQueueRequest cqRequest = new CreateQueueRequest(queueName);
+		CreateQueueResult cqResult = this.awsSQSClient.createQueue(cqRequest);
+		queueURL = cqResult.getQueueUrl();
+	}
+	
+	@Override
+	public void run() {
+		long count = changeDAO.getCount();
+		if (count <= 0) {
+			return;
+		}
+		
+		long min = changeDAO.getMinimumChangeNumber();
+		long max = changeDAO.getCurrentChangeNumber();
+		long chunks = 1 + count / approxRangeSize;
+		long chunkSize = 1 + (max - min) / chunks;
+		List<SendMessageBatchRequestEntry> batch = new LinkedList<SendMessageBatchRequestEntry>();
+		
+		for (int i = 0; i < chunks; i++) {
+			addMessageToBatch(batch, i, min + i * chunkSize, min + (i + 1) * chunkSize);
+		}
+		addMessageToBatch(batch, chunks, min + chunks * chunkSize, max);
+		
+		awsSQSClient.sendMessageBatch(new SendMessageBatchRequest(queueURL, batch));
+	}
+	
+	private void addMessageToBatch(List<SendMessageBatchRequestEntry> batch, long index, long lower, long upper) {
+		if (lower > upper) {
+			throw new IllegalArgumentException("Upper and lower bounds must have the correct numeric relationship (upper >= lower)");
+		}
+		UnsentMessageRange range = new UnsentMessageRange();
+		range.setLowerBound(lower);
+		range.setUpperBound(upper);
+		SendMessageBatchRequestEntry entry= createEntry(index, range);
+		if (entry != null) {
+			batch.add(entry);
+		}
+	}
+	
+	private SendMessageBatchRequestEntry createEntry(long index, UnsentMessageRange range) {
+		try {
+			String messageBody = EntityFactory.createJSONStringForEntity(range);
+			return new SendMessageBatchRequestEntry(""+index, messageBody);
+		} catch (JSONObjectAdapterException e) {
+			log.error("Failed to marshal message", e);
+			return null;
+		}
+	}
+}

--- a/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessageQueuer.java
+++ b/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessageQueuer.java
@@ -58,6 +58,7 @@ public class UnsentMessageQueuer implements Runnable {
 		
 		// Only run if the SQS is empty
 		ReceiveMessageRequest rmRequest = new ReceiveMessageRequest();
+		rmRequest.setQueueUrl(unsentMessageQueue.getQueueUrl());
 		rmRequest.setVisibilityTimeout(0);
 		rmRequest.setWaitTimeSeconds(0);
 		rmRequest.setMaxNumberOfMessages(1);

--- a/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessageQueuer.java
+++ b/services/workers/src/main/java/org/sagebionetworks/message/workers/UnsentMessageQueuer.java
@@ -21,7 +21,7 @@ import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
  */
 public class UnsentMessageQueuer implements Runnable {
 
-	static private Log log = LogFactory.getLog(UnsentMessageQueuerTest.class);
+	static private Log log = LogFactory.getLog(UnsentMessageQueuer.class);
 	
 	@Autowired
 	private AmazonSQSClient awsSQSClient;

--- a/services/workers/src/main/resources/main-scheduler-spb.xml
+++ b/services/workers/src/main/resources/main-scheduler-spb.xml
@@ -22,7 +22,8 @@
 	<import resource="classpath:trash-spb.xml" />
 	<import resource="classpath:log-collate-spb.xml" />
 	<import resource="classpath:worker-log-sweep-spb.xml" />
-	<import resource="classpath:message-sqs-sender.spb.xml" />
+	<import resource="classpath:message-queuer-sqs.xml" />
+	<import resource="classpath:message-popper-sqs-sns.xml" />
 
 	<bean id="mainScheduler"
 			class="org.springframework.scheduling.quartz.SchedulerFactoryBean"
@@ -41,6 +42,7 @@
 				<ref bean="trashWorkerTrigger" />
 				<ref bean="workersLogSweeperTrigger" />
 				<ref bean="unsentMessageQueuerTrigger" />
+				<ref bean="unsentMessagePopperTrigger" />
 			</list>
 		</property>
 	</bean>

--- a/services/workers/src/main/resources/main-scheduler-spb.xml
+++ b/services/workers/src/main/resources/main-scheduler-spb.xml
@@ -22,6 +22,7 @@
 	<import resource="classpath:trash-spb.xml" />
 	<import resource="classpath:log-collate-spb.xml" />
 	<import resource="classpath:worker-log-sweep-spb.xml" />
+	<import resource="classpath:message-sqs-sender.spb.xml" />
 
 	<bean id="mainScheduler"
 			class="org.springframework.scheduling.quartz.SchedulerFactoryBean"
@@ -39,6 +40,7 @@
 				<ref bean="logCollateWorkerTrigger" />
 				<ref bean="trashWorkerTrigger" />
 				<ref bean="workersLogSweeperTrigger" />
+				<ref bean="unsentMessageQueuerTrigger" />
 			</list>
 		</property>
 	</bean>

--- a/services/workers/src/main/resources/message-popper-sqs-sns.xml
+++ b/services/workers/src/main/resources/message-popper-sqs-sns.xml
@@ -14,24 +14,13 @@
 	<import resource="classpath:aws-spb.xml" />
 	<import resource="classpath:cloudwatch-spb.xml" />
 	<import resource="classpath:dao-beans.spb.xml" />
-
-	<bean id="awsSQSClient"
-			class="com.amazonaws.services.sqs.AmazonSQSClient"
-			scope="singleton"
-			depends-on="awsCredentials">
-		<constructor-arg ref="awsCredentials" />
-	</bean>
+	
+	<!-- Uses the awsSQSClient and unsentMessageQueue beans -->
+	<import resource="message-queuer-sqs.xml" />
 
 	<bean id="awsSNSClient" class="com.amazonaws.services.sns.AmazonSNSClient"
 		scope="singleton">
 		<constructor-arg ref="awsCredentials" />
-	</bean>
-
-	<!-- Sets up the message queue. -->
-	<bean id="unsentMessageQueue"
-			class="org.sagebionetworks.asynchronous.workers.sqs.MessageQueueSimpleImpl"
-			depends-on="stackConfiguration">
-		<constructor-arg index="0" ref="stackConfiguration.getUnsentMessagesQueueName" />
 	</bean>
 	
 	<bean id="unsentMessagePopperFactory"
@@ -46,7 +35,7 @@
 		scope="singleton">
 		<property name="messageQueue" ref="unsentMessageQueue" />
 		<property name="workerFactory" ref="unsentMessagePopperFactory" />
-		<property name="maxNumberOfWorkerThreads" ref="stackConfiguration.getSemaphoreGatedMaxRunnersUnsentMessagePoppers" />
+		<property name="maxNumberOfWorkerThreads" ref="stackConfiguration.semaphoreGatedMaxRunnersUnsentMessagePoppers" />
 		<property name="maxMessagePerWorker" value="5" />
 		<property name="visibilityTimeoutSec" value="60" />
 	</bean>
@@ -54,7 +43,7 @@
 	<bean id="unsentMessagePopperSemaphoreGatedRunner"
 		class="org.sagebionetworks.repo.model.dbo.dao.semaphore.SemaphoreGatedRunnerImpl" scope="singleton">
 		<property name="timeoutMS" ref="stackConfiguration.semaphoreGatedLockTimeoutMS" />
-		<property name="maxNumberRunners" ref="stackConfiguration.getSemaphoreGatedMaxRunnersUnsentMessagePoppers" />
+		<property name="maxNumberRunners" ref="stackConfiguration.semaphoreGatedMaxRunnersUnsentMessagePoppers" />
 		<property name="semaphoreKey" value="unsentMessagePopper" />		
 		<property name="runner" ref="unsentMessagePopper" />
 	</bean>

--- a/services/workers/src/main/resources/message-popper-sqs-sns.xml
+++ b/services/workers/src/main/resources/message-popper-sqs-sns.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aop="http://www.springframework.org/schema/aop"
+	xmlns:tx="http://www.springframework.org/schema/tx" xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+	<!-- Turn on Spring's auotproxy using AspectJ's @Aspect annotations. -->
+	<aop:aspectj-autoproxy />
+
+	<import resource="classpath:aws-spb.xml" />
+	<import resource="classpath:cloudwatch-spb.xml" />
+	<import resource="classpath:dao-beans.spb.xml" />
+
+	<bean id="awsSQSClient"
+			class="com.amazonaws.services.sqs.AmazonSQSClient"
+			scope="singleton"
+			depends-on="awsCredentials">
+		<constructor-arg ref="awsCredentials" />
+	</bean>
+
+	<bean id="awsSNSClient" class="com.amazonaws.services.sns.AmazonSNSClient"
+		scope="singleton">
+		<constructor-arg ref="awsCredentials" />
+	</bean>
+
+	<!-- Sets up the message queue. -->
+	<bean id="unsentMessageQueue"
+			class="org.sagebionetworks.asynchronous.workers.sqs.MessageQueueSimpleImpl"
+			depends-on="stackConfiguration">
+		<constructor-arg index="0" ref="stackConfiguration.getUnsentMessagesQueueName" />
+	</bean>
+	
+	<bean id="unsentMessagePopperFactory"
+		class="org.sagebionetworks.message.workers.UnsentMessagePopperFactory"
+		scope="singleton"
+		init-method="initialize">
+		<property name="topicName" ref="stackConfiguration.repositoryChangeTopicName" />
+	</bean>
+		
+	<bean id="unsentMessagePopper"
+		class="org.sagebionetworks.asynchronous.workers.sqs.MessageReceiverImpl"
+		scope="singleton">
+		<property name="messageQueue" ref="unsentMessageQueue" />
+		<property name="workerFactory" ref="unsentMessagePopperFactory" />
+		<property name="maxNumberOfWorkerThreads" ref="stackConfiguration.getSemaphoreGatedMaxRunnersUnsentMessagePoppers" />
+		<property name="maxMessagePerWorker" value="5" />
+		<property name="visibilityTimeoutSec" value="60" />
+	</bean>
+			
+	<bean id="unsentMessagePopperSemaphoreGatedRunner"
+		class="org.sagebionetworks.repo.model.dbo.dao.semaphore.SemaphoreGatedRunnerImpl" scope="singleton">
+		<property name="timeoutMS" ref="stackConfiguration.semaphoreGatedLockTimeoutMS" />
+		<property name="maxNumberRunners" ref="stackConfiguration.getSemaphoreGatedMaxRunnersUnsentMessagePoppers" />
+		<property name="semaphoreKey" value="unsentMessagePopper" />		
+		<property name="runner" ref="unsentMessagePopper" />
+	</bean>
+	
+	<bean id="unsentMessagePopperTrigger"
+			class="org.springframework.scheduling.quartz.SimpleTriggerBean"
+			scope="singleton">
+		<property name="jobDetail">
+			<bean class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+				<property name="targetObject" ref="unsentMessagePopperSemaphoreGatedRunner" />
+				<property name="targetMethod" value="attemptToRun" />
+				<property name="concurrent" value="false" />
+			</bean>
+		</property>
+		<property name="startDelay" value="123" />
+		<!-- 10 seconds -->
+		<property name="repeatInterval" value="10000" />
+	</bean>
+
+</beans>

--- a/services/workers/src/main/resources/message-popper-sqs-sns.xml
+++ b/services/workers/src/main/resources/message-popper-sqs-sns.xml
@@ -36,7 +36,7 @@
 		<property name="messageQueue" ref="unsentMessageQueue" />
 		<property name="workerFactory" ref="unsentMessagePopperFactory" />
 		<property name="maxNumberOfWorkerThreads" ref="stackConfiguration.semaphoreGatedMaxRunnersUnsentMessagePoppers" />
-		<property name="maxMessagePerWorker" value="5" />
+		<property name="maxMessagePerWorker" value="1" />
 		<property name="visibilityTimeoutSec" value="60" />
 	</bean>
 			
@@ -59,8 +59,8 @@
 			</bean>
 		</property>
 		<property name="startDelay" value="123" />
-		<!-- 10 seconds -->
-		<property name="repeatInterval" value="10000" />
+		<!-- 30 seconds -->
+		<property name="repeatInterval" value="30000" />
 	</bean>
 
 </beans>

--- a/services/workers/src/main/resources/message-queuer-sqs.xml
+++ b/services/workers/src/main/resources/message-queuer-sqs.xml
@@ -31,7 +31,7 @@
 	<bean id="unsentMessageQueuer"
 			class="org.sagebionetworks.message.workers.UnsentMessageQueuer"
 			scope="singleton">
-		<property name="approxRangeSize" value="1000" />
+		<property name="approxRangeSize" value="10000" />
 	</bean>
 			
 	<bean id="unsentMessageQueuerSemaphoreGatedRunner"
@@ -53,8 +53,8 @@
 			</bean>
 		</property>
 		<property name="startDelay" value="1337" />
-		<!-- 60 minutes -->
-		<property name="repeatInterval" value="3600000" />
+		<!-- 5 minutes -->
+		<property name="repeatInterval" value="300000" />
 	</bean>
 
 </beans>

--- a/services/workers/src/main/resources/message-queuer-sqs.xml
+++ b/services/workers/src/main/resources/message-queuer-sqs.xml
@@ -12,7 +12,6 @@
 	<aop:aspectj-autoproxy />
 
 	<import resource="classpath:aws-spb.xml" />
-	<import resource="classpath:cloudwatch-spb.xml" />
 	<import resource="classpath:dao-beans.spb.xml" />
 
 	<bean id="awsSQSClient"
@@ -21,18 +20,19 @@
 			depends-on="awsCredentials">
 		<constructor-arg ref="awsCredentials" />
 	</bean>
-	
+
 	<bean id="unsentMessageQueuer"
 			class="org.sagebionetworks.message.workers.UnsentMessageQueuer"
 			scope="singleton"
 			init-method="initialize">
 		<property name="approxRangeSize" value="1000" />
+		<property name="queueName" ref="stackConfiguration.getUnsentMessagesQueueName" />
 	</bean>
 			
 	<bean id="unsentMessageQueuerSemaphoreGatedRunner"
 		class="org.sagebionetworks.repo.model.dbo.dao.semaphore.SemaphoreGatedRunnerImpl" scope="singleton">
 		<property name="timeoutMS" ref="stackConfiguration.semaphoreGatedLockTimeoutMS" />
-		<property name="maxNumberRunners" ref="stackConfiguration.semaphoreGatedMaxRunnersCrowdGroupSynchronize" />
+		<property name="maxNumberRunners" ref="stackConfiguration.getSemaphoreGatedMaxRunnersUnsentMessageQueuer" />
 		<property name="semaphoreKey" value="unsentMessageQueuer" />		
 		<property name="runner" ref="unsentMessageQueuer" />
 	</bean>
@@ -48,8 +48,8 @@
 			</bean>
 		</property>
 		<property name="startDelay" value="1337" />
-		<!-- 30 minutes -->
-		<property name="repeatInterval" value="1800000" />
+		<!-- 60 minutes -->
+		<property name="repeatInterval" value="3600000" />
 	</bean>
 
 </beans>

--- a/services/workers/src/main/resources/message-queuer-sqs.xml
+++ b/services/workers/src/main/resources/message-queuer-sqs.xml
@@ -21,18 +21,23 @@
 		<constructor-arg ref="awsCredentials" />
 	</bean>
 
+	<!-- Sets up the message queue. -->
+	<bean id="unsentMessageQueue"
+			class="org.sagebionetworks.asynchronous.workers.sqs.MessageQueueSimpleImpl"
+			depends-on="stackConfiguration">
+		<constructor-arg index="0" ref="stackConfiguration.unsentMessagesQueueName" />
+	</bean>
+
 	<bean id="unsentMessageQueuer"
 			class="org.sagebionetworks.message.workers.UnsentMessageQueuer"
-			scope="singleton"
-			init-method="initialize">
+			scope="singleton">
 		<property name="approxRangeSize" value="1000" />
-		<property name="queueName" ref="stackConfiguration.getUnsentMessagesQueueName" />
 	</bean>
 			
 	<bean id="unsentMessageQueuerSemaphoreGatedRunner"
 		class="org.sagebionetworks.repo.model.dbo.dao.semaphore.SemaphoreGatedRunnerImpl" scope="singleton">
 		<property name="timeoutMS" ref="stackConfiguration.semaphoreGatedLockTimeoutMS" />
-		<property name="maxNumberRunners" ref="stackConfiguration.getSemaphoreGatedMaxRunnersUnsentMessageQueuer" />
+		<property name="maxNumberRunners" ref="stackConfiguration.semaphoreGatedMaxRunnersUnsentMessageQueuer" />
 		<property name="semaphoreKey" value="unsentMessageQueuer" />		
 		<property name="runner" ref="unsentMessageQueuer" />
 	</bean>

--- a/services/workers/src/main/resources/message-sqs-sender.spb.xml
+++ b/services/workers/src/main/resources/message-sqs-sender.spb.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:aop="http://www.springframework.org/schema/aop"
+	xmlns:tx="http://www.springframework.org/schema/tx" xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
+       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
+       http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+	<!-- Turn on Spring's auotproxy using AspectJ's @Aspect annotations. -->
+	<aop:aspectj-autoproxy />
+
+	<import resource="classpath:aws-spb.xml" />
+	<import resource="classpath:cloudwatch-spb.xml" />
+	<import resource="classpath:dao-beans.spb.xml" />
+
+	<bean id="awsSQSClient"
+			class="com.amazonaws.services.sqs.AmazonSQSClient"
+			scope="singleton"
+			depends-on="awsCredentials">
+		<constructor-arg ref="awsCredentials" />
+	</bean>
+	
+	<bean id="unsentMessageQueuer"
+			class="org.sagebionetworks.message.workers.UnsentMessageQueuer"
+			scope="singleton"
+			init-method="initialize">
+		<property name="approxRangeSize" value="1000" />
+	</bean>
+			
+	<bean id="unsentMessageQueuerSemaphoreGatedRunner"
+		class="org.sagebionetworks.repo.model.dbo.dao.semaphore.SemaphoreGatedRunnerImpl" scope="singleton">
+		<property name="timeoutMS" ref="stackConfiguration.semaphoreGatedLockTimeoutMS" />
+		<property name="maxNumberRunners" ref="stackConfiguration.semaphoreGatedMaxRunnersCrowdGroupSynchronize" />
+		<property name="semaphoreKey" value="unsentMessageQueuer" />		
+		<property name="runner" ref="unsentMessageQueuer" />
+	</bean>
+	
+	<bean id="unsentMessageQueuerTrigger"
+			class="org.springframework.scheduling.quartz.SimpleTriggerBean"
+			scope="singleton">
+		<property name="jobDetail">
+			<bean class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+				<property name="targetObject" ref="unsentMessageQueuerSemaphoreGatedRunner" />
+				<property name="targetMethod" value="attemptToRun" />
+				<property name="concurrent" value="false" />
+			</bean>
+		</property>
+		<property name="startDelay" value="1337" />
+		<!-- 30 minutes -->
+		<property name="repeatInterval" value="1800000" />
+	</bean>
+
+</beans>

--- a/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTest.java
@@ -13,6 +13,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.sagebionetworks.asynchronous.workers.sqs.MessageQueue;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.dbo.dao.DBOChangeDAO;
 import org.sagebionetworks.repo.model.message.ChangeMessage;
@@ -31,6 +32,9 @@ public class UnsentMessageQueuerTest {
 
 	@Autowired
 	private UnsentMessageQueuer unsentMessageQueuer;
+	
+	@Autowired
+	private MessageQueue unsentMessageQueue;
 	
 	@Autowired
 	private DBOChangeDAO changeDAO;
@@ -100,9 +104,9 @@ public class UnsentMessageQueuerTest {
 		// All these should fall within the range that is queued up
 		Set<Long> changeNumbers = unsentMessageQueuerTestHelper.convertBatchToRange(batch);
 		
-		unsentMessageQueuerTestHelper.emptyQueue(unsentMessageQueuer.getQueueURL());
+		unsentMessageQueuerTestHelper.emptyQueue(unsentMessageQueue.getQueueUrl());
 		unsentMessageQueuer.run();
-		List<UnsentMessageRange> ranges = unsentMessageQueuerTestHelper.emptyQueue(unsentMessageQueuer.getQueueURL());
+		List<UnsentMessageRange> ranges = unsentMessageQueuerTestHelper.emptyQueue(unsentMessageQueue.getQueueUrl());
 		
 		// Make sure the entire range of change numbers is accounted for
 		removeRangeFromSet(changeNumbers, ranges);

--- a/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTest.java
@@ -1,0 +1,122 @@
+package org.sagebionetworks.message.workers;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.sagebionetworks.repo.model.ObjectType;
+import org.sagebionetworks.repo.model.dbo.dao.DBOChangeDAO;
+import org.sagebionetworks.repo.model.message.ChangeMessage;
+import org.sagebionetworks.repo.model.message.UnsentMessageRange;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.sagebionetworks.schema.adapter.org.json.JSONObjectAdapterImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath:test-context.xml" })
+public class UnsentMessageQueuerTest {
+
+	@Autowired
+	private UnsentMessageQueuer unsentMessageQueuer;
+	
+	@Autowired
+	private DBOChangeDAO changeDAO;
+	
+	@Autowired
+	private UnsentMessageQueuerTestHelper unsentMessageQueuerTestHelper;
+	
+	@Before
+	public void setup() throws Exception {
+		unsentMessageQueuer.setApproxRangeSize(1000L);
+		changeDAO.deleteAllChanges();
+	}
+
+	@After
+	public void teardown() throws Exception {
+		changeDAO.deleteAllChanges();
+	}
+	
+	@Test
+	public void testRangeAllQueued() throws Exception {
+		// Create a ton of messages (~50% gaps)
+		List<ChangeMessage> batch = unsentMessageQueuerTestHelper.createList(10000, ObjectType.ENTITY, 1234, 5678);
+		batch = changeDAO.replaceChange(batch);
+		
+		// All these should fall within the range that is queued up
+		Set<Long> changeNumbers = unsentMessageQueuerTestHelper.convertBatchToRange(batch);
+		
+		// The range size must be adjustable, so make sure a variety of values work
+		long[] rangeSizes = new long[] { 17L, 83L, 299L, 1000L, 7331L };
+		for (int r = 0; r < rangeSizes.length; r++) {
+			// Get the elements that would be queued
+			unsentMessageQueuer.setApproxRangeSize(rangeSizes[r]);
+			List<SendMessageBatchRequestEntry> queued = unsentMessageQueuer.buildRangeBatch();
+			
+			// Convert the queued elements into ranges
+			List<UnsentMessageRange> ranges = new ArrayList<UnsentMessageRange>();
+			for (int i = 0; i < queued.size(); i++) {
+				ranges.add(extractMessageBody(queued.get(i)));
+			}
+			
+			// Make sure the entire range of change numbers is accounted for
+			Set<Long> outaRange = new HashSet<Long>(changeNumbers);
+			removeRangeFromSet(outaRange, ranges);
+			assertTrue("Not queued: " + outaRange, outaRange.isEmpty());
+		}
+	}
+	
+	private UnsentMessageRange extractMessageBody(SendMessageBatchRequestEntry message) {
+		JSONObject object;
+		try {
+			object = new JSONObject(message.getMessageBody());
+			JSONObjectAdapterImpl adapter = new JSONObjectAdapterImpl(object);
+			return new UnsentMessageRange(adapter);
+		} catch (JSONException e) {
+			throw new RuntimeException("Could not parse the message: " + message.getMessageBody());
+		} catch (JSONObjectAdapterException e) {
+			throw new RuntimeException("Could not convert the message: " + message.getMessageBody());
+		}
+	}
+	
+	@Test
+	public void testRoundtrip() throws Exception {
+		// Create a sizable number of messages (~10% gaps)
+		List<ChangeMessage> batch = unsentMessageQueuerTestHelper.createList(5000, ObjectType.ENTITY, 12345, 67890);
+		batch = changeDAO.replaceChange(batch);
+
+		// All these should fall within the range that is queued up
+		Set<Long> changeNumbers = unsentMessageQueuerTestHelper.convertBatchToRange(batch);
+		
+		unsentMessageQueuerTestHelper.emptyQueue(unsentMessageQueuer.getQueueURL());
+		unsentMessageQueuer.run();
+		List<UnsentMessageRange> ranges = unsentMessageQueuerTestHelper.emptyQueue(unsentMessageQueuer.getQueueURL());
+		
+		// Make sure the entire range of change numbers is accounted for
+		removeRangeFromSet(changeNumbers, ranges);
+		assertTrue("Not queued: " + changeNumbers, changeNumbers.isEmpty());
+	}
+	
+	private void removeRangeFromSet(Set<Long> outaRange, List<UnsentMessageRange> ranges) {
+		for (int i = 0; i < ranges.size(); i++) {
+			UnsentMessageRange range = ranges.get(i);
+			long lower = range.getLowerBound();
+			long upper = range.getUpperBound();
+			for (Long j = lower; j <= upper; j++) {
+				outaRange.remove(j);
+			}
+		}
+	}
+}

--- a/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTest.java
@@ -55,11 +55,12 @@ public class UnsentMessageQueuerTest {
 	@Autowired
 	private AmazonSQSClient awsSQSClient;
 	
-	private static final int NUM_MESSAGES_TO_CREATE = 1000;
+	private static final int NUM_MESSAGES_TO_CREATE = 100;
+	private static final long CONFIGURATION_RANGE_SIZE = 10000L;
 	
 	@Before
 	public void setup() throws Exception {
-		unsentMessageQueuer.setApproxRangeSize(1000L);
+		unsentMessageQueuer.setApproxRangeSize(CONFIGURATION_RANGE_SIZE);
 		changeDAO.deleteAllChanges();
 	}
 
@@ -69,6 +70,7 @@ public class UnsentMessageQueuerTest {
 		
 		// One test replaces the client with a mock
 		unsentMessageQueuer.setAwsSQSClient(awsSQSClient);
+		unsentMessageQueuer.setApproxRangeSize(CONFIGURATION_RANGE_SIZE);
 	}
 	
 	@Test
@@ -82,7 +84,7 @@ public class UnsentMessageQueuerTest {
 		Set<Long> changeNumbers = unsentMessageQueuerTestHelper.convertBatchToRange(batch);
 		
 		// The range size must be adjustable, so make sure a variety of values work
-		long[] rangeSizes = new long[] { 17L, 83L, 299L, 1000L, 7331L };
+		long[] rangeSizes = new long[] { 17L, 83L, 299L, 1000L, 7331L, CONFIGURATION_RANGE_SIZE };
 		for (int r = 0; r < rangeSizes.length; r++) {
 			// Get the elements that would be queued
 			unsentMessageQueuer.setApproxRangeSize(rangeSizes[r]);

--- a/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTestHelper.java
+++ b/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTestHelper.java
@@ -1,0 +1,116 @@
+package org.sagebionetworks.message.workers;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import org.sagebionetworks.asynchronous.workers.sqs.MessageUtils;
+import org.sagebionetworks.repo.model.ObjectType;
+import org.sagebionetworks.repo.model.dbo.dao.DBOChangeDAO;
+import org.sagebionetworks.repo.model.message.ChangeMessage;
+import org.sagebionetworks.repo.model.message.ChangeType;
+import org.sagebionetworks.repo.model.message.UnsentMessageRange;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequestEntry;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+
+public class UnsentMessageQueuerTestHelper {
+	
+	@Autowired
+	private AmazonSQSClient awsSQSClient;
+	
+	@Autowired
+	private DBOChangeDAO changeDAO;
+	
+	public static final long UNSENT_MESSAGE_QUEUER_TEST_SEED = 5330L;
+	private static Random random;
+	
+	public void initialize() {
+		random = new Random(UNSENT_MESSAGE_QUEUER_TEST_SEED);
+	}
+	
+	/**
+	 * Helper to empty a queue of UnsentMessageRange objects
+	 */
+	public List<UnsentMessageRange> emptyQueue(String queueURL) {
+		// Fetch as many messages as possible and don't wait
+		ReceiveMessageRequest rmRequest = new ReceiveMessageRequest(queueURL);
+		rmRequest.setWaitTimeSeconds(0);
+		rmRequest.setMaxNumberOfMessages(10);
+		
+		List<Message> messages = new ArrayList<Message>();
+		List<DeleteMessageBatchRequestEntry> batch = new ArrayList<DeleteMessageBatchRequestEntry>();
+		List<UnsentMessageRange> ranges = new ArrayList<UnsentMessageRange>();
+		do {
+			ReceiveMessageResult rmResult = awsSQSClient.receiveMessage(rmRequest); 
+			messages = rmResult.getMessages();
+			
+			// Transform messages into delete requests
+			for (int i = 0; i < messages.size(); i++) {
+				Message message = messages.get(i);
+				ranges.add(MessageUtils.extractUnsentMessageBody(message));
+				DeleteMessageBatchRequestEntry entry = new DeleteMessageBatchRequestEntry(message.getMessageId(), message.getReceiptHandle());
+				batch.add(entry);
+			}
+		} while (messages.size() > 0);
+		
+		if (batch.size() > 0) {
+			DeleteMessageBatchRequest dmbRequest = new DeleteMessageBatchRequest(queueURL, batch);
+			awsSQSClient.deleteMessageBatch(dmbRequest);
+		}
+		return ranges;
+	}
+
+	/**
+	 * @param batch ChangeMessages that have been inserted/replaced into the CHANGES table
+	 * @return Set of change numbers that should fall between the minimum and maximum of the CHANGE_NUM column
+	 */
+	public Set<Long> convertBatchToRange(List<ChangeMessage> batch) {
+		long minChange = changeDAO.getMinimumChangeNumber();
+		long maxChange = changeDAO.getCurrentChangeNumber();
+		
+		Set<Long> changeNumbers = new HashSet<Long>();
+		for (int i = 0; i < batch.size(); i++) {
+			Long number = batch.get(i).getChangeNumber();
+			if (number >= minChange && number <= maxChange) {
+				changeNumbers.add(number);
+			}
+		}
+		return changeNumbers;
+	}
+
+	/**
+	 * Helper to build up a list of changes
+	 * Based on similarly named method found in DBOChangeDAOImplAutowiredTest
+	 * 
+	 * Randomly and uniformly distributes change number IDs 
+	 * between the given upper and lower bound (inclusive)
+	 * 
+	 * A smaller bound interval results in sparser change numbers
+	 * A larger bound interval results in denser change numbers
+	 */
+	public List<ChangeMessage> createList(int numChangesInBatch, ObjectType type, long lowerBound, long upperBound) {
+		List<ChangeMessage> batch = new ArrayList<ChangeMessage>();
+		for(int i=0; i<numChangesInBatch; i++){
+			ChangeMessage change = new ChangeMessage();
+			long changeNum = lowerBound + (random.nextLong() % (upperBound - lowerBound + 1));
+			if(ObjectType.ENTITY == type){
+				change.setObjectId("syn" + changeNum);
+			}else{
+				change.setObjectId("" + changeNum);
+			}
+			change.setObjectEtag("etag" + changeNum);
+			change.setChangeType(ChangeType.UPDATE);
+			change.setObjectType(type);
+			batch.add(change);
+		}
+		return batch;
+	}
+}

--- a/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTestHelper.java
+++ b/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTestHelper.java
@@ -38,6 +38,7 @@ public class UnsentMessageQueuerTestHelper {
 	
 	/**
 	 * Helper to empty a queue of UnsentMessageRange objects
+	 * @returns All messages removed from the queue
 	 */
 	public List<UnsentMessageRange> emptyQueue(String queueURL) {
 		// Fetch as many messages as possible and don't wait
@@ -69,8 +70,8 @@ public class UnsentMessageQueuerTestHelper {
 	}
 
 	/**
+	 * Extracts change numbers that fall between the minimum and maximum of the CHANGE_NUM column in the CHANGES table
 	 * @param batch ChangeMessages that have been inserted/replaced into the CHANGES table
-	 * @return Set of change numbers that should fall between the minimum and maximum of the CHANGE_NUM column
 	 */
 	public Set<Long> convertBatchToRange(List<ChangeMessage> batch) {
 		long minChange = changeDAO.getMinimumChangeNumber();
@@ -88,7 +89,7 @@ public class UnsentMessageQueuerTestHelper {
 
 	/**
 	 * Helper to build up a list of changes
-	 * Based on similarly named method found in DBOChangeDAOImplAutowiredTest
+	 * Based on the similarly-named method found in DBOChangeDAOImplAutowiredTest
 	 * 
 	 * Randomly and uniformly distributes change number IDs 
 	 * between the given upper and lower bound (inclusive)
@@ -98,12 +99,12 @@ public class UnsentMessageQueuerTestHelper {
 	 */
 	public List<ChangeMessage> createList(int numChangesInBatch, ObjectType type, long lowerBound, long upperBound) {
 		List<ChangeMessage> batch = new ArrayList<ChangeMessage>();
-		for(int i=0; i<numChangesInBatch; i++){
+		for (int i = 0; i < numChangesInBatch; i++) {
 			ChangeMessage change = new ChangeMessage();
 			long changeNum = lowerBound + (random.nextLong() % (upperBound - lowerBound + 1));
-			if(ObjectType.ENTITY == type){
+			if (ObjectType.ENTITY == type) {
 				change.setObjectId("syn" + changeNum);
-			}else{
+			} else {
 				change.setObjectId("" + changeNum);
 			}
 			change.setObjectEtag("etag" + changeNum);

--- a/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageWorkersIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageWorkersIntegrationTest.java
@@ -24,10 +24,10 @@ import com.amazonaws.services.sqs.AmazonSQSClient;
 public class UnsentMessageWorkersIntegrationTest {
 
 	/**
-	 * Enough time for both the Queuer (10 sec) and Popper (10 sec) to fire
+	 * Enough time for both the Queuer (10 sec) and Popper (30 sec) to fire
 	 * Plus some extra time just in case
 	 */
-	public static long MAX_WAIT = 1000*30; 
+	public static long MAX_WAIT = 1000*50; 
 	
 	@Autowired
 	private MessageQueue unsentMessageQueue;

--- a/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageWorkersIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageWorkersIntegrationTest.java
@@ -1,0 +1,80 @@
+package org.sagebionetworks.message.workers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.sagebionetworks.asynchronous.workers.sqs.MessageQueue;
+import org.sagebionetworks.repo.model.ObjectType;
+import org.sagebionetworks.repo.model.dbo.dao.DBOChangeDAO;
+import org.sagebionetworks.repo.model.message.ChangeMessage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.amazonaws.services.sqs.AmazonSQSClient;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "classpath:test-context.xml" })
+public class UnsentMessageWorkersIntegrationTest {
+
+	/**
+	 * Enough time for both the Queuer (10 sec) and Popper (10 sec) to fire
+	 * Plus some extra time just in case
+	 */
+	public static long MAX_WAIT = 1000*30; 
+	
+	@Autowired
+	private MessageQueue unsentMessageQueue;
+	
+	@Autowired
+	private DBOChangeDAO changeDAO;
+	
+	@Autowired
+	private AmazonSQSClient awsSQSClient;
+	private String queueURL;
+
+	@Autowired
+	private UnsentMessageQueuerTestHelper unsentMessageQueuerTestHelper;
+	
+	@Before
+	public void setup() throws Exception {
+		queueURL = unsentMessageQueue.getQueueUrl();
+		
+		changeDAO.deleteAllChanges();
+		unsentMessageQueuerTestHelper.emptyQueue(queueURL);
+	}
+
+	@After
+	public void teardown() throws Exception {
+		changeDAO.deleteAllChanges();
+	}
+
+	@Test
+	public void testUnsentMessages() throws InterruptedException{
+		// This will be added to the change table, but will not be sent
+		List<ChangeMessage> message = unsentMessageQueuerTestHelper.createList(1, ObjectType.ENTITY, 10, 20);
+		message = changeDAO.replaceChange(message);
+		
+		// List the unsent messages.
+		List<ChangeMessage> unsent = changeDAO.listUnsentMessages(Long.MAX_VALUE);
+		assertEquals(1, unsent.size());
+		
+		// Wait for message to be fired
+		long start = System.currentTimeMillis();
+		do{
+			System.out.println("Waiting for UnsentMessagePopper timer to fire...");
+			Thread.sleep(2000);
+			long elpase = System.currentTimeMillis() - start;
+			assertTrue("Timed out waiting for quartz timer to fire.",elpase < MAX_WAIT);
+			
+			// Get the messages
+			unsent = changeDAO.listUnsentMessages(Long.MAX_VALUE);
+		} while (unsent.size() > 0);
+	}
+}

--- a/services/workers/src/test/resources/test-context.xml
+++ b/services/workers/src/test/resources/test-context.xml
@@ -17,6 +17,12 @@
 	<!-- Provides users for testing. -->
 	<bean id="testUserProvider" class="org.sagebionetworks.repo.web.util.UserProviderImpl"
 		scope="singleton" />
+		
+	<!-- Each UnsentMessage worker test needs its own test helper -->
+	<bean id="unsentMessageQueuerTestHelper" 
+		class="org.sagebionetworks.message.workers.UnsentMessageQueuerTestHelper"
+		scope="prototype"
+		init-method="initialize" />
 
 	<bean id="dynamoQueueRemoverFactory"
 		class="org.sagebionetworks.dynamo.workers.sqs.DynamoQueueRemoverFactory"
@@ -45,6 +51,22 @@
 		</property>
 		<property name="startDelay" value="0" />
 		<property name="repeatInterval" value="200" />
+	</bean>
+	
+	<!-- Redefine the unsent message queuer trigger for shorter intervals during tests -->
+	<bean id="unsentMessageQueuerTrigger"
+			class="org.springframework.scheduling.quartz.SimpleTriggerBean"
+			scope="singleton">
+		<property name="jobDetail">
+			<bean class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+				<property name="targetObject" ref="unsentMessageQueuerSemaphoreGatedRunner" />
+				<property name="targetMethod" value="attemptToRun" />
+				<property name="concurrent" value="false" />
+			</bean>
+		</property>
+		<property name="startDelay" value="0" />
+		<!-- 10 seconds -->
+		<property name="repeatInterval" value="10000" />
 	</bean>
 
 </beans>


### PR DESCRIPTION
- Moves the functionality to Services-Workers
- Splits the work into smaller batches that can be scaled up if necessary
- Fix for an issue in MessageReceiverImpl where certain configurations will result in SQS complaints
