### PR TITLE
Context change for UnsentMessageQueuerTest

### DIFF
--- a/services/workers/src/main/resources/message-queuer-sqs.xml
+++ b/services/workers/src/main/resources/message-queuer-sqs.xml
@@ -20,6 +20,12 @@
 			depends-on="awsCredentials">
 		<constructor-arg ref="awsCredentials" />
 	</bean>
+		
+	<!-- Each UnsentMessage worker test needs its own test helper -->
+	<bean id="unsentMessageQueuerTestHelper" 
+		class="org.sagebionetworks.message.workers.UnsentMessageQueuerTestHelper"
+		scope="prototype"
+		init-method="initialize" />
 
 	<!-- Sets up the message queue. -->
 	<bean id="unsentMessageQueue"

--- a/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/message/workers/UnsentMessageQueuerTest.java
@@ -37,7 +37,7 @@ import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = { "classpath:test-context.xml" })
+@ContextConfiguration(locations = { "classpath:message-queuer-sqs.xml" })
 public class UnsentMessageQueuerTest {
 
 	@Autowired

--- a/services/workers/src/test/resources/test-context.xml
+++ b/services/workers/src/test/resources/test-context.xml
@@ -10,12 +10,6 @@
 	<context:annotation-config />
 
 	<import resource="classpath:main-scheduler-spb.xml" />
-		
-	<!-- Each UnsentMessage worker test needs its own test helper -->
-	<bean id="unsentMessageQueuerTestHelper" 
-		class="org.sagebionetworks.message.workers.UnsentMessageQueuerTestHelper"
-		scope="prototype"
-		init-method="initialize" />
 
 	<bean id="dynamoQueueRemoverFactory"
 		class="org.sagebionetworks.dynamo.workers.sqs.DynamoQueueRemoverFactory"


### PR DESCRIPTION
Change the context of the test to mitigate a potential (but unlikely) failure-race condition:

If the queuer bean is run by the test and the popper bean is triggered by the timer, the popper may disrupt the test.
