### PR TITLE
New user password email fix

### DIFF
--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
@@ -63,7 +63,7 @@ public class AuthenticationController extends BaseController {
 	@RequestMapping(value = UrlHelpers.AUTH_USER, method = RequestMethod.POST)
 	public void createUser(@RequestBody NewUser user) throws NotFoundException {
 		authenticationService.createUser(user);
-		authenticationService.sendUserPasswordEmail(user.getEmail(), PW_MODE.RESET_PW);
+		authenticationService.sendUserPasswordEmail(user.getEmail(), PW_MODE.SET_PW);
 	}
 	
 	@ResponseStatus(HttpStatus.OK)

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
@@ -232,7 +232,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 		SendMail sendMail = new SendMail();
 		switch (mode) {
 			case SET_PW:
-				sendMail.sendSetPasswordMail(mailTarget, sessionToken);
+				sendMail.sendSetPasswordMail(mailTarget, AuthorizationConstants.REGISTRATION_TOKEN_PREFIX + sessionToken);
 				break;
 			case RESET_PW:
 				sendMail.sendResetPasswordMail(mailTarget, sessionToken);


### PR DESCRIPTION
Missing the token prefix in the email sent to new users.
