### PR TITLE
Evaluations by project API rename

### DIFF
--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -593,7 +593,7 @@ public interface SynapseClient {
 
 	Evaluation getEvaluation(String evalId) throws SynapseException;
 
-	PaginatedResults<Evaluation> getEvaluationByContentSource(String projectId,
+	PaginatedResults<Evaluation> getEvaluationByContentSource(String id,
 			int offset, int limit) throws SynapseException;
 
 	@Deprecated

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
@@ -3792,8 +3792,8 @@ public class SynapseClientImpl implements SynapseClient {
 		}
 	}
 	@Override
-	public PaginatedResults<Evaluation> getEvaluationByContentSource(String projectId, int offset, int limit) throws SynapseException {
-		String url = EVALUATION_URI_PATH + "/project/" + projectId + "?" + OFFSET + "=" + offset + "&limit=" + limit;
+	public PaginatedResults<Evaluation> getEvaluationByContentSource(String id, int offset, int limit) throws SynapseException {
+		String url = ENTITY_URI_PATH + "/" + id + EVALUATION_URI_PATH + "?" + OFFSET + "=" + offset + "&limit=" + limit;
 		JSONObject jsonObj = getEntity(url);
 		JSONObjectAdapter adapter = new JSONObjectAdapterImpl(jsonObj);
 		PaginatedResults<Evaluation> results = new PaginatedResults<Evaluation>(Evaluation.class);

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/evaluation/dao/EvaluationDAO.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/evaluation/dao/EvaluationDAO.java
@@ -39,7 +39,7 @@ public interface EvaluationDAO {
 	/**
 	 * Retrieves all evaluations (subject to limit and offset) drawing content from the project
 	 */
-	public List<Evaluation> getByContentSource(String projectId, long limit, long offset) throws DatastoreException, NotFoundException;
+	public List<Evaluation> getByContentSource(String id, long limit, long offset) throws DatastoreException, NotFoundException;
 	
 	/**
 	 * Get all Evaluations, in a given range. Note that Evaluations of all
@@ -65,7 +65,7 @@ public interface EvaluationDAO {
 	/**
 	 * Gets the total count of evaluations tied to a project
 	 */
-	public long getCountByContentSource(String projectId) throws DatastoreException;
+	public long getCountByContentSource(String id) throws DatastoreException;
 	
 	public long getAvailableCount(List<Long> principalIds, EvaluationStatus status) throws DatastoreException;
 

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/evaluation/dao/EvaluationDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/evaluation/dao/EvaluationDAOImpl.java
@@ -156,10 +156,10 @@ public class EvaluationDAOImpl implements EvaluationDAO {
 	}
 	
 	@Override
-	public List<Evaluation> getByContentSource(String projectId, long limit, long offset) 
+	public List<Evaluation> getByContentSource(String id, long limit, long offset) 
 			throws DatastoreException, NotFoundException {
 		MapSqlParameterSource params = new MapSqlParameterSource();
-		params.addValue(CONTENT_SOURCE, KeyFactory.stringToKey(projectId));
+		params.addValue(CONTENT_SOURCE, KeyFactory.stringToKey(id));
 		params.addValue(OFFSET_PARAM_NAME, offset);
 		params.addValue(LIMIT_PARAM_NAME, limit);	
 		List<EvaluationDBO> dbos = simpleJdbcTemplate.query(SELECT_BY_CONTENT_SOURCE, rowMapper, params);
@@ -199,9 +199,9 @@ public class EvaluationDAOImpl implements EvaluationDAO {
 	}
 	
 	@Override
-	public long getCountByContentSource(String projectId) throws DatastoreException {
+	public long getCountByContentSource(String id) throws DatastoreException {
 		MapSqlParameterSource params = new MapSqlParameterSource();
-		params.addValue(CONTENT_SOURCE, KeyFactory.stringToKey(projectId));
+		params.addValue(CONTENT_SOURCE, KeyFactory.stringToKey(id));
 		return simpleJdbcTemplate.queryForLong(COUNT_BY_CONTENT_SOURCE, params);
 	}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationManager.java
@@ -27,7 +27,7 @@ public interface EvaluationManager {
 	/**
 	 * Gets all Synapse Evaluations tied to the given project
 	 */
-	public QueryResults<Evaluation> getEvaluationByContentSource(UserInfo userInfo, String projectId, long limit, long offset)
+	public QueryResults<Evaluation> getEvaluationByContentSource(UserInfo userInfo, String id, long limit, long offset)
 			throws DatastoreException, NotFoundException;
 
 	/**

--- a/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationManagerImpl.java
@@ -86,21 +86,21 @@ public class EvaluationManagerImpl implements EvaluationManager {
 	}
 	
 	@Override
-	public QueryResults<Evaluation> getEvaluationByContentSource(UserInfo userInfo, String projectId, long limit, long offset)
+	public QueryResults<Evaluation> getEvaluationByContentSource(UserInfo userInfo, String id, long limit, long offset)
 			throws DatastoreException, NotFoundException {
-		EvaluationUtils.ensureNotNull(projectId, "Project ID");
+		EvaluationUtils.ensureNotNull(id, "Entity ID");
 		if (userInfo == null) {
 			throw new IllegalArgumentException("User info cannot be null.");
 		}
 		
-		List<Evaluation> evalList = evaluationDAO.getByContentSource(projectId, limit, offset);
+		List<Evaluation> evalList = evaluationDAO.getByContentSource(id, limit, offset);
 		List<Evaluation> evaluations = new ArrayList<Evaluation>();
 		for (Evaluation eval : evalList) {
 			if (evaluationPermissionsManager.hasAccess(userInfo, eval.getId(), ACCESS_TYPE.READ)) {
 				evaluations.add(eval);
 			}
 		}
-		long totalNumberOfResults = evaluationDAO.getCountByContentSource(projectId);
+		long totalNumberOfResults = evaluationDAO.getCountByContentSource(id);
 		return new QueryResults<Evaluation>(evaluations, totalNumberOfResults);
 	}
 

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
@@ -530,7 +530,7 @@ public class UrlHelpers {
 	public static final String EVALUATION_ID_PATH_VAR_WITHOUT_BRACKETS = "evalId";
 	public static final String EVALUATION_ID_PATH_VAR = "{"+EVALUATION_ID_PATH_VAR_WITHOUT_BRACKETS+"}";
 	public static final String EVALUATION_WITH_ID = EVALUATION + "/" + EVALUATION_ID_PATH_VAR;
-	public static final String EVALUATION_WITH_CONTENT_SOURCE = EVALUATION + "/project/{projectId}";
+	public static final String EVALUATION_WITH_CONTENT_SOURCE = ENTITY_ID + EVALUATION;
 	public static final String EVALUATION_WITH_NAME = EVALUATION + "/name/{name}";
 	public static final String EVALUATION_COUNT = EVALUATION + "/count";
 	public static final String EVALUATION_AVAILABLE = EVALUATION+"/available";

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/EvaluationController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/EvaluationController.java
@@ -180,13 +180,13 @@ public class EvaluationController extends BaseController {
 	public @ResponseBody
 	PaginatedResults<Evaluation> getEvaluationsByContentSourcePaginated(
 			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = false) String userId,
-			@PathVariable String projectId, 
+			@PathVariable String id, 
 			@RequestParam(value = ServiceConstants.PAGINATION_OFFSET_PARAM, required = false, defaultValue = ServiceConstants.DEFAULT_PAGINATION_OFFSET_PARAM_NEW) long offset,
 			@RequestParam(value = ServiceConstants.PAGINATION_LIMIT_PARAM, required = false, defaultValue = ServiceConstants.DEFAULT_PAGINATION_LIMIT_PARAM) long limit,
 			HttpServletRequest request
 			) throws DatastoreException, NotFoundException
 	{
-		return serviceProvider.getEvaluationService().getEvaluationByContentSource(userId, projectId, limit, offset, request);
+		return serviceProvider.getEvaluationService().getEvaluationByContentSource(userId, id, limit, offset, request);
 	}
 	
 	/**

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationService.java
@@ -48,7 +48,7 @@ public interface EvaluationService {
 	/**
 	 * Gets all Synapse Evaluations tied to the given Project
 	 */
-	public PaginatedResults<Evaluation> getEvaluationByContentSource(String userId, String projectId, long limit, long offset, HttpServletRequest request)
+	public PaginatedResults<Evaluation> getEvaluationByContentSource(String userId, String id, long limit, long offset, HttpServletRequest request)
 			throws DatastoreException, NotFoundException;
 
 	/**

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationServiceImpl.java
@@ -76,10 +76,10 @@ public class EvaluationServiceImpl implements EvaluationService {
 	}
 	
 	@Override
-	public PaginatedResults<Evaluation> getEvaluationByContentSource(String userId, String projectId, long limit, long offset, HttpServletRequest request)
+	public PaginatedResults<Evaluation> getEvaluationByContentSource(String userId, String id, long limit, long offset, HttpServletRequest request)
 			throws DatastoreException, NotFoundException {
 		UserInfo userInfo = userManager.getUserInfo(userId);
-		QueryResults<Evaluation> res = evaluationManager.getEvaluationByContentSource(userInfo, projectId, limit, offset);
+		QueryResults<Evaluation> res = evaluationManager.getEvaluationByContentSource(userInfo, id, limit, offset);
 		return new PaginatedResults<Evaluation>(
 				request.getServletPath() + UrlHelpers.EVALUATION,
 				res.getResults(),

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/EntityServletTestHelper.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/EntityServletTestHelper.java
@@ -436,10 +436,10 @@ public class EntityServletTestHelper {
 	}
 
 	public PaginatedResults<Evaluation> getEvaluationsByContentSourcePaginated(
-			String username, String projectId, long limit, long offset)
+			String username, String id, long limit, long offset)
 			throws Exception {
 		MockHttpServletRequest request = ServletTestHelperUtils.initRequest(
-				HTTPMODE.GET, UrlHelpers.EVALUATION + "/project/" + projectId,
+				HTTPMODE.GET, UrlHelpers.ENTITY + "/" + id + UrlHelpers.EVALUATION,
 				username, null);
 		request.setParameter(ServiceConstants.PAGINATION_OFFSET_PARAM, ""
 				+ offset);


### PR DESCRIPTION
Changing the API for getting evaluations via content source from:
/evaluation/project/{projectId}

To:
/entity/{id}/evaluation
