### PR TITLE
Removal of generic REST calls from Java client

### DIFF
--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseAdminClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseAdminClientImpl.java
@@ -33,36 +33,27 @@ import org.sagebionetworks.schema.adapter.org.json.JSONObjectAdapterImpl;
  */
 public class SynapseAdminClientImpl extends SynapseClientImpl implements SynapseAdminClient {
 
-	public static final String DAEMON = ADMIN + "/daemon";
-	public static final String BACKUP = "/backup";
-	public static final String RESTORE = "/restore";
-//	public static final String SEARCH_DOCUMENT = "/searchDocument";
-	public static final String DAEMON_BACKUP = DAEMON + BACKUP;
-	public static final String DAEMON_RESTORE = DAEMON + RESTORE;
-	public static final String GET_ALL_BACKUP_OBJECTS = "/backupObjects";
-	public static final String INCLUDE_DEPENDENCIES_PARAM = "includeDependencies";
-	public static final String GET_ALL_BACKUP_COUNTS = "/backupObjectsCounts";
+	private static final String DAEMON = ADMIN + "/daemon";
 	private static final String ADMIN_TRASHCAN_VIEW = ADMIN + "/trashcan/view";
 	private static final String ADMIN_TRASHCAN_PURGE = ADMIN + "/trashcan/purge";
 	private static final String ADMIN_CHANGE_MESSAGES = ADMIN + "/messages";
 	private static final String ADMIN_FIRE_MESSAGES = ADMIN + "/messages/refire";
 	private static final String ADMIN_GET_CURRENT_CHANGE_NUM = ADMIN + "/messages/currentnumber";
-	private static final String ADMIN_PUBLISH_MESSAGES = ADMIN_CHANGE_MESSAGES+"/rebroadcast";
+	private static final String ADMIN_PUBLISH_MESSAGES = ADMIN_CHANGE_MESSAGES + "/rebroadcast";
 	private static final String ADMIN_DOI_CLEAR = ADMIN + "/doi/clear";
 	private static final String ADMIN_MIGRATE_FROM_CROWD = ADMIN + "/crowdsync";
-	
-	public static final String MIGRATION = "/migration";
-	public static final String MIGRATION_COUNTS = MIGRATION+"/counts";
-	public static final String MIGRATION_MAX_IDS = MIGRATION+"/maxids";
-	public static final String MIGRATION_ROWS = MIGRATION+"/rows";
-	public static final String MIGRATION_DELTA = MIGRATION+"/delta";
-	public static final String MIGRATION_BACKUP = MIGRATION+"/backup";
-	public static final String MIGRATION_RESTORE = MIGRATION+"/restore";
-	public static final String MIGRATION_DELETE = MIGRATION+"/delete";
-	public static final String MIGRATION_STATUS = MIGRATION+"/status";
-	public static final String MIGRATION_PRIMARY = MIGRATION+"/primarytypes";
 
-	public static final String ADMIN_DYNAMO_CLEAR = ADMIN + "/dynamo/clear";
+	private static final String MIGRATION = "/migration";
+	private static final String MIGRATION_COUNTS = MIGRATION + "/counts";
+	private static final String MIGRATION_ROWS = MIGRATION + "/rows";
+	private static final String MIGRATION_DELTA = MIGRATION + "/delta";
+	private static final String MIGRATION_BACKUP = MIGRATION + "/backup";
+	private static final String MIGRATION_RESTORE = MIGRATION + "/restore";
+	private static final String MIGRATION_DELETE = MIGRATION + "/delete";
+	private static final String MIGRATION_STATUS = MIGRATION + "/status";
+	private static final String MIGRATION_PRIMARY = MIGRATION + "/primarytypes";
+
+	private static final String ADMIN_DYNAMO_CLEAR = ADMIN + "/dynamo/clear";
 
 	public SynapseAdminClientImpl() {
 		super();
@@ -98,7 +89,7 @@ public class SynapseAdminClientImpl extends SynapseClientImpl implements Synapse
 	 */
 	public BackupRestoreStatus getDaemonStatus(String daemonId)
 			throws SynapseException, JSONObjectAdapterException {
-		return getJSONEntity(DAEMON + "/" + daemonId, BackupRestoreStatus.class);
+		return getJSONEntity(repoEndpoint, DAEMON + "/" + daemonId, BackupRestoreStatus.class);
 	}
 
 	/**
@@ -137,7 +128,7 @@ public class SynapseAdminClientImpl extends SynapseClientImpl implements Synapse
 	public ChangeMessages listMessages(Long startChangeNumber, ObjectType type, Long limit) throws SynapseException, JSONObjectAdapterException{
 		// Build up the URL
 		String url = buildListMessagesURL(startChangeNumber, type, limit);
-		return getJSONEntity(url, ChangeMessages.class);
+		return getJSONEntity(repoEndpoint, url, ChangeMessages.class);
 	}
 	
 	// New migration client methods
@@ -376,7 +367,7 @@ public class SynapseAdminClientImpl extends SynapseClientImpl implements Synapse
 			long offset) throws SynapseException, JSONObjectAdapterException {
 		String url = ADMIN_MIGRATE_FROM_CROWD +
 				"?" + OFFSET + "=" + offset + "&limit=" + limit;
-		JSONObject jsonObj = getEntity(url);
+		JSONObject jsonObj = postUri(url);
 		JSONObjectAdapter adapter = new JSONObjectAdapterImpl(jsonObj);
 		PaginatedResults<CrowdMigrationResult> results = new PaginatedResults<CrowdMigrationResult>(CrowdMigrationResult.class);
 

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -59,7 +59,6 @@ import org.sagebionetworks.repo.model.attachment.AttachmentData;
 import org.sagebionetworks.repo.model.attachment.PresignedUrl;
 import org.sagebionetworks.repo.model.attachment.S3AttachmentToken;
 import org.sagebionetworks.repo.model.auth.NewUser;
-import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
 import org.sagebionetworks.repo.model.dao.WikiPageKey;
 import org.sagebionetworks.repo.model.doi.Doi;
@@ -191,6 +190,11 @@ public interface SynapseClient {
 	 */
 	public void loginWithNoProfile(String userName, String password)
 			throws SynapseException;
+	
+	/**
+	 * Log out of Synapse
+	 */
+	public void logout() throws SynapseException;
 
 	public UserSessionData getUserSessionData() throws SynapseException;
 
@@ -554,9 +558,6 @@ public interface SynapseClient {
 			AttachmentType attachmentType, S3AttachmentToken token)
 			throws JSONObjectAdapterException, SynapseException;
 	
-	public Session performLoginForSessionToken(NewUser userInfo)
-			throws SynapseException, JSONObjectAdapterException;
-
 	public String getSynapseTermsOfUse() throws SynapseException;
 
 	public Long getChildCount(String entityId) throws SynapseException;
@@ -986,4 +987,39 @@ public interface SynapseClient {
 
 	public void deleteMembershipRequest(String requestId) throws SynapseException;
 
+	/**
+	 * Creates a user
+	 */
+	public void createUser(NewUser user) throws SynapseException, JSONObjectAdapterException;
+
+	/**
+	 * Retrieves the bare-minimum amount of information about the current user
+	 * i.e. email and name
+	 */
+	public NewUser getAuthUserInfo() throws SynapseException, JSONObjectAdapterException;
+	
+	/**
+	 * Changes the current user's password
+	 */
+	public void changePassword(String newPassword) throws SynapseException, JSONObjectAdapterException;
+
+	/**
+	 * Changes the registering user's password
+	 */
+	public void changePassword(String sessionToken, String newPassword) throws SynapseException, JSONObjectAdapterException;
+	
+	/**
+	 * Changes the current user's email to the email corresponding to the supplied session token
+	 */
+	public void changeEmail(String sessionToken, String newPassword) throws SynapseException, JSONObjectAdapterException;
+	
+	/**
+	 * Sends a password reset email to the current user 
+	 */
+	public void sendPasswordResetEmail() throws SynapseException;
+	
+	/**
+	 * Sends a password reset email to the given user
+	 */
+	public void sendPasswordResetEmail(String email) throws SynapseException, JSONObjectAdapterException;
 }

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -353,6 +353,8 @@ public interface SynapseClient {
 
 	public <T extends AccessApproval> T createAccessApproval(T aa)
 			throws SynapseException;
+	
+	public JSONObject getEntity(String uri) throws SynapseException;
 
 	public <T extends JSONEntity> T getEntity(String entityId,
 			Class<? extends T> clazz) throws SynapseException;

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -943,52 +943,6 @@ public interface SynapseClient {
 	 * @throws SynapseException 
 	 */
 	PaginatedColumnModels listColumnModels(String prefix, Long limit, Long offset) throws SynapseException;
-	public Team getTeam(String id) throws SynapseException;
-
-	public PaginatedResults<Team> getTeams(String fragment, long limit, long offset)
-			throws SynapseException;
-
-	public PaginatedResults<Team> getTeamsForUser(String memberId, long limit,
-			long offset) throws SynapseException;
-
-	public URL getTeamIcon(String teamId, Boolean redirect) throws SynapseException;
-
-	public Team updateTeam(Team team) throws SynapseException;
-
-	public void deleteTeam(String teamId) throws SynapseException;
-
-	public void addTeamMember(String teamId, String memberId) throws SynapseException;
-
-	public PaginatedResults<UserGroupHeader> getTeamMembers(String teamId,
-			String fragment, long limit, long offset) throws SynapseException;
-
-	public void removeTeamMember(String teamId, String memberId)
-			throws SynapseException;
-
-	public MembershipInvtnSubmission createMembershipInvitation(
-			MembershipInvtnSubmission invitation) throws SynapseException;
-
-	public MembershipInvtnSubmission getMembershipInvitation(String invitationId)
-			throws SynapseException;
-
-	public PaginatedResults<MembershipInvitation> getOpenMembershipInvitations(
-			String memberId, String teamId, long limit, long offset)
-			throws SynapseException;
-
-	public void deleteMembershipInvitation(String invitationId)
-			throws SynapseException;
-
-	public MembershipRqstSubmission createMembershipRequest(
-			MembershipRqstSubmission request) throws SynapseException;
-
-	public MembershipRqstSubmission getMembershipRequest(String requestId)
-			throws SynapseException;
-
-	public PaginatedResults<MembershipRequest> getOpenMembershipRequests(
-			String teamId, String requestorId, long limit, long offset)
-			throws SynapseException;
-
-	public void deleteMembershipRequest(String requestId) throws SynapseException;
 
 	/**
 	 * Creates a user
@@ -1026,5 +980,9 @@ public interface SynapseClient {
 	 */
 	public void sendPasswordResetEmail(String email) throws SynapseException;
 	
+	/**
+	 * Performs OpenID authentication using the set of parameters from an OpenID provider
+	 * @return A session token if the authentication passes
+	 */
 	public Session passThroughOpenIDParameters(String queryString) throws SynapseException;
 }

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -7,7 +7,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.http.client.ClientProtocolException;
@@ -87,72 +86,82 @@ import org.sagebionetworks.schema.adapter.JSONEntity;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 
 /**
- * Abstraction for Synpase.
+ * Abstraction for Synapse.
  * 
  * @author jmhill
- *
+ * 
  */
 public interface SynapseClient {
 
 	/**
-	 * Get the current status of the stack.
-	 * @return
-	 * @throws SynapseException
-	 * @throws JSONObjectAdapterException
+	 * Get the current status of the stack
 	 */
-	public StackStatus getCurrentStackStatus() throws SynapseException,	JSONObjectAdapterException;
-	
+	public StackStatus getCurrentStackStatus() 
+			throws SynapseException, JSONObjectAdapterException;
+
 	/**
-	 * Get the endpoint of the repository service.
-	 * @return
+	 * Get the endpoint of the repository service
 	 */
 	public String getRepoEndpoint();
 
 	/**
 	 * Each request includes the 'User-Agent' header. This is set to:
 	 * 'User-Agent':'Synpase-Java-Client/<version_number>'
-	 * Addition User-Agent information can be appended to this string by calling this method.
+	 * 
 	 * @param toAppend
+	 *            Addition User-Agent information can be appended to this string
+	 *            via this parameter
 	 */
 	public void appendUserAgent(String toAppend);
 
 	/**
-	 * The repository end-point includes the host and version.  For example: "https://repo-prod.prod.sagebase.org/repo/v1"
-	 * 
-	 * @param repoEndpoint
+	 * The repository endpoint includes the host and version. For example:
+	 * "https://repo-prod.prod.sagebase.org/repo/v1"
 	 */
 	public void setRepositoryEndpoint(String repoEndpoint);
 
+	/**
+	 * The authorization endpoint includes the host and version. For example:
+	 * "https://repo-prod.prod.sagebase.org/auth/v1"
+	 */
 	public void setAuthEndpoint(String authEndpoint);
 
 	/**
-	 * Get the configured Authorization Service Endpoint
-	 * @return
+	 * Get the endpoint of the authorization service
 	 */
 	public String getAuthEndpoint();
 
+	/**
+	 * The file endpoint includes the host and version. For example:
+	 * "https://repo-prod.prod.sagebase.org/file/v1"
+	 */
 	public void setFileEndpoint(String fileEndpoint);
 
+	/**
+	 * Get the endpoint of the file service
+	 */
 	public String getFileEndpoint();
 
 	/**
-	 * Authenticate the synapse client with an existing session token
-	 * 
-	 * @param sessionToken
+	 * Authenticate the Synapse client with an existing session token
 	 */
 	public void setSessionToken(String sessionToken);
 
-	public AttachmentData uploadAttachmentToSynapse(String entityId, File temp,	String fileName) throws JSONObjectAdapterException, SynapseException, IOException;
+	public AttachmentData uploadAttachmentToSynapse(String entityId, File temp, String fileName) 
+			throws JSONObjectAdapterException, SynapseException, IOException;
 
 	public Entity getEntityById(String entityId) throws SynapseException;
 
 	public <T extends Entity> T putEntity(T entity) throws SynapseException;
 
 	@Deprecated
-	public PresignedUrl waitForPreviewToBeCreated(String entityId, String tokenId, int maxTimeOut) throws SynapseException, JSONObjectAdapterException;
+	public PresignedUrl waitForPreviewToBeCreated(String entityId,
+			String tokenId, int maxTimeOut) throws SynapseException,
+			JSONObjectAdapterException;
 
 	@Deprecated
-	public PresignedUrl createAttachmentPresignedUrl(String entityId, String tokenId) throws SynapseException, JSONObjectAdapterException;
+	public PresignedUrl createAttachmentPresignedUrl(String entityId,
+			String tokenId) throws SynapseException, JSONObjectAdapterException;
 
 	public URL getWikiAttachmentPreviewTemporaryUrl(WikiPageKey properKey,
 			String fileName) throws ClientProtocolException, IOException;
@@ -162,571 +171,551 @@ public interface SynapseClient {
 
 	/**
 	 * Log into Synapse
-	 * 
-	 * @param username
-	 * @param password
-	 * @throws SynapseException
 	 */
-	UserSessionData login(String username, String password)
+	public UserSessionData login(String username, String password)
 			throws SynapseException;
-
-	UserSessionData login(String username, String password,
-			boolean explicitlyAcceptsTermsOfUse) throws SynapseException;
 
 	/**
-	 * 
-	 * Log into Synapse, do not return UserSessionData, do not request user profile, do not explicitely accept terms of use
-	 * 
-	 * @param userName
-	 * @param password
-	 * @throws SynapseException 
+	 * Log into Synapse and specify whether you agree to the terms of use
 	 */
-	void loginWithNoProfile(String userName, String password)
+	public UserSessionData login(String username, String password, boolean explicitlyAcceptsTermsOfUse) 
 			throws SynapseException;
 
-	UserSessionData getUserSessionData() throws SynapseException;
+	/**
+	 * Log into Synapse, 
+	 *   do not return UserSessionData, 
+	 *   do not request a user profile, 
+	 *   and do not explicitly accept the terms of use
+	 */
+	public void loginWithNoProfile(String userName, String password)
+			throws SynapseException;
 
-	boolean revalidateSession() throws SynapseException;
+	public UserSessionData getUserSessionData() throws SynapseException;
+
+	/**
+	 * Refreshes the cached session token so that it can be used for another 24 hours
+	 */
+	public boolean revalidateSession() throws SynapseException;
+
 	/**
 	 * Get the current session token used by this client.
 	 * 
 	 * @return the session token
 	 */
-	String getCurrentSessionToken();
+	public String getCurrentSessionToken();
 
 	/**
 	 * Create a new Entity.
 	 * 
-	 * @param <T>
-	 * @param entity
 	 * @return the newly created entity
-	 * @throws SynapseException
 	 */
 	public <T extends Entity> T createEntity(T entity) throws SynapseException;
 
-	JSONObject createJSONObject(String uri, JSONObject entity)
+	public JSONObject createJSONObject(String uri, JSONObject entity)
 			throws SynapseException;
 
-	public SearchResults search(SearchQuery searchQuery) throws SynapseException, UnsupportedEncodingException, JSONObjectAdapterException;
+	public SearchResults search(SearchQuery searchQuery)
+			throws SynapseException, UnsupportedEncodingException,
+			JSONObjectAdapterException;
 
-	public URL getFileEntityPreviewTemporaryUrlForCurrentVersion(String entityId) throws ClientProtocolException, MalformedURLException, IOException;
+	public URL getFileEntityPreviewTemporaryUrlForCurrentVersion(String entityId)
+			throws ClientProtocolException, MalformedURLException, IOException;
 
-	URL getFileEntityTemporaryUrlForCurrentVersion(String entityId)
+	public URL getFileEntityTemporaryUrlForCurrentVersion(String entityId)
 			throws ClientProtocolException, MalformedURLException, IOException;
 
 	public URL getFileEntityPreviewTemporaryUrlForVersion(String entityId,
-			Long versionNumber) throws ClientProtocolException, MalformedURLException, IOException;
+			Long versionNumber) throws ClientProtocolException,
+			MalformedURLException, IOException;
 
 	public URL getFileEntityTemporaryUrlForVersion(String entityId,
-			Long versionNumber) throws ClientProtocolException, MalformedURLException, IOException;
+			Long versionNumber) throws ClientProtocolException,
+			MalformedURLException, IOException;
 
-	public S3FileHandle createFileHandle(File temp, String contentType) throws SynapseException, IOException;
+	public S3FileHandle createFileHandle(File temp, String contentType)
+			throws SynapseException, IOException;
 
 	/**
 	 * Get a WikiPage using its key
-	 * @param key
-	 * @return
-	 * @throws SynapseException 
-	 * @throws JSONObjectAdapterException 
 	 */
-	public WikiPage getWikiPage(WikiPageKey properKey) throws JSONObjectAdapterException, SynapseException;
-
+	public WikiPage getWikiPage(WikiPageKey properKey)
+			throws JSONObjectAdapterException, SynapseException;
 
 	public VariableContentPaginatedResults<AccessRequirement> getAccessRequirements(
 			RestrictableObjectDescriptor subjectId) throws SynapseException;
 
-	WikiPage updateWikiPage(String ownerId, ObjectType ownerType,
+	public WikiPage updateWikiPage(String ownerId, ObjectType ownerType,
 			WikiPage toUpdate) throws JSONObjectAdapterException,
 			SynapseException;
 
-	void setRequestProfile(boolean request);
+	public void setRequestProfile(boolean request);
 
-	JSONObject getProfileData();
+	public JSONObject getProfileData();
 
-	String getUserName();
+	public String getUserName();
 
-	void setUserName(String userName);
+	public void setUserName(String userName);
 
-	String getApiKey();
+	public String getApiKey();
 
-	void setApiKey(String apiKey);
+	public void setApiKey(String apiKey);
 
-	<T extends Entity> T createEntity(T entity, String activityId) throws SynapseException;
+	public <T extends Entity> T createEntity(T entity, String activityId)
+			throws SynapseException;
 
 	public <T extends JSONEntity> T createJSONEntity(String uri, T entity)
 			throws SynapseException;
 
-	EntityBundle createEntityBundle(EntityBundleCreate ebc)
+	public EntityBundle createEntityBundle(EntityBundleCreate ebc)
 			throws SynapseException;
 
-	EntityBundle createEntityBundle(EntityBundleCreate ebc, String activityId)
+	public EntityBundle createEntityBundle(EntityBundleCreate ebc, String activityId)
 			throws SynapseException;
 
-	EntityBundle updateEntityBundle(String entityId, EntityBundleCreate ebc)
+	public EntityBundle updateEntityBundle(String entityId, EntityBundleCreate ebc)
 			throws SynapseException;
 
-	EntityBundle updateEntityBundle(String entityId, EntityBundleCreate ebc,
+	public EntityBundle updateEntityBundle(String entityId, EntityBundleCreate ebc,
 			String activityId) throws SynapseException;
 
-	JSONObject getEntity(String uri) throws SynapseException;
-
-	Entity getEntityByIdForVersion(String entityId, Long versionNumber)
+	public Entity getEntityByIdForVersion(String entityId, Long versionNumber)
 			throws SynapseException;
 
-	EntityBundle getEntityBundle(String entityId, int partsMask)
+	public EntityBundle getEntityBundle(String entityId, int partsMask)
 			throws SynapseException;
 
-	EntityBundle getEntityBundle(String entityId, Long versionNumber,
+	public EntityBundle getEntityBundle(String entityId, Long versionNumber,
 			int partsMask) throws SynapseException;
 
-	PaginatedResults<VersionInfo> getEntityVersions(String entityId,
+	public PaginatedResults<VersionInfo> getEntityVersions(String entityId,
 			int offset, int limit) throws SynapseException;
 
-	AccessControlList getACL(String entityId) throws SynapseException;
+	public AccessControlList getACL(String entityId) throws SynapseException;
 
-	EntityHeader getEntityBenefactor(String entityId) throws SynapseException;
+	public EntityHeader getEntityBenefactor(String entityId) throws SynapseException;
 
-	UserProfile getMyProfile() throws SynapseException;
+	public UserProfile getMyProfile() throws SynapseException;
 
-	void updateMyProfile(UserProfile userProfile) throws SynapseException;
+	public void updateMyProfile(UserProfile userProfile) throws SynapseException;
 
-	UserProfile getUserProfile(String ownerId) throws SynapseException;
+	public UserProfile getUserProfile(String ownerId) throws SynapseException;
 
-	UserGroupHeaderResponsePage getUserGroupHeadersByIds(List<String> ids)
+	public UserGroupHeaderResponsePage getUserGroupHeadersByIds(List<String> ids)
 			throws SynapseException;
 
-	UserGroupHeaderResponsePage getUserGroupHeadersByPrefix(String prefix)
+	public UserGroupHeaderResponsePage getUserGroupHeadersByPrefix(String prefix)
 			throws SynapseException, UnsupportedEncodingException;
 
-	AccessControlList updateACL(AccessControlList acl) throws SynapseException;
+	public AccessControlList updateACL(AccessControlList acl) throws SynapseException;
 
-	AccessControlList updateACL(AccessControlList acl, boolean recursive)
+	public AccessControlList updateACL(AccessControlList acl, boolean recursive)
 			throws SynapseException;
 
-	void deleteACL(String entityId) throws SynapseException;
+	public void deleteACL(String entityId) throws SynapseException;
 
-	AccessControlList createACL(AccessControlList acl) throws SynapseException;
+	public AccessControlList createACL(AccessControlList acl) throws SynapseException;
 
-	PaginatedResults<UserProfile> getUsers(int offset, int limit)
+	public PaginatedResults<UserProfile> getUsers(int offset, int limit)
 			throws SynapseException;
 
-	PaginatedResults<UserGroup> getGroups(int offset, int limit)
+	public PaginatedResults<UserGroup> getGroups(int offset, int limit)
 			throws SynapseException;
 
-	boolean canAccess(String entityId, ACCESS_TYPE accessType)
+	public boolean canAccess(String entityId, ACCESS_TYPE accessType)
 			throws SynapseException;
 
-	boolean canAccess(String id, ObjectType type, ACCESS_TYPE accessType)
+	public boolean canAccess(String id, ObjectType type, ACCESS_TYPE accessType)
 			throws SynapseException;
 
-	UserEntityPermissions getUsersEntityPermissions(String entityId)
+	public UserEntityPermissions getUsersEntityPermissions(String entityId)
 			throws SynapseException;
 
-	Annotations getAnnotations(String entityId) throws SynapseException;
+	public Annotations getAnnotations(String entityId) throws SynapseException;
 
-	Annotations updateAnnotations(String entityId, Annotations updated)
+	public Annotations updateAnnotations(String entityId, Annotations updated)
 			throws SynapseException;
 
-	public <T extends AccessRequirement> T createAccessRequirement(T ar) throws SynapseException;
-
-	ACTAccessRequirement createLockAccessRequirement(String entityId)
+	public <T extends AccessRequirement> T createAccessRequirement(T ar)
 			throws SynapseException;
 
-	VariableContentPaginatedResults<AccessRequirement> getUnmetAccessRequirements(
+	public ACTAccessRequirement createLockAccessRequirement(String entityId)
+			throws SynapseException;
+
+	public VariableContentPaginatedResults<AccessRequirement> getUnmetAccessRequirements(
 			RestrictableObjectDescriptor subjectId) throws SynapseException;
 
-	public <T extends AccessApproval> T createAccessApproval(T aa) throws SynapseException;
-
-	public <T extends JSONEntity> T getEntity(String entityId, Class<? extends T> clazz) throws SynapseException;
-
-	void deleteAccessRequirement(Long arId) throws SynapseException;
-
-	@Deprecated
-	public JSONObject updateEntity(String uri, JSONObject entity)
+	public <T extends AccessApproval> T createAccessApproval(T aa)
 			throws SynapseException;
 
-	public <T extends Entity> T putEntity(T entity, String activityId) throws SynapseException;
+	public <T extends JSONEntity> T getEntity(String entityId,
+			Class<? extends T> clazz) throws SynapseException;
 
-	JSONObject putJSONObject(String uri, JSONObject entity,
-			Map<String, String> headers) throws SynapseException;
+	public void deleteAccessRequirement(Long arId) throws SynapseException;
 
-	JSONObject postUri(String uri) throws SynapseException;
-
-	void deleteUri(String uri) throws SynapseException;
-	
-	public <T extends Entity> void deleteEntity(T entity) throws SynapseException;
-	
-	public <T extends Entity> void deleteAndPurgeEntity(T entity) throws SynapseException;
-	
-	public void deleteEntityById(String entityId)
+	public <T extends Entity> T putEntity(T entity, String activityId)
 			throws SynapseException;
 
-	void deleteAndPurgeEntityById(String entityId) throws SynapseException;
-	
-	public <T extends Entity> void deleteEntityVersion(T entity, Long versionNumber) throws SynapseException;
-
-	void deleteEntityVersionById(String entityId, Long versionNumber)
+	public <T extends Entity> void deleteEntity(T entity)
 			throws SynapseException;
 
-	EntityPath getEntityPath(Entity entity) throws SynapseException;
-
-	EntityPath getEntityPath(String entityId) throws SynapseException;
-
-	BatchResults<EntityHeader> getEntityTypeBatch(List<String> entityIds)
+	public <T extends Entity> void deleteAndPurgeEntity(T entity)
 			throws SynapseException;
 
-	BatchResults<EntityHeader> getEntityHeaderBatch(List<Reference> references)
+	public void deleteEntityById(String entityId) throws SynapseException;
+
+	public void deleteAndPurgeEntityById(String entityId) throws SynapseException;
+
+	public <T extends Entity> void deleteEntityVersion(T entity,
+			Long versionNumber) throws SynapseException;
+
+	public void deleteEntityVersionById(String entityId, Long versionNumber)
 			throws SynapseException;
 
-	PaginatedResults<EntityHeader> getEntityReferencedBy(Entity entity)
+	public EntityPath getEntityPath(Entity entity) throws SynapseException;
+
+	public EntityPath getEntityPath(String entityId) throws SynapseException;
+
+	public BatchResults<EntityHeader> getEntityTypeBatch(List<String> entityIds)
 			throws SynapseException;
 
-	PaginatedResults<EntityHeader> getEntityReferencedBy(String entityId,
+	public BatchResults<EntityHeader> getEntityHeaderBatch(List<Reference> references)
+			throws SynapseException;
+
+	public PaginatedResults<EntityHeader> getEntityReferencedBy(Entity entity)
+			throws SynapseException;
+
+	public PaginatedResults<EntityHeader> getEntityReferencedBy(String entityId,
 			String targetVersion) throws SynapseException;
 
-	JSONObject query(String query) throws SynapseException;
+	public JSONObject query(String query) throws SynapseException;
 
-	FileHandleResults createFileHandles(List<File> files)
+	public FileHandleResults createFileHandles(List<File> files)
 			throws SynapseException;
 
-	ChunkedFileToken createChunkedFileUploadToken(
+	public ChunkedFileToken createChunkedFileUploadToken(
 			CreateChunkedFileTokenRequest ccftr) throws SynapseException;
 
-	URL createChunkedPresignedUrl(ChunkRequest chunkRequest)
+	public URL createChunkedPresignedUrl(ChunkRequest chunkRequest)
 			throws SynapseException;
 
-	String putFileToURL(URL url, File file, String contentType)
-			throws SynapseException;
-
-	@Deprecated
-	ChunkResult addChunkToFile(ChunkRequest chunkRequest)
+	public String putFileToURL(URL url, File file, String contentType)
 			throws SynapseException;
 
 	@Deprecated
-	S3FileHandle completeChunkFileUpload(CompleteChunkedFileRequest request)
+	public ChunkResult addChunkToFile(ChunkRequest chunkRequest)
 			throws SynapseException;
 
-	UploadDaemonStatus startUploadDeamon(CompleteAllChunksRequest cacr)
+	@Deprecated
+	public S3FileHandle completeChunkFileUpload(CompleteChunkedFileRequest request)
 			throws SynapseException;
 
-	UploadDaemonStatus getCompleteUploadDaemonStatus(String daemonId)
+	public UploadDaemonStatus startUploadDeamon(CompleteAllChunksRequest cacr)
 			throws SynapseException;
 
-	ExternalFileHandle createExternalFileHandle(ExternalFileHandle efh)
+	public UploadDaemonStatus getCompleteUploadDaemonStatus(String daemonId)
+			throws SynapseException;
+
+	public ExternalFileHandle createExternalFileHandle(ExternalFileHandle efh)
 			throws JSONObjectAdapterException, SynapseException;
 
-	FileHandle getRawFileHandle(String fileHandleId) throws SynapseException;
+	public FileHandle getRawFileHandle(String fileHandleId) throws SynapseException;
 
-	void deleteFileHandle(String fileHandleId) throws SynapseException;
+	public void deleteFileHandle(String fileHandleId) throws SynapseException;
 
-	void clearPreview(String fileHandleId) throws SynapseException;
+	public void clearPreview(String fileHandleId) throws SynapseException;
 
-	WikiPage createWikiPage(String ownerId, ObjectType ownerType,
+	public WikiPage createWikiPage(String ownerId, ObjectType ownerType,
 			WikiPage toCreate) throws JSONObjectAdapterException,
 			SynapseException;
 
-	WikiPage getRootWikiPage(String ownerId, ObjectType ownerType)
+	public WikiPage getRootWikiPage(String ownerId, ObjectType ownerType)
 			throws JSONObjectAdapterException, SynapseException;
 
-	FileHandleResults getWikiAttachmenthHandles(WikiPageKey key)
+	public FileHandleResults getWikiAttachmenthHandles(WikiPageKey key)
 			throws JSONObjectAdapterException, SynapseException;
 
-	File downloadWikiAttachment(WikiPageKey key, String fileName)
+	public File downloadWikiAttachment(WikiPageKey key, String fileName)
 			throws ClientProtocolException, IOException;
 
-	File downloadWikiAttachmentPreview(WikiPageKey key, String fileName)
+	public File downloadWikiAttachmentPreview(WikiPageKey key, String fileName)
 			throws ClientProtocolException, FileNotFoundException, IOException;
 
-	void deleteWikiPage(WikiPageKey key) throws SynapseException;
+	public void deleteWikiPage(WikiPageKey key) throws SynapseException;
 
-	PaginatedResults<WikiHeader> getWikiHeaderTree(String ownerId,
+	public PaginatedResults<WikiHeader> getWikiHeaderTree(String ownerId,
 			ObjectType ownerType) throws SynapseException,
 			JSONObjectAdapterException;
 
-	FileHandleResults getEntityFileHandlesForCurrentVersion(String entityId)
+	public FileHandleResults getEntityFileHandlesForCurrentVersion(String entityId)
 			throws JSONObjectAdapterException, SynapseException;
 
-	FileHandleResults getEntityFileHandlesForVersion(String entityId,
+	public FileHandleResults getEntityFileHandlesForVersion(String entityId,
 			Long versionNumber) throws JSONObjectAdapterException,
 			SynapseException;
 
 	@Deprecated
-	File downloadLocationableFromSynapse(Locationable locationable)
+	public File downloadLocationableFromSynapse(Locationable locationable)
 			throws SynapseException;
 
 	@Deprecated
-	File downloadLocationableFromSynapse(Locationable locationable,
+	public File downloadLocationableFromSynapse(Locationable locationable,
 			File destinationFile) throws SynapseException;
 
 	@Deprecated
-	File downloadFromSynapse(LocationData location, String md5,
+	public File downloadFromSynapse(LocationData location, String md5,
 			File destinationFile) throws SynapseException;
 
 	@Deprecated
-	File downloadFromSynapse(String path, String md5, File destinationFile)
+	public File downloadFromSynapse(String path, String md5, File destinationFile)
 			throws SynapseException;
 
 	@Deprecated
-	Locationable uploadLocationableToSynapse(Locationable locationable,
+	public Locationable uploadLocationableToSynapse(Locationable locationable,
 			File dataFile) throws SynapseException;
 
 	@Deprecated
-	Locationable uploadLocationableToSynapse(Locationable locationable,
+	public Locationable uploadLocationableToSynapse(Locationable locationable,
 			File dataFile, String md5) throws SynapseException;
 
 	@Deprecated
-	Locationable updateExternalLocationableToSynapse(Locationable locationable,
+	public Locationable updateExternalLocationableToSynapse(Locationable locationable,
 			String externalUrl) throws SynapseException;
+
 	@Deprecated
-	Locationable updateExternalLocationableToSynapse(Locationable locationable,
+	public Locationable updateExternalLocationableToSynapse(Locationable locationable,
 			String externalUrl, String md5) throws SynapseException;
+
 	@Deprecated
-	AttachmentData uploadAttachmentToSynapse(String entityId, File dataFile)
+	public AttachmentData uploadAttachmentToSynapse(String entityId, File dataFile)
 			throws JSONObjectAdapterException, SynapseException, IOException;
+
 	@Deprecated
-	AttachmentData uploadUserProfileAttachmentToSynapse(String userId,
+	public AttachmentData uploadUserProfileAttachmentToSynapse(String userId,
 			File dataFile, String fileName) throws JSONObjectAdapterException,
 			SynapseException, IOException;
+
 	@Deprecated
-	AttachmentData uploadAttachmentToSynapse(String id,
+	public AttachmentData uploadAttachmentToSynapse(String id,
 			AttachmentType attachmentType, File dataFile, String fileName)
 			throws JSONObjectAdapterException, SynapseException, IOException;
+
 	@Deprecated
-	PresignedUrl createUserProfileAttachmentPresignedUrl(String id,
+	public PresignedUrl createUserProfileAttachmentPresignedUrl(String id,
 			String tokenOrPreviewId) throws SynapseException,
 			JSONObjectAdapterException;
+
 	@Deprecated
-	PresignedUrl createAttachmentPresignedUrl(String id,
+	public PresignedUrl createAttachmentPresignedUrl(String id,
 			AttachmentType attachmentType, String tokenOrPreviewId)
 			throws SynapseException, JSONObjectAdapterException;
+
 	@Deprecated
-	PresignedUrl waitForUserProfilePreviewToBeCreated(String userId,
+	public PresignedUrl waitForUserProfilePreviewToBeCreated(String userId,
 			String tokenOrPreviewId, int timeout) throws SynapseException,
 			JSONObjectAdapterException;
+
 	@Deprecated
-	PresignedUrl waitForPreviewToBeCreated(String id, AttachmentType type,
+	public PresignedUrl waitForPreviewToBeCreated(String id, AttachmentType type,
 			String tokenOrPreviewId, int timeout) throws SynapseException,
 			JSONObjectAdapterException;
+
 	@Deprecated
-	void downloadEntityAttachment(String entityId,
+	public void downloadEntityAttachment(String entityId,
 			AttachmentData attachmentData, File destFile)
 			throws SynapseException, JSONObjectAdapterException;
+
 	@Deprecated
-	void downloadUserProfileAttachment(String userId,
+	public void downloadUserProfileAttachment(String userId,
 			AttachmentData attachmentData, File destFile)
 			throws SynapseException, JSONObjectAdapterException;
+
 	@Deprecated
-	void downloadAttachment(String id, AttachmentType type,
+	public void downloadAttachment(String id, AttachmentType type,
 			AttachmentData attachmentData, File destFile)
 			throws SynapseException, JSONObjectAdapterException;
+
 	@Deprecated
-	void downloadEntityAttachmentPreview(String entityId, String previewId,
+	public void downloadEntityAttachmentPreview(String entityId, String previewId,
 			File destFile) throws SynapseException, JSONObjectAdapterException;
+
 	@Deprecated
-	void downloadUserProfileAttachmentPreview(String userId, String previewId,
+	public void downloadUserProfileAttachmentPreview(String userId, String previewId,
 			File destFile) throws SynapseException, JSONObjectAdapterException;
+
 	@Deprecated
-	void downloadAttachmentPreview(String id, AttachmentType type,
+	public void downloadAttachmentPreview(String id, AttachmentType type,
 			String previewId, File destFile) throws SynapseException,
 			JSONObjectAdapterException;
+
 	@Deprecated
-	S3AttachmentToken createAttachmentS3Token(String id,
+	public S3AttachmentToken createAttachmentS3Token(String id,
 			AttachmentType attachmentType, S3AttachmentToken token)
 			throws JSONObjectAdapterException, SynapseException;
 
-	JSONObject createAuthEntity(String uri, JSONObject entity)
-			throws SynapseException;
+	public String getSynapseTermsOfUse() throws SynapseException;
 
-	JSONObject getAuthEntity(String uri) throws SynapseException;
+	public Long getChildCount(String entityId) throws SynapseException;
 
-	JSONObject putAuthEntity(String uri, JSONObject entity)
-			throws SynapseException;
-
-	JSONObject createJSONObjectEntity(String endpoint, String uri,
-			JSONObject entity) throws SynapseException;
-
-	JSONObject getSynapseEntity(String endpoint, String uri)
-			throws SynapseException;
-
-	JSONObject putJSONObject(String endpoint, String uri, JSONObject entity,
-			Map<String, String> headers) throws SynapseException;
-
-	JSONObject postUri(String endpoint, String uri) throws SynapseException;
-
-	JSONObject querySynapse(String endpoint, String query)
-			throws SynapseException;
-
-	void deleteUri(String endpoint, String uri) throws SynapseException;
-	
-	public <T extends JSONEntity> T getJSONEntity(String uri,
-			Class<? extends T> clazz) throws SynapseException,
+	public SynapseVersionInfo getVersionInfo() throws SynapseException,
 			JSONObjectAdapterException;
 
-	String getSynapseTermsOfUse() throws SynapseException;
+	public Set<String> getAllUserAndGroupIds() throws SynapseException;
 
-	Long getChildCount(String entityId) throws SynapseException;
+	public Activity getActivityForEntity(String entityId) throws SynapseException;
 
-	SynapseVersionInfo getVersionInfo() throws SynapseException,
-			JSONObjectAdapterException;
-
-	Set<String> getAllUserAndGroupIds() throws SynapseException;
-
-	Activity getActivityForEntity(String entityId) throws SynapseException;
-
-	Activity getActivityForEntityVersion(String entityId, Long versionNumber)
+	public Activity getActivityForEntityVersion(String entityId, Long versionNumber)
 			throws SynapseException;
 
-	Activity setActivityForEntity(String entityId, String activityId)
+	public Activity setActivityForEntity(String entityId, String activityId)
 			throws SynapseException;
 
-	void deleteGeneratedByForEntity(String entityId) throws SynapseException;
+	public void deleteGeneratedByForEntity(String entityId) throws SynapseException;
 
-	Activity createActivity(Activity activity) throws SynapseException;
+	public Activity createActivity(Activity activity) throws SynapseException;
 
-	Activity getActivity(String activityId) throws SynapseException;
+	public Activity getActivity(String activityId) throws SynapseException;
 
-	Activity putActivity(Activity activity) throws SynapseException;
+	public Activity putActivity(Activity activity) throws SynapseException;
 
-	void deleteActivity(String activityId) throws SynapseException;
+	public void deleteActivity(String activityId) throws SynapseException;
 
-	PaginatedResults<Reference> getEntitiesGeneratedBy(String activityId,
+	public PaginatedResults<Reference> getEntitiesGeneratedBy(String activityId,
 			Integer limit, Integer offset) throws SynapseException;
 
-	EntityIdList getDescendants(String nodeId, int pageSize,
+	public EntityIdList getDescendants(String nodeId, int pageSize,
 			String lastDescIdExcl) throws SynapseException;
 
-	EntityIdList getDescendants(String nodeId, int generation, int pageSize,
+	public EntityIdList getDescendants(String nodeId, int generation, int pageSize,
 			String lastDescIdExcl) throws SynapseException;
 
-	Evaluation createEvaluation(Evaluation eval) throws SynapseException;
+	public Evaluation createEvaluation(Evaluation eval) throws SynapseException;
 
-	Evaluation getEvaluation(String evalId) throws SynapseException;
+	public Evaluation getEvaluation(String evalId) throws SynapseException;
 
-	PaginatedResults<Evaluation> getEvaluationByContentSource(String id,
+	public PaginatedResults<Evaluation> getEvaluationByContentSource(String id,
 			int offset, int limit) throws SynapseException;
 
 	@Deprecated
-	PaginatedResults<Evaluation> getEvaluationsPaginated(int offset, int limit)
+	public PaginatedResults<Evaluation> getEvaluationsPaginated(int offset, int limit)
 			throws SynapseException;
 
 	@Deprecated
-	PaginatedResults<Evaluation> getAvailableEvaluationsPaginated(
+	public PaginatedResults<Evaluation> getAvailableEvaluationsPaginated(
 			EvaluationStatus status, int offset, int limit)
 			throws SynapseException;
 
-	Long getEvaluationCount() throws SynapseException;
+	public Long getEvaluationCount() throws SynapseException;
 
-	Evaluation findEvaluation(String name) throws SynapseException,
+	public Evaluation findEvaluation(String name) throws SynapseException,
 			UnsupportedEncodingException;
 
-	Evaluation updateEvaluation(Evaluation eval) throws SynapseException;
+	public Evaluation updateEvaluation(Evaluation eval) throws SynapseException;
 
-	void deleteEvaluation(String evalId) throws SynapseException;
+	public void deleteEvaluation(String evalId) throws SynapseException;
 
-	Participant createParticipant(String evalId) throws SynapseException;
+	public Participant createParticipant(String evalId) throws SynapseException;
 
-	Participant getParticipant(String evalId, String principalId)
+	public Participant getParticipant(String evalId, String principalId)
 			throws SynapseException;
 
-	void deleteParticipant(String evalId, String principalId)
+	public void deleteParticipant(String evalId, String principalId)
 			throws SynapseException;
 
-	PaginatedResults<Participant> getAllParticipants(String s,
-			long offset, long limit) throws SynapseException;
-
-	Long getParticipantCount(String evalId) throws SynapseException;
-
-	Submission createSubmission(Submission sub, String etag)
-			throws SynapseException;
-
-	Submission getSubmission(String subId) throws SynapseException;
-
-	SubmissionStatus getSubmissionStatus(String subId) throws SynapseException;
-
-	SubmissionStatus updateSubmissionStatus(SubmissionStatus status)
-			throws SynapseException;
-
-	void deleteSubmission(String subId) throws SynapseException;
-
-	PaginatedResults<Submission> getAllSubmissions(String evalId, long offset,
+	public PaginatedResults<Participant> getAllParticipants(String s, long offset,
 			long limit) throws SynapseException;
 
-	PaginatedResults<SubmissionStatus> getAllSubmissionStatuses(String evalId,
+	public Long getParticipantCount(String evalId) throws SynapseException;
+
+	public Submission createSubmission(Submission sub, String etag)
+			throws SynapseException;
+
+	public Submission getSubmission(String subId) throws SynapseException;
+
+	public SubmissionStatus getSubmissionStatus(String subId) throws SynapseException;
+
+	public SubmissionStatus updateSubmissionStatus(SubmissionStatus status)
+			throws SynapseException;
+
+	public void deleteSubmission(String subId) throws SynapseException;
+
+	public PaginatedResults<Submission> getAllSubmissions(String evalId, long offset,
+			long limit) throws SynapseException;
+
+	public PaginatedResults<SubmissionStatus> getAllSubmissionStatuses(String evalId,
 			long offset, long limit) throws SynapseException;
 
-	PaginatedResults<SubmissionBundle> getAllSubmissionBundles(String evalId,
+	public PaginatedResults<SubmissionBundle> getAllSubmissionBundles(String evalId,
 			long offset, long limit) throws SynapseException;
 
-	PaginatedResults<Submission> getAllSubmissionsByStatus(String evalId,
+	public PaginatedResults<Submission> getAllSubmissionsByStatus(String evalId,
 			SubmissionStatusEnum status, long offset, long limit)
 			throws SynapseException;
 
-	PaginatedResults<SubmissionStatus> getAllSubmissionStatusesByStatus(
+	public PaginatedResults<SubmissionStatus> getAllSubmissionStatusesByStatus(
 			String evalId, SubmissionStatusEnum status, long offset, long limit)
 			throws SynapseException;
 
-	PaginatedResults<SubmissionBundle> getAllSubmissionBundlesByStatus(
+	public PaginatedResults<SubmissionBundle> getAllSubmissionBundlesByStatus(
 			String evalId, SubmissionStatusEnum status, long offset, long limit)
 			throws SynapseException;
 
-	PaginatedResults<Submission> getMySubmissions(String evalId, long offset,
+	public PaginatedResults<Submission> getMySubmissions(String evalId, long offset,
 			long limit) throws SynapseException;
 
-	PaginatedResults<SubmissionBundle> getMySubmissionBundles(String evalId,
+	public PaginatedResults<SubmissionBundle> getMySubmissionBundles(String evalId,
 			long offset, long limit) throws SynapseException;
 
-	URL getFileTemporaryUrlForSubmissionFileHandle(String submissionId,
+	public URL getFileTemporaryUrlForSubmissionFileHandle(String submissionId,
 			String fileHandleId) throws ClientProtocolException,
 			MalformedURLException, IOException;
 
-	Long getSubmissionCount(String evalId) throws SynapseException;
+	public Long getSubmissionCount(String evalId) throws SynapseException;
 
-	UserEvaluationState getUserEvaluationState(String evalId)
+	public UserEvaluationState getUserEvaluationState(String evalId)
 			throws SynapseException;
 
-	QueryTableResults queryEvaluation(String query) throws SynapseException;
+	public QueryTableResults queryEvaluation(String query) throws SynapseException;
 
-	void moveToTrash(String entityId) throws SynapseException;
+	public void moveToTrash(String entityId) throws SynapseException;
 
-	void restoreFromTrash(String entityId, String newParentId)
+	public void restoreFromTrash(String entityId, String newParentId)
 			throws SynapseException;
 
-	PaginatedResults<TrashedEntity> viewTrashForUser(long offset, long limit)
+	public PaginatedResults<TrashedEntity> viewTrashForUser(long offset, long limit)
 			throws SynapseException;
 
-	void purgeTrashForUser(String entityId) throws SynapseException;
+	public void purgeTrashForUser(String entityId) throws SynapseException;
 
-	void purgeTrashForUser() throws SynapseException;
+	public void purgeTrashForUser() throws SynapseException;
 
-	EntityHeader addFavorite(String entityId) throws SynapseException;
+	public EntityHeader addFavorite(String entityId) throws SynapseException;
 
-	void removeFavorite(String entityId) throws SynapseException;
+	public void removeFavorite(String entityId) throws SynapseException;
 
-	PaginatedResults<EntityHeader> getFavorites(Integer limit, Integer offset)
+	public PaginatedResults<EntityHeader> getFavorites(Integer limit, Integer offset)
 			throws SynapseException;
 
-	void createEntityDoi(String entityId) throws SynapseException;
+	public void createEntityDoi(String entityId) throws SynapseException;
 
-	void createEntityDoi(String entityId, Long entityVersion)
+	public void createEntityDoi(String entityId, Long entityVersion)
 			throws SynapseException;
 
-	Doi getEntityDoi(String entityId) throws SynapseException;
+	public Doi getEntityDoi(String entityId) throws SynapseException;
 
-	Doi getEntityDoi(String s, Long entityVersion)
+	public Doi getEntityDoi(String s, Long entityVersion) throws SynapseException;
+
+	public List<EntityHeader> getEntityHeaderByMd5(String md5) throws SynapseException;
+
+	public String retrieveApiKey() throws SynapseException;
+
+	public AccessControlList updateEvaluationAcl(AccessControlList acl)
 			throws SynapseException;
 
-	List<EntityHeader> getEntityHeaderByMd5(String md5) throws SynapseException;
+	public AccessControlList getEvaluationAcl(String evalId) throws SynapseException;
 
-	String retrieveApiKey() throws SynapseException;
-
-	AccessControlList updateEvaluationAcl(AccessControlList acl)
+	public UserEvaluationPermissions getUserEvaluationPermissions(String evalId)
 			throws SynapseException;
 
-	AccessControlList getEvaluationAcl(String evalId) throws SynapseException;
-
-	UserEvaluationPermissions getUserEvaluationPermissions(String evalId)
-			throws SynapseException;
-	
 	/**
 	 * Create a new ColumnModel. If a column already exists with the same parameters,
 	 * that column will be returned.
@@ -945,4 +934,51 @@ public interface SynapseClient {
 	 * @throws SynapseException 
 	 */
 	PaginatedColumnModels listColumnModels(String prefix, Long limit, Long offset) throws SynapseException;
+	public Team getTeam(String id) throws SynapseException;
+
+	public PaginatedResults<Team> getTeams(String fragment, long limit, long offset)
+			throws SynapseException;
+
+	public PaginatedResults<Team> getTeamsForUser(String memberId, long limit,
+			long offset) throws SynapseException;
+
+	public URL getTeamIcon(String teamId, Boolean redirect) throws SynapseException;
+
+	public Team updateTeam(Team team) throws SynapseException;
+
+	public void deleteTeam(String teamId) throws SynapseException;
+
+	public void addTeamMember(String teamId, String memberId) throws SynapseException;
+
+	public PaginatedResults<UserGroupHeader> getTeamMembers(String teamId,
+			String fragment, long limit, long offset) throws SynapseException;
+
+	public void removeTeamMember(String teamId, String memberId)
+			throws SynapseException;
+
+	public MembershipInvtnSubmission createMembershipInvitation(
+			MembershipInvtnSubmission invitation) throws SynapseException;
+
+	public MembershipInvtnSubmission getMembershipInvitation(String invitationId)
+			throws SynapseException;
+
+	public PaginatedResults<MembershipInvitation> getOpenMembershipInvitations(
+			String memberId, String teamId, long limit, long offset)
+			throws SynapseException;
+
+	public void deleteMembershipInvitation(String invitationId)
+			throws SynapseException;
+
+	public MembershipRqstSubmission createMembershipRequest(
+			MembershipRqstSubmission request) throws SynapseException;
+
+	public MembershipRqstSubmission getMembershipRequest(String requestId)
+			throws SynapseException;
+
+	public PaginatedResults<MembershipRequest> getOpenMembershipRequests(
+			String teamId, String requestorId, long limit, long offset)
+			throws SynapseException;
+
+	public void deleteMembershipRequest(String requestId) throws SynapseException;
+
 }

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -58,6 +58,8 @@ import org.sagebionetworks.repo.model.VersionInfo;
 import org.sagebionetworks.repo.model.attachment.AttachmentData;
 import org.sagebionetworks.repo.model.attachment.PresignedUrl;
 import org.sagebionetworks.repo.model.attachment.S3AttachmentToken;
+import org.sagebionetworks.repo.model.auth.NewUser;
+import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
 import org.sagebionetworks.repo.model.dao.WikiPageKey;
 import org.sagebionetworks.repo.model.doi.Doi;
@@ -551,6 +553,9 @@ public interface SynapseClient {
 	public S3AttachmentToken createAttachmentS3Token(String id,
 			AttachmentType attachmentType, S3AttachmentToken token)
 			throws JSONObjectAdapterException, SynapseException;
+	
+	public Session performLoginForSessionToken(NewUser userInfo)
+			throws SynapseException, JSONObjectAdapterException;
 
 	public String getSynapseTermsOfUse() throws SynapseException;
 

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -59,6 +59,7 @@ import org.sagebionetworks.repo.model.attachment.AttachmentData;
 import org.sagebionetworks.repo.model.attachment.PresignedUrl;
 import org.sagebionetworks.repo.model.attachment.S3AttachmentToken;
 import org.sagebionetworks.repo.model.auth.NewUser;
+import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
 import org.sagebionetworks.repo.model.dao.WikiPageKey;
 import org.sagebionetworks.repo.model.doi.Doi;
@@ -714,6 +715,8 @@ public interface SynapseClient {
 
 	public String retrieveApiKey() throws SynapseException;
 
+	public void invalidateApiKey() throws SynapseException;
+	
 	public AccessControlList updateEvaluationAcl(AccessControlList acl)
 			throws SynapseException;
 
@@ -990,28 +993,28 @@ public interface SynapseClient {
 	/**
 	 * Creates a user
 	 */
-	public void createUser(NewUser user) throws SynapseException, JSONObjectAdapterException;
+	public void createUser(NewUser user) throws SynapseException;
 
 	/**
 	 * Retrieves the bare-minimum amount of information about the current user
 	 * i.e. email and name
 	 */
-	public NewUser getAuthUserInfo() throws SynapseException, JSONObjectAdapterException;
+	public NewUser getAuthUserInfo() throws SynapseException;
 	
 	/**
 	 * Changes the current user's password
 	 */
-	public void changePassword(String newPassword) throws SynapseException, JSONObjectAdapterException;
+	public void changePassword(String newPassword) throws SynapseException;
 
 	/**
 	 * Changes the registering user's password
 	 */
-	public void changePassword(String sessionToken, String newPassword) throws SynapseException, JSONObjectAdapterException;
+	public void changePassword(String sessionToken, String newPassword) throws SynapseException;
 	
 	/**
 	 * Changes the current user's email to the email corresponding to the supplied session token
 	 */
-	public void changeEmail(String sessionToken, String newPassword) throws SynapseException, JSONObjectAdapterException;
+	public void changeEmail(String sessionToken, String newPassword) throws SynapseException;
 	
 	/**
 	 * Sends a password reset email to the current user 
@@ -1021,5 +1024,7 @@ public interface SynapseClient {
 	/**
 	 * Sends a password reset email to the given user
 	 */
-	public void sendPasswordResetEmail(String email) throws SynapseException, JSONObjectAdapterException;
+	public void sendPasswordResetEmail(String email) throws SynapseException;
+	
+	public Session passThroughOpenIDParameters(String queryString) throws SynapseException;
 }

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
@@ -97,7 +97,6 @@ import org.sagebionetworks.repo.model.TeamMember;
 import org.sagebionetworks.repo.model.TeamMembershipStatus;
 import org.sagebionetworks.repo.model.TrashedEntity;
 import org.sagebionetworks.repo.model.UserGroup;
-import org.sagebionetworks.repo.model.UserGroupHeader;
 import org.sagebionetworks.repo.model.UserGroupHeaderResponsePage;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.UserSessionData;
@@ -1322,7 +1321,8 @@ public class SynapseClientImpl implements SynapseClient {
 	 * 
 	 * @return the retrieved entity
 	 */
-	private JSONObject getEntity(String uri) throws SynapseException {
+	@Override
+	public JSONObject getEntity(String uri) throws SynapseException {
 		return getSynapseEntity(repoEndpoint, uri);
 	}
 

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
@@ -27,8 +27,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import javax.swing.plaf.basic.BasicOptionPaneUI;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
@@ -177,8 +175,8 @@ public class SynapseClientImpl implements SynapseClient {
 	private static final String QUERY_URI = "/query?query=";
 	private static final String REPO_SUFFIX_VERSION = "/version";
 	private static final String ANNOTATION_URI_SUFFIX = "annotations";
-	private static final String ADMIN = "/admin";
-	private static final String STACK_STATUS = ADMIN + "/synapse/status";
+	protected static final String ADMIN = "/admin";
+	protected static final String STACK_STATUS = ADMIN + "/synapse/status";
 	private static final String ENTITY = "/entity";
 	private static final String ATTACHMENT_S3_TOKEN = "/s3AttachmentToken";
 	private static final String ATTACHMENT_URL = "/attachmentUrl";
@@ -262,8 +260,8 @@ public class SynapseClientImpl implements SynapseClient {
 	private static final String ETAG = "etag";
 
 	// web request pagination parameters
-	private static final String LIMIT = "limit";
-	private static final String OFFSET = "offset";
+	public static final String LIMIT = "limit";
+	public static final String OFFSET = "offset";
 
 	private static final String LIMIT_1_OFFSET_1 = "' limit 1 offset 1";
 	private static final String SELECT_ID_FROM_ENTITY_WHERE_PARENT_ID = "select id from entity where parentId == '";
@@ -292,12 +290,12 @@ public class SynapseClientImpl implements SynapseClient {
 	private static final String REQUESTOR_ID_REQUEST_PARAMETER = "requestorId";
 
 	
-	private String repoEndpoint;
-	private String authEndpoint;
-	private String fileEndpoint;
+	protected String repoEndpoint;
+	protected String authEndpoint;
+	protected String fileEndpoint;
 
-	private Map<String, String> defaultGETDELETEHeaders;
-	private Map<String, String> defaultPOSTPUTHeaders;
+	protected Map<String, String> defaultGETDELETEHeaders;
+	protected Map<String, String> defaultPOSTPUTHeaders;
 
 	private JSONObject profileData;
 	private boolean requestProfile;
@@ -1426,7 +1424,7 @@ public class SynapseClientImpl implements SynapseClient {
 	/**
 	 * Create a dataset, layer, etc...
 	 */
-	private JSONObject postUri(String uri) throws SynapseException {
+	protected JSONObject postUri(String uri) throws SynapseException {
 		return postUri(repoEndpoint, uri);
 	}
 
@@ -3047,15 +3045,9 @@ public class SynapseClientImpl implements SynapseClient {
 	}
 	
 	/**
-	 * Get a JSONEntity.
-	 * @param endpoint
-	 * @param uri
-	 * @param clazz
-	 * @return
-	 * @throws JSONObjectAdapterException
-	 * @throws SynapseException
+	 * Get a JSONEntity
 	 */
-	private <T extends JSONEntity> T getJSONEntity(String endpoint, String uri, Class<? extends T> clazz) throws JSONObjectAdapterException, SynapseException{
+	protected <T extends JSONEntity> T getJSONEntity(String endpoint, String uri, Class<? extends T> clazz) throws JSONObjectAdapterException, SynapseException{
 		if (null == endpoint) {
 			throw new IllegalArgumentException("must provide endpoint");
 		}
@@ -3209,7 +3201,7 @@ public class SynapseClientImpl implements SynapseClient {
 		}
 	}
 	
-	private JSONObject signAndDispatchSynapseRequest(String endpoint, String uri,
+	protected JSONObject signAndDispatchSynapseRequest(String endpoint, String uri,
 			String requestMethod, String requestContent,
 			Map<String, String> requestHeaders) throws SynapseException {
 		if (apiKey!=null) {
@@ -3241,7 +3233,7 @@ public class SynapseClientImpl implements SynapseClient {
 	 * @param requestHeaders
 	 * @return
 	 */
-	private JSONObject dispatchSynapseRequest(String endpoint, String uri,
+	protected JSONObject dispatchSynapseRequest(String endpoint, String uri,
 			String requestMethod, String requestContent,
 			Map<String, String> requestHeaders) throws SynapseException {
 

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
@@ -4461,7 +4461,7 @@ public class SynapseClientImpl implements SynapseClient {
 		if(columnId == null) throw new IllegalArgumentException("ColumnId cannot be null");
 		String url = COLUMN+"/"+columnId;
 		try {
-			return getJSONEntity(url, ColumnModel.class);
+			return getJSONEntity(repoEndpoint, url, ColumnModel.class);
 		} catch (JSONObjectAdapterException e) {
 			throw new SynapseException(e);
 		}
@@ -4472,7 +4472,7 @@ public class SynapseClientImpl implements SynapseClient {
 		if(tableEntityId == null) throw new IllegalArgumentException("tableEntityId cannot be null");
 		String url = ENTITY+"/"+tableEntityId+COLUMN;
 		try {
-			PaginatedColumnModels pcm =  getJSONEntity(url, PaginatedColumnModels.class);
+			PaginatedColumnModels pcm = getJSONEntity(repoEndpoint, url, PaginatedColumnModels.class);
 			return pcm.getResults();
 		} catch (JSONObjectAdapterException e) {
 			throw new SynapseException(e);
@@ -4483,7 +4483,7 @@ public class SynapseClientImpl implements SynapseClient {
 	public PaginatedColumnModels listColumnModels(String prefix, Long limit, Long offset) throws SynapseException {
 		String url = buildListColumnModelUrl(prefix, limit, offset);
 		try {
-			return  getJSONEntity(url, PaginatedColumnModels.class);
+			return  getJSONEntity(repoEndpoint, url, PaginatedColumnModels.class);
 			
 		} catch (JSONObjectAdapterException e) {
 			throw new SynapseException(e);

--- a/integration-test/src/test/java/org/sagebionetworks/IT500SynapseJavaClient.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT500SynapseJavaClient.java
@@ -161,17 +161,15 @@ public class IT500SynapseJavaClient {
 		if (0 < datasets.length()) {
 			String datasetId = datasets.getJSONObject(0).getString("dataset.id");
 
-			JSONObject aStoredDataset = synapse.getEntity("/entity/"
-					+ datasetId);
-			assertTrue(aStoredDataset.has("annotations"));
+			Data aStoredDataset = synapse.getEntity(datasetId, Data.class);
+			assertNotNull(aStoredDataset.getAnnotations());
 
-			JSONObject annotations = synapse.getEntity(aStoredDataset
-					.getString("annotations"));
-			assertTrue(annotations.has("stringAnnotations"));
-			assertTrue(annotations.has("dateAnnotations"));
-			assertTrue(annotations.has("longAnnotations"));
-			assertTrue(annotations.has("doubleAnnotations"));
-			assertTrue(annotations.has("blobAnnotations"));
+			Annotations annos = synapse.getAnnotations(datasetId);
+			assertNotNull(annos.getStringAnnotations());
+			assertNotNull(annos.getDateAnnotations());
+			assertNotNull(annos.getLongAnnotations());
+			assertNotNull(annos.getDoubleAnnotations());
+			assertNotNull(annos.getBlobAnnotations());
 		}
 	}
 	
@@ -893,9 +891,7 @@ public class IT500SynapseJavaClient {
 	public void testAPIKey() throws Exception {
 		// get API key for integration test user
 		// must be logged in to do this, so use the global client 'synapse'
-		JSONObject keyJson = synapse.getSynapseEntity(StackConfiguration
-				.getAuthenticationServicePrivateEndpoint(), "/secretKey");
-		String apiKey = keyJson.getString("secretKey");
+		String apiKey = synapse.retrieveApiKey();
 		assertNotNull(apiKey);
 		// set user name and api key in a synapse client
 		// we don't want to log-in, so use a new Synapse client instance

--- a/integration-test/src/test/java/org/sagebionetworks/IT970UserProfileController.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT970UserProfileController.java
@@ -4,12 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.logging.Logger;
 
-import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -19,10 +15,9 @@ import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.PaginatedResults;
 import org.sagebionetworks.repo.model.Project;
+import org.sagebionetworks.repo.model.UserProfile;
 
 public class IT970UserProfileController {
-	private static final Logger log = Logger.getLogger(IT970UserProfileController.class.getName());
-	
 	private static SynapseClientImpl synapse = null;
 
 	List<String> entitiesToDelete;
@@ -63,13 +58,13 @@ public class IT970UserProfileController {
 	
 	@Test
 	public void testGetAndUpdateOwnUserProfile() throws Exception {
-		JSONObject userProfile = synapse.getSynapseEntity(synapse.getRepoEndpoint(), "/userProfile");
+		UserProfile userProfile = synapse.getMyProfile();
 		System.out.println(userProfile);
 		// now update the fields
-		userProfile.put("firstName", "foo");
-		userProfile.put("lastName", "bar");
-		Map<String,String> headers = new HashMap<String, String>();
-		synapse.putJSONObject("/userProfile", userProfile, headers);
+		userProfile.setFirstName("foo");
+		userProfile.setLastName("bar");
+		
+		synapse.updateMyProfile(userProfile);
 	}
 	
 	@Test 

--- a/integration-test/src/test/java/org/sagebionetworks/IT990CrowdAuthentication.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT990CrowdAuthentication.java
@@ -24,26 +24,23 @@ import org.sagebionetworks.client.exceptions.SynapseBadRequestException;
 import org.sagebionetworks.client.exceptions.SynapseForbiddenException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.client.exceptions.SynapseServiceException;
+import org.sagebionetworks.repo.model.auth.NewUser;
+import org.sagebionetworks.repo.model.auth.Session;
 import org.springframework.http.HttpStatus;
-
 
 /**
  * CrowdAuthUtil
  */
-
 public class IT990CrowdAuthentication {
-	private static SynapseClientImpl synapse = null;
-	private static String authEndpoint = null;
-	private static String repoEndpoint = null;
-	/**
-	 * @throws Exception
-	 * 
-	 */
+	private static SynapseClientImpl synapse;
+	
+	private static final String username = StackConfiguration.getIntegrationTestUserThreeName();
+	private static final String password = StackConfiguration.getIntegrationTestUserThreePassword();
+
 	@BeforeClass
 	public static void beforeClass() throws Exception {
-
-		authEndpoint = StackConfiguration.getAuthenticationServicePrivateEndpoint();
-		repoEndpoint = StackConfiguration.getRepositoryServiceEndpoint();
+		String authEndpoint = StackConfiguration.getAuthenticationServicePrivateEndpoint();
+		String repoEndpoint = StackConfiguration.getRepositoryServiceEndpoint();
 		synapse = new SynapseClientImpl();
 		synapse.setAuthEndpoint(authEndpoint);
 		synapse.setRepositoryEndpoint(repoEndpoint);
@@ -51,25 +48,20 @@ public class IT990CrowdAuthentication {
 				StackConfiguration.getIntegrationTestUserThreePassword());
 	}
 
-	private static final String SESSION_TOKEN_LABEL = "sessionToken";
-	
 	@Test
 	public void testCreateSession() throws Exception {
-		JSONObject loginRequest = new JSONObject();
-		String username = StackConfiguration.getIntegrationTestUserThreeName();
-		String password = StackConfiguration.getIntegrationTestUserThreePassword();
-		loginRequest.put("email", username);
-		loginRequest.put("password", password);
+		NewUser userInfo = new NewUser();
+		userInfo.setEmail(username);
+		userInfo.setPassword(password);
 
-		JSONObject session = synapse.createAuthEntity("/session", loginRequest);
-		assertTrue(session.has(SESSION_TOKEN_LABEL));
+		Session session = synapse.performLoginForSessionToken(userInfo);
+		assertNotNull(session);
+		assertNotNull(session.getSessionToken());
 	}
 	
 	@Test
 	public void testCreateSessionSigningTermsOfUse() throws Exception {
 		JSONObject loginRequest = new JSONObject();
-		String username = StackConfiguration.getIntegrationTestUserThreeName();
-		String password = StackConfiguration.getIntegrationTestUserThreePassword();
 		loginRequest.put("email", username);
 		loginRequest.put("password", password);
 

--- a/integration-test/src/test/java/org/sagebionetworks/IT990CrowdAuthentication.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT990CrowdAuthentication.java
@@ -109,6 +109,7 @@ public class IT990CrowdAuthentication {
 		synapse.createUser(user);
 	}
 	
+	@Ignore
 	@Test
 	public void testCreateUserAndAcceptToU() throws Exception {	
 		String username = "integration@test." + UUID.randomUUID();

--- a/integration-test/src/test/java/org/sagebionetworks/IT990CrowdAuthentication.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT990CrowdAuthentication.java
@@ -25,9 +25,9 @@ import org.sagebionetworks.authutil.CrowdAuthUtil;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseBadRequestException;
-import org.sagebionetworks.client.exceptions.SynapseForbiddenException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.client.exceptions.SynapseServiceException;
+import org.sagebionetworks.client.exceptions.SynapseTermsOfUseException;
 import org.sagebionetworks.client.exceptions.SynapseUnauthorizedException;
 import org.sagebionetworks.repo.model.auth.NewUser;
 import org.springframework.http.HttpStatus;
@@ -72,7 +72,7 @@ public class IT990CrowdAuthentication {
 		synapse.login(username, "incorrectPassword");
 	}
 	
-	@Test(expected = SynapseForbiddenException.class)
+	@Test(expected = SynapseTermsOfUseException.class)
 	public void testCreateSessionNoTermsOfUse() throws Exception {
 		String username = StackConfiguration.getIntegrationTestRejectTermsOfUseEmail();
 		String password = StackConfiguration.getIntegrationTestRejectTermsOfUsePassword();

--- a/integration-test/src/test/java/org/sagebionetworks/IT990CrowdAuthentication.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT990CrowdAuthentication.java
@@ -51,7 +51,7 @@ public class IT990CrowdAuthentication {
 	}
 	
 	@Before
-	public static void setup() throws Exception {
+	public void setup() throws Exception {
 		synapse.login(username, password);
 	}
 

--- a/services/authutil/src/main/java/org/sagebionetworks/authutil/CrowdAuthUtil.java
+++ b/services/authutil/src/main/java/org/sagebionetworks/authutil/CrowdAuthUtil.java
@@ -30,6 +30,7 @@ import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpResponse;
+import org.apache.logging.log4j.Level;
 import org.joda.time.DateTime;
 import org.sagebionetworks.StackConfiguration;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
@@ -588,6 +589,13 @@ public class CrowdAuthUtil {
 		Session session = authenticate(user, false);
 		// need the rest of the user's fields
 		user = getUser(user.getEmail());
+		
+		// Don't spam emails for integration tests
+		if (!StackConfiguration.isProductionStack()) {
+			log.info("Prevented " + mode + " email from being sent to " + userEmail + " with session token " + sessiontoken);
+			return;
+		}
+		
 		// now send the reset password email, filling in the user name and session token
 		SendMail sendMail = new SendMail();
 		switch (mode) {

--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
@@ -99,7 +99,7 @@ public class AuthenticationController extends BaseController {
 	}
 	
 	@ResponseStatus(HttpStatus.CREATED)
-	@RequestMapping(value = "/session", method = RequestMethod.POST)
+	@RequestMapping(value = UrlHelpers.AUTH_SESSION, method = RequestMethod.POST)
 	public @ResponseBody
 	Session authenticate(@RequestBody NewUser credentials,
 			HttpServletRequest request) throws Exception {
@@ -137,7 +137,7 @@ public class AuthenticationController extends BaseController {
 	}
 
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@RequestMapping(value = "/session", method = RequestMethod.PUT)
+	@RequestMapping(value = UrlHelpers.AUTH_SESSION, method = RequestMethod.PUT)
 	public void revalidate(@RequestBody Session session) throws Exception {
 		String userId = CrowdAuthUtil.revalidate(session.getSessionToken());
 		if (!CrowdAuthUtil.acceptsTermsOfUse(userId, false /*i.e. may have accepted TOU previously, but acceptance is not given in this request*/)) {
@@ -146,7 +146,7 @@ public class AuthenticationController extends BaseController {
 	}
 
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@RequestMapping(value = "/session", method = RequestMethod.DELETE)
+	@RequestMapping(value = UrlHelpers.AUTH_SESSION, method = RequestMethod.DELETE)
 	public void deauthenticate(HttpServletRequest request) throws Exception {
 		String sessionToken = request.getHeader(AuthorizationConstants.SESSION_TOKEN_PARAM);
 		if (null == sessionToken) throw new AuthenticationException(HttpStatus.BAD_REQUEST.value(), "Not authorized.", null);
@@ -166,7 +166,7 @@ public class AuthenticationController extends BaseController {
 	}
 	
 	@ResponseStatus(HttpStatus.CREATED)
-	@RequestMapping(value = "/user", method = RequestMethod.POST)
+	@RequestMapping(value = UrlHelpers.AUTH_USER, method = RequestMethod.POST)
 	public void createNewUser(@RequestBody NewUser user) throws Exception {
 		String itu = getIntegrationTestNewUser();
 		boolean isITU = (itu!=null && user.getEmail().equals(itu));
@@ -182,7 +182,7 @@ public class AuthenticationController extends BaseController {
 	}
 	
 	@ResponseStatus(HttpStatus.OK)
-	@RequestMapping(value = "/user", method = RequestMethod.GET)
+	@RequestMapping(value = UrlHelpers.AUTH_USER, method = RequestMethod.GET)
 	public @ResponseBody NewUser getNewUser(@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = false) String userId) throws Exception {
 		if (AuthorizationConstants.ANONYMOUS_USER_ID.equals(userId)) 
 			throw new AuthenticationException(HttpStatus.BAD_REQUEST.value(), "No user info for "+AuthorizationConstants.ANONYMOUS_USER_ID, null);
@@ -192,7 +192,7 @@ public class AuthenticationController extends BaseController {
 	
 	// for integration testing
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@RequestMapping(value = "/user", method = RequestMethod.DELETE)
+	@RequestMapping(value = UrlHelpers.AUTH_USER_PASSWORD_EMAIL, method = RequestMethod.POST)
 	public void deleteNewUser(@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = false) String userId) throws Exception {
 		String itu = getIntegrationTestNewUser();
 		boolean isITU = (itu!=null && userId!=null && userId.equals(itu));
@@ -212,7 +212,7 @@ public class AuthenticationController extends BaseController {
 	}
 	
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@RequestMapping(value = "/userPasswordEmail", method = RequestMethod.POST)
+	@RequestMapping(value = UrlHelpers.AUTH_API_PASSWORD_EMAIL, method = RequestMethod.POST)
 	public void sendChangePasswordEmail(@RequestBody NewUser user) throws Exception {
 		sendNewUserPasswordEmail(user.getEmail(), PW_MODE.RESET_PW);
 	}
@@ -228,7 +228,7 @@ public class AuthenticationController extends BaseController {
 	}
 	
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@RequestMapping(value = "/userPassword", method = RequestMethod.POST)
+	@RequestMapping(value = UrlHelpers.AUTH_USER_PASSWORD, method = RequestMethod.POST)
 	public void setPassword(@RequestBody ChangeUserPassword changeNewUserPassword,
 			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = false) String userId) throws Exception {
 		if (userId==null) 
@@ -242,7 +242,7 @@ public class AuthenticationController extends BaseController {
 	}
 	
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@RequestMapping(value = "/changeEmail", method = RequestMethod.POST)
+	@RequestMapping(value = UrlHelpers.AUTH_CHANGE_EMAIL, method = RequestMethod.POST)
 	public void changeEmail(@RequestBody RegistrationInfo registrationInfo,
 			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = false) String userId) throws Exception {
 		//user must be logged in to make this request
@@ -269,7 +269,7 @@ public class AuthenticationController extends BaseController {
 	
 
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@RequestMapping(value = "/registeringNewUserPassword", method = RequestMethod.POST)
+	@RequestMapping(value = UrlHelpers.AUTH_REGISTERING_USER_PASSWORD, method = RequestMethod.POST)
 	public void setRegisteringNewUserPassword(@RequestBody RegistrationInfo registrationInfo,
 			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = false) String userId) throws Exception {
 		String registrationToken = registrationInfo.getRegistrationToken();
@@ -288,7 +288,7 @@ public class AuthenticationController extends BaseController {
 	}
 	
 	@ResponseStatus(HttpStatus.OK)
-	@RequestMapping(value = "/secretKey", method = RequestMethod.GET)
+	@RequestMapping(value = UrlHelpers.AUTH_SECRET_KEY, method = RequestMethod.GET)
 	public @ResponseBody SecretKey newSecretKey(
 			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = false) String userId) throws Exception {
 		if (userId==null) 
@@ -316,7 +316,7 @@ public class AuthenticationController extends BaseController {
 	
 
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@RequestMapping(value = "/secretKey", method = RequestMethod.DELETE)
+	@RequestMapping(value = UrlHelpers.AUTH_SECRET_KEY, method = RequestMethod.DELETE)
 	public void invalidateSecretKey(
 			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = false) String userId) throws Exception {
 		if (userId==null) 

--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
@@ -189,17 +189,6 @@ public class AuthenticationController extends BaseController {
 		NewUser user = CrowdAuthUtil.getUser(userId);
 		return user;
 	}
-	
-	// for integration testing
-	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@RequestMapping(value = UrlHelpers.AUTH_USER_PASSWORD_EMAIL, method = RequestMethod.POST)
-	public void deleteNewUser(@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = false) String userId) throws Exception {
-		String itu = getIntegrationTestNewUser();
-		boolean isITU = (itu!=null && userId!=null && userId.equals(itu));
-		if (!isITU) throw new AuthenticationException(HttpStatus.BAD_REQUEST.value(), "Not allowed outside of integration testing.", null);
-		CrowdAuthUtil.deleteUser(userId);
-	}
-	
 
 	// reset == true means send the 'reset' message; reset== false means send the 'set' message
 	private static void sendNewUserPasswordEmail(String userEmail, PW_MODE mode) throws Exception {
@@ -212,13 +201,13 @@ public class AuthenticationController extends BaseController {
 	}
 	
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@RequestMapping(value = UrlHelpers.AUTH_API_PASSWORD_EMAIL, method = RequestMethod.POST)
+	@RequestMapping(value = UrlHelpers.AUTH_USER_PASSWORD_EMAIL, method = RequestMethod.POST)
 	public void sendChangePasswordEmail(@RequestBody NewUser user) throws Exception {
 		sendNewUserPasswordEmail(user.getEmail(), PW_MODE.RESET_PW);
 	}
 	
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@RequestMapping(value = "/apiPasswordEmail", method = RequestMethod.POST)
+	@RequestMapping(value = UrlHelpers.AUTH_API_PASSWORD_EMAIL, method = RequestMethod.POST)
 	public void sendSetAPIPasswordEmail(
 			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM, required = false) String userId) throws Exception {
 		if (userId == null)

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
@@ -227,6 +227,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 		// Don't spam emails for integration tests
 		if (!StackConfiguration.isProductionStack()) {
 			log.debug("Prevented " + mode + " email from being sent to " + mailTarget + " with session token " + sessionToken);
+			return;
 		}
 		
 		SendMail sendMail = new SendMail();

--- a/tools/tool-migration-utility/src/main/java/org/sagebionetworks/tool/migration/v3/StubSynapseAdministration.java
+++ b/tools/tool-migration-utility/src/main/java/org/sagebionetworks/tool/migration/v3/StubSynapseAdministration.java
@@ -71,6 +71,8 @@ import org.sagebionetworks.repo.model.VersionInfo;
 import org.sagebionetworks.repo.model.attachment.AttachmentData;
 import org.sagebionetworks.repo.model.attachment.PresignedUrl;
 import org.sagebionetworks.repo.model.attachment.S3AttachmentToken;
+import org.sagebionetworks.repo.model.auth.NewUser;
+import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.repo.model.auth.UserEntityPermissions;
 import org.sagebionetworks.repo.model.daemon.BackupRestoreStatus;
 import org.sagebionetworks.repo.model.daemon.DaemonStatus;
@@ -303,16 +305,6 @@ public class StubSynapseAdministration implements SynapseAdminClient {
 		return result;
 	}
 
-	private Long maxId(List<RowMetadata> vals) {
-		Long m = vals.get(0).getId();
-		for (RowMetadata v: vals) {
-			if (v.getId() > m) {
-				m = v.getId();
-			}
-		}
-		return m;
-	}
-
 	@Override
 	public MigrationTypeList getPrimaryTypes() throws SynapseException,
 			JSONObjectAdapterException {
@@ -470,6 +462,7 @@ public class StubSynapseAdministration implements SynapseAdminClient {
 	 * @param req
 	 * @return
 	 */
+	@SuppressWarnings("unchecked")
 	private List<RowMetadata> readRestoreFile(RestoreSubmission req) {
 		try {
 			File placeHolder = File.createTempFile("notUsed", ".tmp");
@@ -850,13 +843,6 @@ public class StubSynapseAdministration implements SynapseAdminClient {
 
 
 	@Override
-	public JSONObject getEntity(String uri) throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
 	public Entity getEntityByIdForVersion(String entityId, Long versionNumber)
 			throws SynapseException {
 		// TODO Auto-generated method stub
@@ -1075,43 +1061,13 @@ public class StubSynapseAdministration implements SynapseAdminClient {
 
 
 	@Override
-	public JSONObject updateEntity(String uri, JSONObject entity)
-			throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
 	public <T extends Entity> T putEntity(T entity, String activityId)
 			throws SynapseException {
 		// TODO Auto-generated method stub
 		return null;
 	}
 
-
-	@Override
-	public JSONObject putJSONObject(String uri, JSONObject entity,
-			Map<String, String> headers) throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
-	public JSONObject postUri(String uri) throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
-	public void deleteUri(String uri) throws SynapseException {
-		// TODO Auto-generated method stub
-		
-	}
-
-
+	
 	@Override
 	public <T extends Entity> void deleteEntity(T entity)
 			throws SynapseException {
@@ -1568,86 +1524,6 @@ public class StubSynapseAdministration implements SynapseAdminClient {
 	public S3AttachmentToken createAttachmentS3Token(String id,
 			AttachmentType attachmentType, S3AttachmentToken token)
 			throws JSONObjectAdapterException, SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
-	public JSONObject createAuthEntity(String uri, JSONObject entity)
-			throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
-	public JSONObject getAuthEntity(String uri) throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
-	public JSONObject putAuthEntity(String uri, JSONObject entity)
-			throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
-	public JSONObject createJSONObjectEntity(String endpoint, String uri,
-			JSONObject entity) throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
-	public JSONObject getSynapseEntity(String endpoint, String uri)
-			throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
-	public JSONObject putJSONObject(String endpoint, String uri,
-			JSONObject entity, Map<String, String> headers)
-			throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
-	public JSONObject postUri(String endpoint, String uri)
-			throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
-	public JSONObject querySynapse(String endpoint, String query)
-			throws SynapseException {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-	@Override
-	public void deleteUri(String endpoint, String uri) throws SynapseException {
-		// TODO Auto-generated method stub
-		
-	}
-
-
-	@Override
-	public <T extends JSONEntity> T getJSONEntity(String uri,
-			Class<? extends T> clazz) throws SynapseException,
-			JSONObjectAdapterException {
 		// TODO Auto-generated method stub
 		return null;
 	}
@@ -2333,6 +2209,79 @@ public class StubSynapseAdministration implements SynapseAdminClient {
 	public void updateTeamSearchCache() throws SynapseException {
 		// TODO Auto-generated method stub
 		
+	}
+
+
+	@Override
+	public void logout() throws SynapseException {
+		// TODO Auto-generated method stub
+		
+	}
+
+
+	@Override
+	public void invalidateApiKey() throws SynapseException {
+		// TODO Auto-generated method stub
+		
+	}
+
+
+	@Override
+	public void createUser(NewUser user) throws SynapseException {
+		// TODO Auto-generated method stub
+		
+	}
+
+
+	@Override
+	public NewUser getAuthUserInfo() throws SynapseException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+	@Override
+	public void changePassword(String newPassword) throws SynapseException {
+		// TODO Auto-generated method stub
+		
+	}
+
+
+	@Override
+	public void changePassword(String sessionToken, String newPassword)
+			throws SynapseException {
+		// TODO Auto-generated method stub
+		
+	}
+
+
+	@Override
+	public void changeEmail(String sessionToken, String newPassword)
+			throws SynapseException {
+		// TODO Auto-generated method stub
+		
+	}
+
+
+	@Override
+	public void sendPasswordResetEmail() throws SynapseException {
+		// TODO Auto-generated method stub
+		
+	}
+
+
+	@Override
+	public void sendPasswordResetEmail(String email) throws SynapseException {
+		// TODO Auto-generated method stub
+		
+	}
+
+
+	@Override
+	public Session passThroughOpenIDParameters(String queryString)
+			throws SynapseException {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 }

--- a/tools/tool-migration-utility/src/main/java/org/sagebionetworks/tool/migration/v3/StubSynapseAdministration.java
+++ b/tools/tool-migration-utility/src/main/java/org/sagebionetworks/tool/migration/v3/StubSynapseAdministration.java
@@ -1046,6 +1046,13 @@ public class StubSynapseAdministration implements SynapseAdminClient {
 
 
 	@Override
+	public JSONObject getEntity(String uri) throws SynapseException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+	@Override
 	public <T extends JSONEntity> T getEntity(String entityId,
 			Class<? extends T> clazz) throws SynapseException {
 		// TODO Auto-generated method stub

--- a/tools/usageMetrics/src/main/java/org/sagebionetworks/usagemetrics/GetProjectNames.java
+++ b/tools/usageMetrics/src/main/java/org/sagebionetworks/usagemetrics/GetProjectNames.java
@@ -1,9 +1,8 @@
 package org.sagebionetworks.usagemetrics;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.repo.model.Project;
 
 public class GetProjectNames {
 
@@ -24,25 +23,14 @@ public class GetProjectNames {
 
 	private static void printProjectNames(SynapseClientImpl synapse) {
 		for (String id : projectIds) {
-			JSONObject entity;
+			Project entity;
 			try {
-				entity = synapse.getEntity("/entity/" + id);
+				entity = synapse.getEntity(id, Project.class);
 			} catch (SynapseException e) {
 				continue;
 			}
-			String name;
-			try {
-				name = entity.getString("name");
-			} catch (JSONException e) {
-				continue;
-			}
-			
-			String userName;
-			try {
-				userName = entity.getString("createdBy");
-			} catch (JSONException e) {
-				continue;
-			}
+			String name = entity.getName();
+			String userName = entity.getCreatedBy();
 			
 			System.out.format("Project Id:%s - created by %s - %s%n", id, userName, name);
 		}


### PR DESCRIPTION
Prevents users of the Java client from supplying URIs or URLs to the client

Only getEntity(String uri) will remain, to support the SuperTable feature in the SWC
