### PR TITLE
Accept ToU via session token (for OpenID)

### DIFF
--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -952,7 +952,7 @@ public interface SynapseClient {
 	public void createUser(NewUser user) throws SynapseException;
 	
 	/**
-	 * 
+	 * Accepts the terms of use for the given user, as identified by a session token
 	 */
 	public void acceptTermsOfUse(Session session) throws SynapseException;
 

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -950,6 +950,11 @@ public interface SynapseClient {
 	 * Creates a user
 	 */
 	public void createUser(NewUser user) throws SynapseException;
+	
+	/**
+	 * 
+	 */
+	public void acceptTermsOfUse(Session session) throws SynapseException;
 
 	/**
 	 * Retrieves the bare-minimum amount of information about the current user

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
@@ -4810,6 +4810,16 @@ public class SynapseClientImpl implements SynapseClient {
 			throw new SynapseException(e);
 		}
 	}
+
+	@Override
+	public void acceptTermsOfUse(Session session) throws SynapseException {
+		try {
+			JSONObject obj = EntityFactory.createJSONObjectForEntity(session);
+			createAuthEntity("/termsOfUse", obj);
+		} catch (JSONObjectAdapterException e) {
+			throw new SynapseException(e);
+		}
+	}
 	
 	@Override
 	public NewUser getAuthUserInfo() throws SynapseException {

--- a/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
+import org.sagebionetworks.client.exceptions.SynapseTermsOfUseException;
 import org.sagebionetworks.client.exceptions.SynapseUnauthorizedException;
 import org.sagebionetworks.repo.model.auth.NewUser;
 import org.sagebionetworks.repo.model.auth.Session;
@@ -61,7 +62,7 @@ public class IT990AuthenticationController {
 		synapse.login(username, "incorrectPassword");
 	}
 	
-	@Test(expected = SynapseUnauthorizedException.class)
+	@Test(expected = SynapseTermsOfUseException.class)
 	public void testCreateSessionNoTermsOfUse() throws Exception {
 		String username = StackConfiguration.getIntegrationTestRejectTermsOfUseName();
 		String password = StackConfiguration.getIntegrationTestRejectTermsOfUsePassword();
@@ -118,9 +119,7 @@ public class IT990AuthenticationController {
 		try {
 			synapse.login(username, password);
 			fail();
-		} catch (SynapseUnauthorizedException e) { 
-			assertTrue(e.getMessage().contains("Terms of Use"));
-		}
+		} catch (SynapseTermsOfUseException e) { }
 		
 		// Now accept the terms and get a session token
 		synapse.login(username, password, true);

--- a/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
@@ -22,6 +22,7 @@ import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.client.exceptions.SynapseUnauthorizedException;
 import org.sagebionetworks.repo.model.auth.NewUser;
+import org.sagebionetworks.repo.model.auth.Session;
 
 public class IT990AuthenticationController {
 	private static SynapseClient synapse;
@@ -292,5 +293,13 @@ public class IT990AuthenticationController {
 		} catch (SynapseUnauthorizedException e) {
 			assertTrue(e.getMessage().contains("Required parameter missing"));
 		}
+	}
+	
+	@Test
+	public void testAcceptTermsViaSessionToken() throws Exception {
+		Session session = new Session();
+		session.setSessionToken(synapse.getCurrentSessionToken());
+		
+		synapse.acceptTermsOfUse(session);
 	}
 }

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImpl.java
@@ -83,10 +83,12 @@ public class DBOAuthenticationDAOImpl implements AuthenticationDAO {
 					SqlConstants.COL_CREDENTIAL_SESSION_TOKEN+"=NULL"+
 			" WHERE "+SqlConstants.COL_CREDENTIAL_SESSION_TOKEN+"=:"+TOKEN_PARAM_NAME;
 	
-	private static final String SELECT_PRINCIPAL_BY_TOKEN_IF_VALID = 
+	private static final String SELECT_PRINCIPAL_BY_TOKEN = 
 			"SELECT "+SqlConstants.COL_CREDENTIAL_PRINCIPAL_ID+" FROM "+SqlConstants.TABLE_CREDENTIAL+
-			" WHERE "+SqlConstants.COL_CREDENTIAL_SESSION_TOKEN+"=:"+TOKEN_PARAM_NAME+
-				IF_VALID_SUFFIX;
+			" WHERE "+SqlConstants.COL_CREDENTIAL_SESSION_TOKEN+"=:"+TOKEN_PARAM_NAME;
+	
+	private static final String SELECT_PRINCIPAL_BY_TOKEN_IF_VALID = 
+			SELECT_PRINCIPAL_BY_TOKEN+IF_VALID_SUFFIX;
 	
 	private static final String SELECT_PASSWORD = 
 			"SELECT "+SqlConstants.COL_CREDENTIAL_PASS_HASH+
@@ -189,9 +191,20 @@ public class DBOAuthenticationDAOImpl implements AuthenticationDAO {
 		param.addValue(TOKEN_PARAM_NAME, sessionToken);
 		simpleJdbcTemplate.update(NULLIFY_SESSION_TOKEN, param);
 	}
+
+	@Override
+	public Long getPrincipal(String sessionToken) {
+		MapSqlParameterSource param = new MapSqlParameterSource();
+		param.addValue(TOKEN_PARAM_NAME, sessionToken);
+		
+		try {
+			return simpleJdbcTemplate.queryForLong(SELECT_PRINCIPAL_BY_TOKEN, param); 
+		} catch (EmptyResultDataAccessException e) {
+			return null;
+		}
+	}
 	
 	@Override
-	@Transactional(readOnly=false, propagation=Propagation.REQUIRED)
 	public Long getPrincipalIfValid(String sessionToken) {
 		MapSqlParameterSource param = new MapSqlParameterSource();
 		param.addValue(TOKEN_PARAM_NAME, sessionToken);

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImplTest.java
@@ -120,6 +120,10 @@ public class DBOAuthenticationDAOImplTest {
 		Long id = authDAO.getPrincipalIfValid(secretRow.getSessionToken());
 		assertEquals(secretRow.getPrincipalId(), id);
 		
+		// Get by token, without restrictions
+		Long principalId = authDAO.getPrincipal(secretRow.getSessionToken());
+		assertEquals(secretRow.getPrincipalId(), principalId);
+		
 		// Delete
 		authDAO.deleteSessionToken(secretRow.getSessionToken());
 		session = authDAO.getSessionTokenIfValid(GROUP_NAME);

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthenticationDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthenticationDAO.java
@@ -43,6 +43,12 @@ public interface AuthenticationDAO {
 	
 	/**
 	 * Looks for the given session token
+	 * @return The principal ID of the holder
+	 */
+	public Long getPrincipal(String sessionToken);
+	
+	/**
+	 * Looks for the given valid session token
 	 * @return The principal ID of the holder, or null if the token is invalid
 	 */
 	public Long getPrincipalIfValid(String sessionToken);

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/TermsOfUseException.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/TermsOfUseException.java
@@ -1,0 +1,10 @@
+package org.sagebionetworks.repo.model;
+
+public class TermsOfUseException extends RuntimeException {
+	
+	private static final long serialVersionUID = 1L;
+
+	public TermsOfUseException() {
+		super(ServiceConstants.TERMS_OF_USE_ERROR_MESSAGE);
+	}
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManager.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.repo.manager;
 
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.repo.web.NotFoundException;
@@ -17,8 +18,9 @@ public interface AuthenticationManager {
 	 * Looks for the given session token
 	 * @return The principal ID of the holder
 	 * @throws UnauthorizedException If the token is not valid
+	 * @throws TermsOfUseException If the user has not signed the terms of use
 	 */
-	public Long checkSessionToken(String sessionToken) throws UnauthorizedException;
+	public Long checkSessionToken(String sessionToken) throws UnauthorizedException, TermsOfUseException;
 	
 	/**
 	 * Deletes the given session token, thereby invalidating it

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManager.java
@@ -15,6 +15,12 @@ public interface AuthenticationManager {
 	public Session authenticate(String email, String password) throws NotFoundException;
 	
 	/**
+	 * Looks for the user holding the given session token
+	 * @throws UnauthorizedException If the token has expired
+	 */
+	public Long getPrincipalId(String sessionToken) throws UnauthorizedException;
+	
+	/**
 	 * Looks for the given session token
 	 * @return The principal ID of the holder
 	 * @throws UnauthorizedException If the token is not valid

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManagerImpl.java
@@ -45,6 +45,15 @@ public class AuthenticationManagerImpl implements AuthenticationManager {
 	}
 	
 	@Override
+	public Long getPrincipalId(String sessionToken) throws UnauthorizedException {
+		Long principalId = authDAO.getPrincipal(sessionToken);
+		if (principalId == null) {
+			throw new UnauthorizedException("The session token (" + sessionToken + ") has expired");
+		}
+		return principalId;
+	}
+	
+	@Override
 	public Long checkSessionToken(String sessionToken) throws UnauthorizedException, TermsOfUseException {
 		Long principalId = authDAO.getPrincipalIfValid(sessionToken);
 		if (principalId == null) {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManagerImpl.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.repo.manager;
 
 import org.sagebionetworks.repo.model.AuthenticationDAO;
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserGroupDAO;
@@ -44,10 +45,18 @@ public class AuthenticationManagerImpl implements AuthenticationManager {
 	}
 	
 	@Override
-	public Long checkSessionToken(String sessionToken) throws UnauthorizedException {
+	public Long checkSessionToken(String sessionToken) throws UnauthorizedException, TermsOfUseException {
 		Long principalId = authDAO.getPrincipalIfValid(sessionToken);
 		if (principalId == null) {
-			throw new UnauthorizedException("The session token (" + sessionToken + ") is invalid");
+			// Check to see why the token is invalid
+			Long userId = authDAO.getPrincipal(sessionToken);
+			if (userId == null) {
+				throw new UnauthorizedException("The session token (" + sessionToken + ") is invalid");
+			}
+			if (!authDAO.hasUserAcceptedToU(userId.toString())) {
+				throw new TermsOfUseException();
+			}
+			throw new UnauthorizedException("The session token (" + sessionToken + ") has expired");
 		}
 		return principalId;
 	}

--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
@@ -82,6 +82,12 @@ public class AuthenticationController extends BaseController {
 		return user;
 	}
 	
+	@ResponseStatus(HttpStatus.OK)
+	@RequestMapping(value = UrlHelpers.AUTH_ACCEPT_TERMS_OF_USE, method = RequestMethod.POST)
+	public void acceptTermsOfUse(@RequestBody Session session) throws NotFoundException {
+		authenticationService.acceptTermsOfUse(session);
+	}
+	
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@RequestMapping(value = UrlHelpers.AUTH_USER_PASSWORD_EMAIL, method = RequestMethod.POST)
 	public void sendChangePasswordEmail(@RequestBody NewUser credential)

--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationFilter.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationFilter.java
@@ -21,10 +21,13 @@ import org.joda.time.Minutes;
 import org.sagebionetworks.auth.services.AuthenticationService;
 import org.sagebionetworks.authutil.ModParamHttpServletRequest;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.securitytools.HMACUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import com.atlassian.httpclient.api.HttpStatus;
 
 /**
  * This filter authenticates incoming requests:
@@ -55,7 +58,11 @@ public class AuthenticationFilter implements Filter {
 	public void destroy() { }
 	
 	private static void reject(HttpServletRequest req, HttpServletResponse resp, String reason) throws IOException {
-		resp.setStatus(401);
+		reject(req, resp, reason, HttpStatus.UNAUTHORIZED);
+	}
+	
+	private static void reject(HttpServletRequest req, HttpServletResponse resp, String reason, HttpStatus status) throws IOException {
+		resp.setStatus(status.code);
 
 		// This header is required according to RFC-2612
 		// See: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2
@@ -84,10 +91,20 @@ public class AuthenticationFilter implements Filter {
 			try {
 				String userId = authenticationService.revalidate(sessionToken);
 				username = authenticationService.getUsername(userId);
-			} catch (Exception xee) {
-				String reason = "The session token is invalid.";
+			} catch (TermsOfUseException e) {
+				String reason = "Terms of use have not been signed";
+				reject(req, (HttpServletResponse) servletResponse, reason, HttpStatus.FORBIDDEN);
+				log.warn("Session token used without signing terms of use", e);
+				return;
+			} catch (UnauthorizedException e) {
+				String reason = "The session token is invalid";
 				reject(req, (HttpServletResponse) servletResponse, reason);
-				log.warn("invalid session token", xee);
+				log.warn("Invalid session token", e);
+				return;
+			} catch (NotFoundException e) {
+				String reason = "The session token is invalid";
+				reject(req, (HttpServletResponse) servletResponse, reason);
+				log.warn("Invalid session token", e);
 				return;
 			}
 		

--- a/services/repository/src/main/java/org/sagebionetworks/auth/BaseController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/BaseController.java
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.error.ErrorResponse;
 import org.sagebionetworks.repo.web.NotFoundException;
@@ -49,6 +50,23 @@ public class BaseController {
 	@ResponseStatus(HttpStatus.UNAUTHORIZED)
 	public @ResponseBody
 	ErrorResponse handleForbiddenException(UnauthorizedException ex,
+			HttpServletRequest request,
+			HttpServletResponse response) {
+		return handleException(ex, request, false);
+	}
+	
+	/**
+	 * This is thrown when the user has not accepted the terms of use
+	 * 
+	 * @param request
+	 *            the client request
+	 * @return an ErrorResponse object containing the exception reason or some
+	 *         other human-readable response
+	 */
+	@ExceptionHandler(TermsOfUseException.class)
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	public @ResponseBody
+	ErrorResponse handleTermsOfUseException(TermsOfUseException ex,
 			HttpServletRequest request,
 			HttpServletResponse response) {
 		return handleException(ex, request, false);

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
@@ -1,9 +1,7 @@
 package org.sagebionetworks.auth.services;
 
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
-
 import org.openid4java.message.ParameterList;
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.NewUser;
@@ -25,7 +23,7 @@ public interface AuthenticationService {
 	 * Authenticates a user/password combination, returning a session token if valid
 	 * @throws UnauthorizedException If the credentials are incorrect
 	 */
-	public Session authenticate(NewUser credential) throws NotFoundException, UnauthorizedException;
+	public Session authenticate(NewUser credential) throws NotFoundException, UnauthorizedException, TermsOfUseException;
 	
 	/**
 	 * Revalidates a session token and checks whether the user has accepted the terms of use
@@ -67,14 +65,14 @@ public interface AuthenticationService {
 	 * Changes the password of the user
 	 */
 	public void changePassword(String username, String newPassword)
-			throws NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException;
+			throws NotFoundException;
 	
 	/**
 	 * Changes the email of a user to another email
 	 * Simultaneously changes the user's password
 	 */
 	public void updateEmail(String oldEmail, RegistrationInfo registrationInfo)
-			throws NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException;
+			throws NotFoundException;
 	
 	/**
 	 * Gets the current secret key of the user

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
@@ -38,6 +38,11 @@ public interface AuthenticationService {
 	 * Invalidates a session token
 	 */
 	public void invalidateSessionToken(String sessionToken);
+	
+	/**
+	 * Marks the user, as identified by the token, as having accepted the terms of use
+	 */
+	public void acceptTermsOfUse(Session session) throws NotFoundException;
 
 	/**
 	 * Returns whether the given user has accepted the most recent terms of use

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
@@ -85,7 +85,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 			throw new IllegalArgumentException("Session token may not be null");
 		}
 		String sessionToken = session.getSessionToken();
-		Long userId = authManager.checkSessionToken(sessionToken);
+		Long userId = authManager.getPrincipalId(sessionToken);
 		String username = userManager.getGroupName(userId.toString());
 		handleTermsOfUse(username, true);
 	}

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
@@ -15,7 +15,6 @@ import org.sagebionetworks.repo.manager.AuthenticationManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.DatastoreException;
-import org.sagebionetworks.repo.model.ServiceConstants;
 import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
@@ -67,9 +66,6 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 	@Transactional(readOnly = false, propagation = Propagation.REQUIRED)
 	public String revalidate(String sessionToken) throws NotFoundException {
 		Long userId = authManager.checkSessionToken(sessionToken);
-		if (!hasUserAcceptedTermsOfUse(userId.toString())) {
-			throw new UnauthorizedException(ServiceConstants.TERMS_OF_USE_ERROR_MESSAGE);
-		}
 		return userId.toString();
 	}
 

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
@@ -668,6 +668,7 @@ public class UrlHelpers {
 	public static final String AUTH_SESSION = "/session";
 	public static final String AUTH_SESSION_PORTAL = AUTH_SESSION + "/portal";
 	public static final String AUTH_USER = "/user";
+	public static final String AUTH_ACCEPT_TERMS_OF_USE = "/termsOfUse";
 	public static final String AUTH_USER_PASSWORD_EMAIL = "/userPasswordEmail";
 	public static final String AUTH_API_PASSWORD_EMAIL = "/apiPasswordEmail";
 	public static final String AUTH_USER_PASSWORD = "/userPassword";

--- a/services/repository/src/test/java/org/sagebionetworks/auth/services/AuthenticationServiceImplTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/services/AuthenticationServiceImplTest.java
@@ -19,22 +19,20 @@ import org.sagebionetworks.authutil.OpenIDConsumerUtils;
 import org.sagebionetworks.authutil.OpenIDInfo;
 import org.sagebionetworks.repo.manager.AuthenticationManager;
 import org.sagebionetworks.repo.manager.UserManager;
-import org.sagebionetworks.repo.manager.UserProfileManager;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.User;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserInfo;
-import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.auth.NewUser;
 import org.sagebionetworks.repo.model.auth.RegistrationInfo;
+import org.sagebionetworks.repo.model.auth.Session;
 
 public class AuthenticationServiceImplTest {
 
 	private AuthenticationServiceImpl service;
 	
 	private UserManager mockUserManager;
-	private UserProfileManager mockUserProfileManager;
 	private AuthenticationManager mockAuthenticationManager;
 	
 	private NewUser credential;
@@ -62,13 +60,10 @@ public class AuthenticationServiceImplTest {
 		when(mockUserManager.getUserInfo(eq(username))).thenReturn(userInfo);
 		when(mockUserManager.getGroupName(anyString())).thenReturn(username);
 		
-		mockUserProfileManager = Mockito.mock(UserProfileManager.class);
-		when(mockUserProfileManager.getUserProfile(any(UserInfo.class), anyString())).thenReturn(new UserProfile());
-		
 		mockAuthenticationManager = Mockito.mock(AuthenticationManager.class);
 		when(mockAuthenticationManager.checkSessionToken(eq(sessionToken))).thenReturn(userId);
 		
-		service = new AuthenticationServiceImpl(mockUserManager, mockUserProfileManager, mockAuthenticationManager);
+		service = new AuthenticationServiceImpl(mockUserManager, mockAuthenticationManager);
 	}
 	
 	@Test
@@ -80,7 +75,6 @@ public class AuthenticationServiceImplTest {
 		service.authenticate(credential);
 		verify(mockAuthenticationManager).authenticate(eq(username), eq(password));
 		verify(mockUserManager).getUserInfo(anyString());
-		verify(mockUserProfileManager, times(0)).updateUserProfile(eq(userInfo), any(UserProfile.class));
 		verify(mockAuthenticationManager).setTermsOfUseAcceptance(eq("" + userId), eq(true));
 		
 	}
@@ -134,7 +128,6 @@ public class AuthenticationServiceImplTest {
 		verify(mockUserManager, times(0)).createUser(any(NewUser.class));
 		verify(mockAuthenticationManager).authenticate(eq(username), eq((String) null));
 		verify(mockUserManager).getUserInfo(anyString());
-		verify(mockUserProfileManager, times(0)).updateUserProfile(eq(userInfo), any(UserProfile.class));
 		verify(mockAuthenticationManager).setTermsOfUseAcceptance(eq("" + userId), eq(true));
 	}
 	
@@ -148,5 +141,15 @@ public class AuthenticationServiceImplTest {
 		service.updateEmail(username, registrationInfo);
 		verify(mockUserManager, times(3)).getUserInfo(eq(username));
 		verify(mockUserManager).updateEmail(eq(userInfo), eq(username));
+	}
+	
+	@Test
+	public void testAcceptTermsOfUse() throws Exception {
+		userInfo.getUser().setAgreesToTermsOfUse(false);
+		Session session = new Session();
+		session.setSessionToken(sessionToken);
+		
+		service.acceptTermsOfUse(session);
+		verify(mockAuthenticationManager).setTermsOfUseAcceptance(eq("" + userId), eq(true));
 	}
 }

--- a/services/repository/src/test/java/org/sagebionetworks/auth/services/AuthenticationServiceImplTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/services/AuthenticationServiceImplTest.java
@@ -20,6 +20,7 @@ import org.sagebionetworks.authutil.OpenIDInfo;
 import org.sagebionetworks.repo.manager.AuthenticationManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.User;
 import org.sagebionetworks.repo.model.UserGroup;
@@ -79,7 +80,7 @@ public class AuthenticationServiceImplTest {
 		
 	}
 	
-	@Test(expected=UnauthorizedException.class)
+	@Test(expected=TermsOfUseException.class)
 	public void testAuthenticateToUFail() throws Exception {
 		// ToU checking should fail
 		credential.setAcceptsTermsOfUse(false);

--- a/tools/tool-migration-utility/src/main/java/org/sagebionetworks/tool/migration/v3/StubSynapseAdministration.java
+++ b/tools/tool-migration-utility/src/main/java/org/sagebionetworks/tool/migration/v3/StubSynapseAdministration.java
@@ -2299,4 +2299,11 @@ public class StubSynapseAdministration implements SynapseAdminClient {
 		return null;
 	}
 
+
+	@Override
+	public void acceptTermsOfUse(Session session) throws SynapseException {
+		// TODO Auto-generated method stub
+		
+	}
+
 }


### PR DESCRIPTION
Adds a new way to accept the terms of use via a session token.  This works only if you get a session token via OpenID (because other approaches will throw an error before you get the token).

Also adds an exception class for ToU, so that it can be mapped to 403's.  
