### PR TITLE
Authentication Fix

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/IT500SynapseJavaClient.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT500SynapseJavaClient.java
@@ -809,7 +809,7 @@ public class IT500SynapseJavaClient {
 	@Ignore
 	@Test
 	public void testGetUserGroupHeadersByPrefix() throws Exception {
-		UserGroupHeaderResponsePage response = synapse.getUserGroupHeadersByPrefix(StackConfiguration.getIntegrationTestUserOneEmail());
+		UserGroupHeaderResponsePage response = synapse.getUserGroupHeadersByPrefix(StackConfiguration.getIntegrationTestUserOneName());
 		assertTrue(response.getChildren().size() > 0);
 		
 		String dummyPrefix = "INVALIDPREFIX12345@INVALID.COM.WRONG";

--- a/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
@@ -63,7 +63,7 @@ public class IT990AuthenticationController {
 	
 	@Test(expected = SynapseUnauthorizedException.class)
 	public void testCreateSessionNoTermsOfUse() throws Exception {
-		String username = StackConfiguration.getIntegrationTestRejectTermsOfUseEmail();
+		String username = StackConfiguration.getIntegrationTestRejectTermsOfUseName();
 		String password = StackConfiguration.getIntegrationTestRejectTermsOfUsePassword();
 		synapse.login(username, password);
 	}

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImpl.java
@@ -277,10 +277,10 @@ public class DBOAuthenticationDAOImpl implements AuthenticationDAO {
 		} else {
 			String testUsers[] = new String[] { 
 					StackConfiguration.getIntegrationTestUserAdminName(), 
-					StackConfiguration.getIntegrationTestRejectTermsOfUseEmail(), 
-					StackConfiguration.getIntegrationTestUserOneEmail(), 
+					StackConfiguration.getIntegrationTestRejectTermsOfUseName(), 
+					StackConfiguration.getIntegrationTestUserOneName(), 
 					StackConfiguration.getIntegrationTestUserTwoName(), 
-					StackConfiguration.getIntegrationTestUserThreeEmail() };
+					StackConfiguration.getIntegrationTestUserThreeName() };
 			String testPasswords[] = new String[] { 
 					StackConfiguration.getIntegrationTestUserAdminPassword(), 
 					StackConfiguration.getIntegrationTestRejectTermsOfUsePassword(), 
@@ -298,7 +298,7 @@ public class DBOAuthenticationDAOImpl implements AuthenticationDAO {
 		// bootstrapped users should not need to sign the terms of use
 		List<UserGroupInt> ugs = userGroupDAO.getBootstrapUsers();
 		for (UserGroupInt ug : ugs) {
-			if (ug.getIsIndividual() && !ug.getName().equals(StackConfiguration.getIntegrationTestRejectTermsOfUseEmail())
+			if (ug.getIsIndividual() && !ug.getName().equals(StackConfiguration.getIntegrationTestRejectTermsOfUseName())
 					&& !AuthorizationUtils.isUserAnonymous(ug.getName())) {
 				setTermsOfUseAcceptance(ug.getId(), true);
 			}

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOUserGroupDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOUserGroupDAOImpl.java
@@ -397,10 +397,10 @@ public class DBOUserGroupDAOImpl implements UserGroupDAO {
 		if (!StackConfiguration.isProductionStack()) {
 			String testUsers[] = new String[]{ 
 					StackConfiguration.getIntegrationTestUserAdminName(), 
-					StackConfiguration.getIntegrationTestRejectTermsOfUseEmail(), 
-					StackConfiguration.getIntegrationTestUserOneEmail(), 
+					StackConfiguration.getIntegrationTestRejectTermsOfUseName(), 
+					StackConfiguration.getIntegrationTestUserOneName(), 
 					StackConfiguration.getIntegrationTestUserTwoName(), 
-					StackConfiguration.getIntegrationTestUserThreeEmail(), 
+					StackConfiguration.getIntegrationTestUserThreeName(), 
 					AuthorizationConstants.ADMIN_USER_NAME, 
 					AuthorizationConstants.TEST_GROUP_NAME, 
 					AuthorizationConstants.TEST_USER_NAME };

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImplTest.java
@@ -243,10 +243,10 @@ public class DBOAuthenticationDAOImplTest {
 		if (!StackConfiguration.isProductionStack()) {
 			String testUsers[] = new String[] { 
 					StackConfiguration.getIntegrationTestUserAdminName(), 
-					StackConfiguration.getIntegrationTestRejectTermsOfUseEmail(), 
-					StackConfiguration.getIntegrationTestUserOneEmail(), 
+					StackConfiguration.getIntegrationTestRejectTermsOfUseName(), 
+					StackConfiguration.getIntegrationTestUserOneName(), 
 					StackConfiguration.getIntegrationTestUserTwoName(), 
-					StackConfiguration.getIntegrationTestUserThreeEmail() };
+					StackConfiguration.getIntegrationTestUserThreeName() };
 			String testPasswords[] = new String[] { 
 					StackConfiguration.getIntegrationTestUserAdminPassword(), 
 					StackConfiguration.getIntegrationTestRejectTermsOfUsePassword(), 
@@ -263,7 +263,7 @@ public class DBOAuthenticationDAOImplTest {
 		List<UserGroupInt> ugs = userGroupDAO.getBootstrapUsers();
 		for (UserGroupInt ug : ugs) {
 			if (ug.getIsIndividual() 
-					&& !ug.getName().equals(StackConfiguration.getIntegrationTestRejectTermsOfUseEmail())
+					&& !ug.getName().equals(StackConfiguration.getIntegrationTestRejectTermsOfUseName())
 					&& !AuthorizationUtils.isUserAnonymous(ug.getName())) {
 				MapSqlParameterSource param = new MapSqlParameterSource();
 				param.addValue("principalId", ug.getId());

--- a/lib/stackConfiguration/src/main/java/org/sagebionetworks/StackConfiguration.java
+++ b/lib/stackConfiguration/src/main/java/org/sagebionetworks/StackConfiguration.java
@@ -417,15 +417,7 @@ public class StackConfiguration {
 		return configuration
 				.getProperty("org.sagebionetworks.integration.test.username.one");
 	}
-
-	/**
-	 * @return The name of a user for integration tests
-	 */
-	public static String getIntegrationTestUserOneEmail() {
-		return configuration
-				.getProperty("org.sagebionetworks.integration.test.email.one");
-	}
-
+	
 	/**
 	 * @return The password of a user for integration tests
 	 */
@@ -456,14 +448,6 @@ public class StackConfiguration {
 	public static String getIntegrationTestUserThreeName() {
 		return configuration
 				.getProperty("org.sagebionetworks.integration.test.username.three");
-	}
-
-	/**
-	 * @return The name of a user for integration tests
-	 */
-	public static String getIntegrationTestUserThreeEmail() {
-		return configuration
-				.getProperty("org.sagebionetworks.integration.test.email.three");
 	}
 
 	/**
@@ -504,14 +488,6 @@ public class StackConfiguration {
 	public static String getIntegrationTestRejectTermsOfUseName() {
 		return configuration
 				.getProperty("org.sagebionetworks.integration.test.username.rejecttermsofuse");
-	}
-
-	/**
-	 * @return The name of a user for integration tests
-	 */
-	public static String getIntegrationTestRejectTermsOfUseEmail() {
-		return configuration
-				.getProperty("org.sagebionetworks.integration.test.email.rejecttermsofuse");
 	}
 
 	/**

--- a/lib/stackConfiguration/src/main/resources/stack.properties
+++ b/lib/stackConfiguration/src/main/resources/stack.properties
@@ -91,20 +91,16 @@ org.sagebionetworks.migration.admin.apikey=lfWE6qgpUl9KPuysyygjg2NhuVOfM3oV
 
 org.sagebionetworks.integration.test.username.one=devUser1@sagebase.org
 org.sagebionetworks.integration.test.password.one=password
-org.sagebionetworks.integration.test.email.one=devUser1@sagebase.org
 
 org.sagebionetworks.integration.test.username.two=devUser2@sagebase.org
 org.sagebionetworks.integration.test.password.two=password
-org.sagebionetworks.integration.test.email.two=devUser2@sagebase.org
 
 org.sagebionetworks.integration.test.username.three=integration.test@sagebase.org
 org.sagebionetworks.integration.test.password.three=password
-org.sagebionetworks.integration.test.email.three=integration.test@sagebase.org
 org.sagebionetworks.integration.test.displayname.three=dev usr3
 
 org.sagebionetworks.integration.test.username.rejecttermsofuse=rejecttermsofuse.integration.test@sagebase.org
 org.sagebionetworks.integration.test.password.rejecttermsofuse=password
-org.sagebionetworks.integration.test.email.rejecttermsofuse=rejecttermsofuse.integration.test@sagebase.org
 
 org.sagebionetworks.integration.test.username.admin=devUserAdmin@sagebase.org
 org.sagebionetworks.integration.test.password.admin=password

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/EntityPermissionsManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/EntityPermissionsManagerImplTest.java
@@ -155,7 +155,7 @@ public class EntityPermissionsManagerImplTest {
 		acl.setId("resource id");
 		
 		// Should fail, since user is not included with proper permissions in ACL
-		UserInfo otherUserInfo = userManager.getUserInfo(StackConfiguration.getIntegrationTestUserOneEmail());
+		UserInfo otherUserInfo = userManager.getUserInfo(StackConfiguration.getIntegrationTestUserOneName());
 		PermissionsManagerUtils.validateACLContent(acl, otherUserInfo, ownerId);
 	}
 
@@ -194,7 +194,7 @@ public class EntityPermissionsManagerImplTest {
 		acl.setResourceAccess(ras);	
 		
 		// Should fail since user does not have permission editing rights in ACL
-		UserInfo otherUserInfo = userManager.getUserInfo(StackConfiguration.getIntegrationTestUserOneEmail());
+		UserInfo otherUserInfo = userManager.getUserInfo(StackConfiguration.getIntegrationTestUserOneName());
 		PermissionsManagerUtils.validateACLContent(acl, otherUserInfo, ownerId);
 	}
 

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/AdministrationControllerTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/AdministrationControllerTest.java
@@ -140,6 +140,6 @@ public class AdministrationControllerTest {
 		extraParams.put("limit", "10");
 		
 		// Not an admin, so this should fail with a 403
-		ServletTestHelper.migrateFromCrowd(dispatchServlet, StackConfiguration.getIntegrationTestUserOneEmail(), extraParams);
+		ServletTestHelper.migrateFromCrowd(dispatchServlet, StackConfiguration.getIntegrationTestUserOneName(), extraParams);
 	}
 }

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/S3TokenControllerTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/S3TokenControllerTest.java
@@ -55,7 +55,7 @@ public class S3TokenControllerTest {
 
 	private UserGroup testUser;
 	private static final String TEST_USER1 = AuthorizationConstants.TEST_USER_NAME;
-	private static final String TEST_USER2 = StackConfiguration.getIntegrationTestUserOneEmail();
+	private static final String TEST_USER2 = StackConfiguration.getIntegrationTestUserOneName();
 	private static final String TEST_MD5 = "4053f00b39aae693a6969f37102e2764";
 
 	private Project project;

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/StepControllerTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/StepControllerTest.java
@@ -53,7 +53,7 @@ public class StepControllerTest {
 	private UserGroupDAO userGroupDAO;
 
 	private static final String TEST_USER1 = AuthorizationConstants.TEST_USER_NAME;
-	private static final String TEST_USER2 = StackConfiguration.getIntegrationTestUserOneEmail();
+	private static final String TEST_USER2 = StackConfiguration.getIntegrationTestUserOneName();
 	
 	private Project project;
 	private Study dataset;


### PR DESCRIPTION
Perhaps the build problem is due to configuration.  Since there's no problem in the bootstrapping, the 5 integration test users probably exist.  However, there are duplicate entries for "name" and "email" in the configuration.  If either is misspelled or different, then a test might fail.  

I'm guessing that, in Hudson's configuration, IT-user 3's email and name are different.  This change forces all code to use the "name" rather than "email", which should be the same anyway.  
