### PR TITLE
Throw 403 for ToU exceptions

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
+import org.sagebionetworks.client.exceptions.SynapseTermsOfUseException;
 import org.sagebionetworks.client.exceptions.SynapseUnauthorizedException;
 import org.sagebionetworks.repo.model.auth.NewUser;
 
@@ -60,7 +61,7 @@ public class IT990AuthenticationController {
 		synapse.login(username, "incorrectPassword");
 	}
 	
-	@Test(expected = SynapseUnauthorizedException.class)
+	@Test(expected = SynapseTermsOfUseException.class)
 	public void testCreateSessionNoTermsOfUse() throws Exception {
 		String username = StackConfiguration.getIntegrationTestRejectTermsOfUseName();
 		String password = StackConfiguration.getIntegrationTestRejectTermsOfUsePassword();
@@ -117,9 +118,7 @@ public class IT990AuthenticationController {
 		try {
 			synapse.login(username, password);
 			fail();
-		} catch (SynapseUnauthorizedException e) { 
-			assertTrue(e.getMessage().contains("Terms of Use"));
-		}
+		} catch (SynapseTermsOfUseException e) { }
 		
 		// Now accept the terms and get a session token
 		synapse.login(username, password, true);

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImpl.java
@@ -83,10 +83,12 @@ public class DBOAuthenticationDAOImpl implements AuthenticationDAO {
 					SqlConstants.COL_CREDENTIAL_SESSION_TOKEN+"=NULL"+
 			" WHERE "+SqlConstants.COL_CREDENTIAL_SESSION_TOKEN+"=:"+TOKEN_PARAM_NAME;
 	
-	private static final String SELECT_PRINCIPAL_BY_TOKEN_IF_VALID = 
+	private static final String SELECT_PRINCIPAL_BY_TOKEN = 
 			"SELECT "+SqlConstants.COL_CREDENTIAL_PRINCIPAL_ID+" FROM "+SqlConstants.TABLE_CREDENTIAL+
-			" WHERE "+SqlConstants.COL_CREDENTIAL_SESSION_TOKEN+"=:"+TOKEN_PARAM_NAME+
-				IF_VALID_SUFFIX;
+			" WHERE "+SqlConstants.COL_CREDENTIAL_SESSION_TOKEN+"=:"+TOKEN_PARAM_NAME;
+	
+	private static final String SELECT_PRINCIPAL_BY_TOKEN_IF_VALID = 
+			SELECT_PRINCIPAL_BY_TOKEN+IF_VALID_SUFFIX;
 	
 	private static final String SELECT_PASSWORD = 
 			"SELECT "+SqlConstants.COL_CREDENTIAL_PASS_HASH+
@@ -189,9 +191,20 @@ public class DBOAuthenticationDAOImpl implements AuthenticationDAO {
 		param.addValue(TOKEN_PARAM_NAME, sessionToken);
 		simpleJdbcTemplate.update(NULLIFY_SESSION_TOKEN, param);
 	}
+
+	@Override
+	public Long getPrincipal(String sessionToken) {
+		MapSqlParameterSource param = new MapSqlParameterSource();
+		param.addValue(TOKEN_PARAM_NAME, sessionToken);
+		
+		try {
+			return simpleJdbcTemplate.queryForLong(SELECT_PRINCIPAL_BY_TOKEN, param); 
+		} catch (EmptyResultDataAccessException e) {
+			return null;
+		}
+	}
 	
 	@Override
-	@Transactional(readOnly=false, propagation=Propagation.REQUIRED)
 	public Long getPrincipalIfValid(String sessionToken) {
 		MapSqlParameterSource param = new MapSqlParameterSource();
 		param.addValue(TOKEN_PARAM_NAME, sessionToken);

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImplTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.After;
 import org.junit.Before;
@@ -25,6 +26,7 @@ import org.sagebionetworks.repo.model.UserGroupInt;
 import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.repo.model.dbo.DBOBasicDao;
 import org.sagebionetworks.repo.model.dbo.persistence.DBOCredential;
+import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.securitytools.PBKDF2Utils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -217,6 +219,11 @@ public class DBOAuthenticationDAOImplTest {
 		// Compare the salts
 		byte[] passedSalt = authDAO.getPasswordSalt(GROUP_NAME);
 		assertArrayEquals(salt, passedSalt);
+	}
+	
+	@Test(expected=NotFoundException.class)
+	public void testGetPasswordSalt_InvalidUser() throws Exception {
+		authDAO.getPasswordSalt("Blarg" + UUID.randomUUID());
 	}
 	
 	@Test

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImplTest.java
@@ -120,6 +120,10 @@ public class DBOAuthenticationDAOImplTest {
 		Long id = authDAO.getPrincipalIfValid(secretRow.getSessionToken());
 		assertEquals(secretRow.getPrincipalId(), id);
 		
+		// Get by token, without restrictions
+		Long principalId = authDAO.getPrincipal(secretRow.getSessionToken());
+		assertEquals(secretRow.getPrincipalId(), principalId);
+		
 		// Delete
 		authDAO.deleteSessionToken(secretRow.getSessionToken());
 		session = authDAO.getSessionTokenIfValid(GROUP_NAME);

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthenticationDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthenticationDAO.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.repo.model;
 
 import org.sagebionetworks.repo.model.auth.Session;
+import org.sagebionetworks.repo.web.NotFoundException;
 
 /**
  * Note: These methods assume that all users have a row in the appropriate table, 
@@ -56,7 +57,7 @@ public interface AuthenticationDAO {
 	/**
 	 * Returns the salt used to hash the user's password
 	 */
-	public byte[] getPasswordSalt(String username);
+	public byte[] getPasswordSalt(String username) throws NotFoundException;
 	
 	/**
 	 * Changes a user's password

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthenticationDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthenticationDAO.java
@@ -43,6 +43,12 @@ public interface AuthenticationDAO {
 	
 	/**
 	 * Looks for the given session token
+	 * @return The principal ID of the holder
+	 */
+	public Long getPrincipal(String sessionToken);
+	
+	/**
+	 * Looks for the given valid session token
 	 * @return The principal ID of the holder, or null if the token is invalid
 	 */
 	public Long getPrincipalIfValid(String sessionToken);

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/TermsOfUseException.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/TermsOfUseException.java
@@ -1,0 +1,10 @@
+package org.sagebionetworks.repo.model;
+
+public class TermsOfUseException extends RuntimeException {
+	
+	private static final long serialVersionUID = 1L;
+
+	public TermsOfUseException() {
+		super(ServiceConstants.TERMS_OF_USE_ERROR_MESSAGE);
+	}
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManager.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.repo.manager;
 
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.repo.web.NotFoundException;
@@ -17,8 +18,9 @@ public interface AuthenticationManager {
 	 * Looks for the given session token
 	 * @return The principal ID of the holder
 	 * @throws UnauthorizedException If the token is not valid
+	 * @throws TermsOfUseException If the user has not signed the terms of use
 	 */
-	public Long checkSessionToken(String sessionToken) throws UnauthorizedException;
+	public Long checkSessionToken(String sessionToken) throws UnauthorizedException, TermsOfUseException;
 	
 	/**
 	 * Deletes the given session token, thereby invalidating it

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManager.java
@@ -15,6 +15,12 @@ public interface AuthenticationManager {
 	public Session authenticate(String email, String password) throws NotFoundException;
 	
 	/**
+	 * Looks for the user holding the given session token
+	 * @throws UnauthorizedException If the token has expired
+	 */
+	public Long getPrincipalId(String sessionToken) throws UnauthorizedException;
+	
+	/**
 	 * Looks for the given session token
 	 * @return The principal ID of the holder
 	 * @throws UnauthorizedException If the token is not valid

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManagerImpl.java
@@ -45,6 +45,15 @@ public class AuthenticationManagerImpl implements AuthenticationManager {
 	}
 	
 	@Override
+	public Long getPrincipalId(String sessionToken) throws UnauthorizedException {
+		Long principalId = authDAO.getPrincipal(sessionToken);
+		if (principalId == null) {
+			throw new UnauthorizedException("The session token (" + sessionToken + ") has expired");
+		}
+		return principalId;
+	}
+	
+	@Override
 	public Long checkSessionToken(String sessionToken) throws UnauthorizedException, TermsOfUseException {
 		Long principalId = authDAO.getPrincipalIfValid(sessionToken);
 		if (principalId == null) {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManagerImpl.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.repo.manager;
 
 import org.sagebionetworks.repo.model.AuthenticationDAO;
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserGroupDAO;
@@ -44,10 +45,18 @@ public class AuthenticationManagerImpl implements AuthenticationManager {
 	}
 	
 	@Override
-	public Long checkSessionToken(String sessionToken) throws UnauthorizedException {
+	public Long checkSessionToken(String sessionToken) throws UnauthorizedException, TermsOfUseException {
 		Long principalId = authDAO.getPrincipalIfValid(sessionToken);
 		if (principalId == null) {
-			throw new UnauthorizedException("The session token (" + sessionToken + ") is invalid");
+			// Check to see why the token is invalid
+			Long userId = authDAO.getPrincipal(sessionToken);
+			if (userId == null) {
+				throw new UnauthorizedException("The session token (" + sessionToken + ") is invalid");
+			}
+			if (!authDAO.hasUserAcceptedToU(userId.toString())) {
+				throw new TermsOfUseException();
+			}
+			throw new UnauthorizedException("The session token (" + sessionToken + ") has expired");
 		}
 		return principalId;
 	}

--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
@@ -123,7 +123,9 @@ public class AuthenticationController extends BaseController {
 			throws NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException {
 		String registrationToken = registrationInfo.getRegistrationToken();
 		String sessionToken = registrationToken.substring(AuthorizationConstants.REGISTRATION_TOKEN_PREFIX.length());
-		String realUserId = authenticationService.revalidate(sessionToken);
+		
+		// A registering user has not had a chance to accept the terms yet
+		String realUserId = authenticationService.revalidate(sessionToken, false);
 		String realUsername = authenticationService.getUsername(realUserId);
 
 		// Set the password

--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationFilter.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationFilter.java
@@ -26,6 +26,7 @@ import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.securitytools.HMACUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 
 /**
  * This filter authenticates incoming requests:
@@ -60,7 +61,7 @@ public class AuthenticationFilter implements Filter {
 	}
 	
 	private static void reject(HttpServletRequest req, HttpServletResponse resp, String reason, HttpStatus status) throws IOException {
-		resp.setStatus(status.code);
+		resp.setStatus(status.value());
 
 		// This header is required according to RFC-2612
 		// See: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2

--- a/services/repository/src/main/java/org/sagebionetworks/auth/BaseController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/BaseController.java
@@ -6,6 +6,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.error.ErrorResponse;
 import org.sagebionetworks.repo.web.NotFoundException;
@@ -49,6 +50,23 @@ public class BaseController {
 	@ResponseStatus(HttpStatus.UNAUTHORIZED)
 	public @ResponseBody
 	ErrorResponse handleForbiddenException(UnauthorizedException ex,
+			HttpServletRequest request,
+			HttpServletResponse response) {
+		return handleException(ex, request, false);
+	}
+	
+	/**
+	 * This is thrown when the user has not accepted the terms of use
+	 * 
+	 * @param request
+	 *            the client request
+	 * @return an ErrorResponse object containing the exception reason or some
+	 *         other human-readable response
+	 */
+	@ExceptionHandler(TermsOfUseException.class)
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	public @ResponseBody
+	ErrorResponse handleTermsOfUseException(TermsOfUseException ex,
 			HttpServletRequest request,
 			HttpServletResponse response) {
 		return handleException(ex, request, false);

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
@@ -1,9 +1,7 @@
 package org.sagebionetworks.auth.services;
 
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
-
 import org.openid4java.message.ParameterList;
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.NewUser;
@@ -25,7 +23,7 @@ public interface AuthenticationService {
 	 * Authenticates a user/password combination, returning a session token if valid
 	 * @throws UnauthorizedException If the credentials are incorrect
 	 */
-	public Session authenticate(NewUser credential) throws NotFoundException, UnauthorizedException;
+	public Session authenticate(NewUser credential) throws NotFoundException, UnauthorizedException, TermsOfUseException;
 	
 	/**
 	 * Revalidates a session token and checks whether the user has accepted the terms of use
@@ -62,14 +60,14 @@ public interface AuthenticationService {
 	 * Changes the password of the user
 	 */
 	public void changePassword(String username, String newPassword)
-			throws NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException;
+			throws NotFoundException;
 	
 	/**
 	 * Changes the email of a user to another email
 	 * Simultaneously changes the user's password
 	 */
 	public void updateEmail(String oldEmail, RegistrationInfo registrationInfo)
-			throws NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException;
+			throws NotFoundException;
 	
 	/**
 	 * Gets the current secret key of the user

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
@@ -26,11 +26,19 @@ public interface AuthenticationService {
 	public Session authenticate(NewUser credential) throws NotFoundException, UnauthorizedException, TermsOfUseException;
 	
 	/**
-	 * Revalidates a session token and checks whether the user has accepted the terms of use
+	 * Revalidates a session token and checks if the user has accepted the terms of use
 	 * @return The principalId of the user holding the token
 	 * @throws UnauthorizedException If the token has expired or is otherwise not valid
 	 */
-	public String revalidate(String sessionToken) throws NotFoundException, UnauthorizedException;
+	public String revalidate(String sessionToken) throws NotFoundException, UnauthorizedException, TermsOfUseException;
+	
+	/**
+	 * Revalidates a session token
+	 * @param checkToU Should the check fail if the user has not accepted the terms of use?
+	 * @return The principalId of the user holding the token
+	 * @throws UnauthorizedException If the token has expired or is otherwise not valid
+	 */
+	public String revalidate(String sessionToken, boolean checkToU) throws NotFoundException, UnauthorizedException, TermsOfUseException;
 	
 	/**
 	 * Invalidates a session token

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
@@ -77,7 +77,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 		try {
 			userId = authManager.checkSessionToken(sessionToken);
 		} catch (TermsOfUseException e) {
-			if (!checkToU) {
+			if (checkToU) {
 				throw e;
 			}
 			userId = authManager.getPrincipalId(sessionToken);
@@ -324,7 +324,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 		//TODO This should not be the case
 		try {
 			handleTermsOfUse(email, acceptsTermsOfUse);
-		} catch (UnauthorizedException e) { }
+		} catch (TermsOfUseException e) { }
 		
 		// Open ID is successful
 		return authManager.authenticate(email, null);

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
@@ -1,8 +1,6 @@
 package org.sagebionetworks.auth.services;
 
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
 import java.util.List;
 import java.util.Map;
 
@@ -15,10 +13,9 @@ import org.sagebionetworks.authutil.OpenIDInfo;
 import org.sagebionetworks.authutil.SendMail;
 import org.sagebionetworks.repo.manager.AuthenticationManager;
 import org.sagebionetworks.repo.manager.UserManager;
-import org.sagebionetworks.repo.manager.UserProfileManager;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.DatastoreException;
-import org.sagebionetworks.repo.model.ServiceConstants;
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.NewUser;
@@ -36,18 +33,14 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
 	@Autowired
 	private UserManager userManager;
-
-	@Autowired
-	private UserProfileManager userProfileManager;
 	
 	@Autowired
 	private AuthenticationManager authManager;
 	
 	public AuthenticationServiceImpl() {}
 	
-	public AuthenticationServiceImpl(UserManager userManager, UserProfileManager userProfileManager, AuthenticationManager authManager) {
+	public AuthenticationServiceImpl(UserManager userManager, AuthenticationManager authManager) {
 		this.userManager = userManager;
-		this.userProfileManager = userProfileManager;
 		this.authManager = authManager;
 	}
 
@@ -73,9 +66,6 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 	@Transactional(readOnly = false, propagation = Propagation.REQUIRED)
 	public String revalidate(String sessionToken) throws NotFoundException {
 		Long userId = authManager.checkSessionToken(sessionToken);
-		if (!hasUserAcceptedTermsOfUse(userId.toString())) {
-			throw new UnauthorizedException(ServiceConstants.TERMS_OF_USE_ERROR_MESSAGE);
-		}
 		return userId.toString();
 	}
 
@@ -129,7 +119,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 	
 	@Override
 	@Transactional(readOnly = false, propagation = Propagation.REQUIRED)
-	public void changePassword(String username, String newPassword) throws NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException {
+	public void changePassword(String username, String newPassword) throws NotFoundException {
 		if (username == null) {
 			throw new IllegalArgumentException("Username may not be null");
 		}
@@ -143,7 +133,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 	
 	@Override
 	@Transactional(readOnly = false, propagation = Propagation.REQUIRED)
-	public void updateEmail(String oldEmail, RegistrationInfo registrationInfo) throws NotFoundException, NoSuchAlgorithmException, InvalidKeySpecException {
+	public void updateEmail(String oldEmail, RegistrationInfo registrationInfo) throws NotFoundException {
 		// User must be logged in to make this request
 		if (oldEmail == null) {
 			throw new UnauthorizedException("Not authorized");

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
@@ -233,7 +233,8 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 	 * Note: Could be made into a public service sometime in the future
 	 * @param acceptsTermsOfUse Will check stored data on user if set to null or false
 	 */
-	private void handleTermsOfUse(String username, Boolean acceptsTermsOfUse) throws NotFoundException, UnauthorizedException {
+	private void handleTermsOfUse(String username, Boolean acceptsTermsOfUse) 
+			throws NotFoundException, TermsOfUseException {
 		UserInfo userInfo = userManager.getUserInfo(username);
 		
 		// The ToU field might not be explicitly specified or false
@@ -243,7 +244,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 		
 		// Check for ToU acceptance
 		if (!acceptsTermsOfUse) {
-			throw new UnauthorizedException(ServiceConstants.TERMS_OF_USE_ERROR_MESSAGE);
+			throw new TermsOfUseException();
 		}
 		
 		// If the user is accepting the terms in this request, save the time of acceptance

--- a/services/repository/src/test/java/org/sagebionetworks/auth/services/AuthenticationServiceImplTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/services/AuthenticationServiceImplTest.java
@@ -63,7 +63,7 @@ public class AuthenticationServiceImplTest {
 		mockAuthenticationManager = Mockito.mock(AuthenticationManager.class);
 		when(mockAuthenticationManager.checkSessionToken(eq(sessionToken))).thenReturn(userId);
 		
-		service = new AuthenticationServiceImpl(mockUserManager, mockUserProfileManager, mockAuthenticationManager);
+		service = new AuthenticationServiceImpl(mockUserManager, mockAuthenticationManager);
 	}
 	
 	@Test

--- a/services/repository/src/test/java/org/sagebionetworks/auth/services/AuthenticationServiceImplTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/services/AuthenticationServiceImplTest.java
@@ -19,13 +19,12 @@ import org.sagebionetworks.authutil.OpenIDConsumerUtils;
 import org.sagebionetworks.authutil.OpenIDInfo;
 import org.sagebionetworks.repo.manager.AuthenticationManager;
 import org.sagebionetworks.repo.manager.UserManager;
-import org.sagebionetworks.repo.manager.UserProfileManager;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
+import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.User;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserInfo;
-import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.auth.NewUser;
 import org.sagebionetworks.repo.model.auth.RegistrationInfo;
 
@@ -34,7 +33,6 @@ public class AuthenticationServiceImplTest {
 	private AuthenticationServiceImpl service;
 	
 	private UserManager mockUserManager;
-	private UserProfileManager mockUserProfileManager;
 	private AuthenticationManager mockAuthenticationManager;
 	
 	private NewUser credential;
@@ -62,9 +60,6 @@ public class AuthenticationServiceImplTest {
 		when(mockUserManager.getUserInfo(eq(username))).thenReturn(userInfo);
 		when(mockUserManager.getGroupName(anyString())).thenReturn(username);
 		
-		mockUserProfileManager = Mockito.mock(UserProfileManager.class);
-		when(mockUserProfileManager.getUserProfile(any(UserInfo.class), anyString())).thenReturn(new UserProfile());
-		
 		mockAuthenticationManager = Mockito.mock(AuthenticationManager.class);
 		when(mockAuthenticationManager.checkSessionToken(eq(sessionToken))).thenReturn(userId);
 		
@@ -80,12 +75,11 @@ public class AuthenticationServiceImplTest {
 		service.authenticate(credential);
 		verify(mockAuthenticationManager).authenticate(eq(username), eq(password));
 		verify(mockUserManager).getUserInfo(anyString());
-		verify(mockUserProfileManager, times(0)).updateUserProfile(eq(userInfo), any(UserProfile.class));
 		verify(mockAuthenticationManager).setTermsOfUseAcceptance(eq("" + userId), eq(true));
 		
 	}
 	
-	@Test(expected=UnauthorizedException.class)
+	@Test(expected=TermsOfUseException.class)
 	public void testAuthenticateToUFail() throws Exception {
 		// ToU checking should fail
 		credential.setAcceptsTermsOfUse(false);
@@ -134,7 +128,6 @@ public class AuthenticationServiceImplTest {
 		verify(mockUserManager, times(0)).createUser(any(NewUser.class));
 		verify(mockAuthenticationManager).authenticate(eq(username), eq((String) null));
 		verify(mockUserManager).getUserInfo(anyString());
-		verify(mockUserProfileManager, times(0)).updateUserProfile(eq(userInfo), any(UserProfile.class));
 		verify(mockAuthenticationManager).setTermsOfUseAcceptance(eq("" + userId), eq(true));
 	}
 	


### PR DESCRIPTION
If a user must sign the terms of use, the status code should be 403, not 401.
Also fixes the /registeringUserPassword method, which should not require ToU acceptance

This change is to comply with the specs found at https://sagebionetworks.jira.com/wiki/display/PLFM/Authentication+and+Authorization+API
