### PR TITLE
MergeWorkerTest - Fix #1 (again)

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/semaphore/SemaphoreGatedRunnerImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/semaphore/SemaphoreGatedRunnerImpl.java
@@ -1,12 +1,13 @@
 package org.sagebionetworks.repo.model.dbo.dao.semaphore;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import org.sagebionetworks.repo.model.dao.semaphore.SemaphoreDao;
 import org.sagebionetworks.repo.model.dao.semaphore.SemaphoreGatedRunner;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -118,7 +119,7 @@ public class SemaphoreGatedRunnerImpl implements SemaphoreGatedRunner {
 		}
 		// randomly generate a lock number to attempt
 		int lockNumber = randomGen.nextInt(maxNumberRunners);
-		String key = semaphoreKey+KEY_NUM_DELIMITER+lockNumber;
+		String key = generateKeyForLockNumber(lockNumber);
 		String token = semaphoreDao.attemptToAcquireLock(key, timeoutMS);
 		if(token != null){
 			try{
@@ -137,5 +138,18 @@ public class SemaphoreGatedRunnerImpl implements SemaphoreGatedRunner {
 	 */
 	void clearKeys(){
 		USED_KEY_SET.clear();
+	}
+	
+	private String generateKeyForLockNumber(int lockNumber) {
+		return semaphoreKey + KEY_NUM_DELIMITER + lockNumber;
+	}
+	
+	@Override
+	public List<String> getAllLockKeys() {
+		List<String> keys = new ArrayList<String>();
+		for (int i = 0; i < maxNumberRunners; i++) {
+			keys.add(generateKeyForLockNumber(i));
+		}
+		return keys;
 	}
 }

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/dao/semaphore/SemaphoreGatedRunner.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/dao/semaphore/SemaphoreGatedRunner.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.repo.model.dao.semaphore;
 
+import java.util.List;
+
 /**
  * An abstraction for a job runner that is gated by a semaphore.
  * The basic idea is to run if a lock can be acquired from a semaphore.
@@ -22,4 +24,10 @@ public interface SemaphoreGatedRunner {
 	 * acquired.  Instead, the caller should continue to attempt to run at a regular interval.
 	 */
 	public void attemptToRun();
+	
+	/**
+	 * Returns all keys needed to prevent this runner from starting any workers
+	 * (For testing purposes)
+	 */
+	public List<String> getAllLockKeys();
 }


### PR DESCRIPTION
Got the semaphore key incorrect, so the previous fix didn't do anything. This should let worker tests programmatically fetch all the keys necessary to lock down the scheduler.
