### PR TITLE
PLFM-2372 - More Auth Revisions

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/IT501SynapseJavaClientMessagingTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT501SynapseJavaClientMessagingTest.java
@@ -111,7 +111,10 @@ public class IT501SynapseJavaClientMessagingTest {
 		for (String id : cleanup) {
 			synapseAdmin.deleteMessage(id);
 		}
-		synapseOne.deleteFileHandle(oneToRuleThemAll.getId());
+		
+		try {
+			synapseOne.deleteFileHandle(oneToRuleThemAll.getId());
+		} catch (Exception e) { }
 	}
 
 	@SuppressWarnings("serial")

--- a/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
@@ -206,6 +206,30 @@ public class IT990AuthenticationController {
 	public void testGetSecretKey() throws Exception {
 		String apikey = synapse.retrieveApiKey();
 		assertNotNull(apikey);
+		
+		// Use the API key
+		synapse.logout();
+		synapse.setUserName(username);
+		synapse.setApiKey(apikey);
+		
+		// Should work
+		synapse.getMyProfile();
+		
+		// This should make subsequent API key calls fail
+		synapse.login(username, password);
+		synapse.signTermsOfUse(synapse.getCurrentSessionToken(), false);
+		
+		synapse.logout();
+		synapse.setUserName(username);
+		synapse.setApiKey(apikey);
+		try {
+			synapse.getMyProfile();
+			fail();
+		} catch (SynapseForbiddenException e) { }
+
+		// Clean up
+		synapse.login(username, password);
+		synapse.signTermsOfUse(synapse.getCurrentSessionToken(), true);
 	}
 	
 	@Test

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAuthenticationDAOImpl.java
@@ -260,10 +260,14 @@ public class DBOAuthenticationDAOImpl implements AuthenticationDAO {
 	}
 	
 	@Override
-	public String getSecretKey(String id) {
+	public String getSecretKey(String id) throws NotFoundException {
 		MapSqlParameterSource param = new MapSqlParameterSource();
 		param.addValue(ID_PARAM_NAME, id);
-		return simpleJdbcTemplate.queryForObject(SELECT_SECRET_KEY, String.class, param);
+		try {
+			return simpleJdbcTemplate.queryForObject(SELECT_SECRET_KEY, String.class, param);
+		} catch (EmptyResultDataAccessException e) {
+			throw new NotFoundException(e);
+		}
 	}
 	
 	@Override
@@ -284,10 +288,15 @@ public class DBOAuthenticationDAOImpl implements AuthenticationDAO {
 	}
 
 	@Override
-	public boolean hasUserAcceptedToU(String id) {
+	public boolean hasUserAcceptedToU(String id) throws NotFoundException {
 		MapSqlParameterSource param = new MapSqlParameterSource();
 		param.addValue(ID_PARAM_NAME, id);
-		Boolean acceptance = simpleJdbcTemplate.queryForObject(SELECT_TOU_ACCEPTANCE, Boolean.class, param);
+		Boolean acceptance;
+		try {
+			acceptance = simpleJdbcTemplate.queryForObject(SELECT_TOU_ACCEPTANCE, Boolean.class, param);
+		} catch (EmptyResultDataAccessException e) {
+			throw new NotFoundException(e);
+		}
 		if (acceptance == null) {
 			return false;
 		}

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthenticationDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthenticationDAO.java
@@ -75,7 +75,7 @@ public interface AuthenticationDAO {
 	/**
 	 * Returns the user's secret key
 	 */
-	public String getSecretKey(String id);
+	public String getSecretKey(String id) throws NotFoundException;
 	
 	/**
 	 * Generates a new secret key for the user
@@ -90,7 +90,7 @@ public interface AuthenticationDAO {
 	/**
 	 * Returns whether the user has accepted the terms of use
 	 */
-	public boolean hasUserAcceptedToU(String id);
+	public boolean hasUserAcceptedToU(String id) throws NotFoundException;
 	
 	/**
 	 * Sets whether the user has accepted, rejected, or not seen the terms of use

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManager.java
@@ -29,7 +29,7 @@ public interface AuthenticationManager {
 	 * @throws UnauthorizedException If the token is not valid
 	 * @throws TermsOfUseException If the user has not signed the terms of use
 	 */
-	public Long checkSessionToken(String sessionToken, boolean checkToU);
+	public Long checkSessionToken(String sessionToken, boolean checkToU) throws NotFoundException;
 	
 	/**
 	 * Deletes the given session token, thereby invalidating it
@@ -44,7 +44,7 @@ public interface AuthenticationManager {
 	/** 
 	 * Gets the user's secret key
 	 */
-	public String getSecretKey(String id);
+	public String getSecretKey(String id) throws NotFoundException;
 	
 	/**
 	 * Replaces the user's secret key with a new one
@@ -60,7 +60,7 @@ public interface AuthenticationManager {
 	/**
 	 * Returns whether the user has accepted the terms of use
 	 */
-	public boolean hasUserAcceptedTermsOfUse(String id);
+	public boolean hasUserAcceptedTermsOfUse(String id) throws NotFoundException;
 
 	/**
 	 * Sets whether the user has accepted or rejected the terms of use

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/AuthenticationManagerImpl.java
@@ -55,7 +55,7 @@ public class AuthenticationManagerImpl implements AuthenticationManager {
 	
 	@Override
 	@Transactional(readOnly = false, propagation = Propagation.REQUIRED)
-	public Long checkSessionToken(String sessionToken, boolean checkToU) {
+	public Long checkSessionToken(String sessionToken, boolean checkToU) throws NotFoundException {
 		Long principalId = authDAO.getPrincipalIfValid(sessionToken);
 		if (principalId == null) {
 			// Check to see why the token is invalid
@@ -89,7 +89,7 @@ public class AuthenticationManagerImpl implements AuthenticationManager {
 	}
 	
 	@Override
-	public String getSecretKey(String id) {
+	public String getSecretKey(String id) throws NotFoundException {
 		return authDAO.getSecretKey(id);
 	}
 
@@ -129,7 +129,7 @@ public class AuthenticationManagerImpl implements AuthenticationManager {
 	}
 
 	@Override
-	public boolean hasUserAcceptedTermsOfUse(String id) {
+	public boolean hasUserAcceptedTermsOfUse(String id) throws NotFoundException {
 		return authDAO.hasUserAcceptedToU(id);
 	}
 	

--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
@@ -67,7 +67,7 @@ public class AuthenticationController extends BaseController {
 	 */
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@RequestMapping(value = UrlHelpers.AUTH_SESSION, method = RequestMethod.PUT)
-	public void revalidate(@RequestBody Session session) {
+	public void revalidate(@RequestBody Session session) throws NotFoundException {
 		authenticationService.revalidate(session.getSessionToken());
 	}
 
@@ -120,7 +120,7 @@ public class AuthenticationController extends BaseController {
 	 */
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@RequestMapping(value = UrlHelpers.AUTH_USER_PASSWORD, method = RequestMethod.POST)
-	public void changePassword(@RequestBody ChangePasswordRequest request) {
+	public void changePassword(@RequestBody ChangePasswordRequest request) throws NotFoundException {
 		authenticationService.changePassword(request);
 	}
 	

--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationFilter.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationFilter.java
@@ -21,7 +21,6 @@ import org.joda.time.Minutes;
 import org.sagebionetworks.auth.services.AuthenticationService;
 import org.sagebionetworks.authutil.ModParamHttpServletRequest;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
-import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.securitytools.HMACUtils;
@@ -87,53 +86,63 @@ public class AuthenticationFilter implements Filter {
 		
 		// A session token maps to a specific user
 		if (sessionToken != null) {
+			String failureReason = "Invalid session token";
 			try {
-				String userId = authenticationService.revalidate(sessionToken);
+				String userId = authenticationService.revalidate(sessionToken, false);
 				username = authenticationService.getUsername(userId);
-			} catch (TermsOfUseException e) {
-				String reason = "Terms of use have not been signed";
-				reject(req, (HttpServletResponse) servletResponse, reason, HttpStatus.FORBIDDEN);
-				log.warn("Session token used without signing terms of use", e);
-				return;
 			} catch (UnauthorizedException e) {
-				String reason = "The session token is invalid";
-				reject(req, (HttpServletResponse) servletResponse, reason);
-				log.warn("Invalid session token", e);
+				reject(req, (HttpServletResponse) servletResponse, failureReason);
+				log.warn(failureReason, e);
 				return;
 			} catch (NotFoundException e) {
-				String reason = "The session token is invalid";
-				reject(req, (HttpServletResponse) servletResponse, reason);
-				log.warn("Invalid session token", e);
+				reject(req, (HttpServletResponse) servletResponse, failureReason);
+				log.warn(failureReason, e);
 				return;
 			}
 		
 		// If there is no session token, then check for a HMAC signature
-		} else if (isSigned(req)) {  
+		} else if (isSigned(req)) {
+			String failureReason = "Invalid HMAC signature";
 			username = req.getHeader(AuthorizationConstants.USER_ID_HEADER);
 			try {
 				String secretKey = authenticationService.getSecretKey(username);
 				matchHMACSHA1Signature(req, secretKey);
-			} catch (TermsOfUseException e) {
-				String reason = "Terms of use have not been signed";
-				reject(req, (HttpServletResponse) servletResponse, reason, HttpStatus.FORBIDDEN);
-				log.warn("Secret key used without signing terms of use", e);
-				return;
 			} catch (UnauthorizedException e) {
 				reject(req, (HttpServletResponse) servletResponse, e.getMessage());
-				log.warn("Invalid HMAC signature", e);
+				log.warn(failureReason, e);
 				return;
 			} catch (NotFoundException e) {
 				reject(req, (HttpServletResponse) servletResponse, e.getMessage());
-				log.warn("Invalid HMAC signature", e);
+				log.warn(failureReason, e);
 				return;
 			}
 		}
+		
 		if (username == null && !allowAnonymous) {
 			String reason = "The session token provided was missing, invalid or expired.";
 			reject(req, (HttpServletResponse) servletResponse, reason);
 			log.warn("Anonymous not allowed");
 			return;
 		}
+		
+		// If the user has been identified, check if they have accepted the terms of use
+		if (username != null) {
+			boolean toUCheck = false;
+			try {
+				toUCheck = authenticationService.hasUserAcceptedTermsOfUse(username);
+			} catch (NotFoundException e) {
+				String reason = "User " + username + " does not exist";
+				reject(req, (HttpServletResponse) servletResponse, reason, HttpStatus.NOT_FOUND);
+				log.error("This should be unreachable", e);
+				return;
+			}
+			if (!toUCheck) {
+				String reason = "Terms of use have not been signed";
+				reject(req, (HttpServletResponse) servletResponse, reason, HttpStatus.FORBIDDEN);
+				return;
+			}	
+		}
+		
 		if (username == null) {
 			username = AuthorizationConstants.ANONYMOUS_USER_ID;
 		}

--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationFilter.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationFilter.java
@@ -113,6 +113,11 @@ public class AuthenticationFilter implements Filter {
 			try {
 				String secretKey = authenticationService.getSecretKey(username);
 				matchHMACSHA1Signature(req, secretKey);
+			} catch (TermsOfUseException e) {
+				String reason = "Terms of use have not been signed";
+				reject(req, (HttpServletResponse) servletResponse, reason, HttpStatus.FORBIDDEN);
+				log.warn("Secret key used without signing terms of use", e);
+				return;
 			} catch (UnauthorizedException e) {
 				reject(req, (HttpServletResponse) servletResponse, e.getMessage());
 				log.warn("Invalid HMAC signature", e);

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
@@ -66,8 +66,6 @@ public interface AuthenticationService {
 	
 	/**
 	 * Gets the current secret key of the user
-	 * Also double checks to see if the user has accepted the terms of use
-	 *   If not, a TermsOfUseException is thrown
 	 */
 	public String getSecretKey(String username)
 			throws NotFoundException;
@@ -82,6 +80,12 @@ public interface AuthenticationService {
 	 * Returns the username of the user
 	 */
 	public String getUsername(String principalId)
+			throws NotFoundException;
+	
+	/**
+	 * Has the user accepted the terms of use?
+	 */
+	public boolean hasUserAcceptedTermsOfUse(String username) 
 			throws NotFoundException;
 	
 	/**

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
@@ -27,14 +27,14 @@ public interface AuthenticationService {
 	 * @throws UnauthorizedException If the token has expired or is otherwise not valid
 	 * @throws TermsOfUseException If the user has not accepted the terms of use
 	 */
-	public String revalidate(String sessionToken);
+	public String revalidate(String sessionToken) throws NotFoundException;
 	
 	/**
 	 * Revalidates a session token
 	 * See {@link #revalidate(String)}
 	 * @param checkToU Should the check fail if the user has not accepted the terms of use?
 	 */
-	public String revalidate(String sessionToken, boolean checkToU);
+	public String revalidate(String sessionToken, boolean checkToU) throws NotFoundException;
 	
 	/**
 	 * Invalidates a session token
@@ -57,7 +57,7 @@ public interface AuthenticationService {
 	/**
 	 * Changes the password of the user
 	 */
-	public void changePassword(ChangePasswordRequest request);
+	public void changePassword(ChangePasswordRequest request) throws NotFoundException;
 	
 	/**
 	 * Identifies a user via session token and signs that user's terms of use
@@ -66,6 +66,8 @@ public interface AuthenticationService {
 	
 	/**
 	 * Gets the current secret key of the user
+	 * Also double checks to see if the user has accepted the terms of use
+	 *   If not, a TermsOfUseException is thrown
 	 */
 	public String getSecretKey(String username)
 			throws NotFoundException;

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
@@ -11,7 +11,6 @@ import org.sagebionetworks.repo.manager.AuthenticationManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.OriginatingClient;
-import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.ChangePasswordRequest;
@@ -164,9 +163,6 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 	@Override
 	public String getSecretKey(String username) throws NotFoundException {
 		UserInfo userInfo = userManager.getUserInfo(username);
-		if (!userInfo.getUser().isAgreesToTermsOfUse()) {
-			throw new TermsOfUseException();
-		}
 		return authManager.getSecretKey(userInfo.getIndividualGroup().getId());
 	}
 	
@@ -180,6 +176,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 	@Override
 	public String getUsername(String principalId) throws NotFoundException {
 		return userManager.getGroupName(principalId);
+	}
+	
+	@Override
+	public boolean hasUserAcceptedTermsOfUse(String username) throws NotFoundException {
+		UserInfo userInfo = userManager.getUserInfo(username);
+		return authManager.hasUserAcceptedTermsOfUse(userInfo.getIndividualGroup().getId());
 	}
 	
 	@Override

--- a/services/repository/src/test/java/org/sagebionetworks/auth/AuthenticationFilterTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/AuthenticationFilterTest.java
@@ -44,9 +44,10 @@ public class AuthenticationFilterTest {
 	@Before
 	public void setupFilter() throws Exception {
 		mockAuthService = mock(AuthenticationService.class);
-		when(mockAuthService.revalidate(eq(sessionToken))).thenReturn(userId);
+		when(mockAuthService.revalidate(eq(sessionToken), eq(false))).thenReturn(userId);
 		when(mockAuthService.getUsername(eq(userId))).thenReturn(username);
 		when(mockAuthService.getSecretKey(eq(username))).thenReturn(secretKey);
+		when(mockAuthService.hasUserAcceptedTermsOfUse(eq(username))).thenReturn(true);
 		
 		final Map<String,String> filterParams = new HashMap<String, String>();
 		filterParams.put("allow-anonymous", "true");
@@ -107,7 +108,7 @@ public class AuthenticationFilterTest {
 		filter.doFilter(request, response, filterChain);
 		
 		// Session token should be recognized
-		Mockito.verify(mockAuthService, times(1)).revalidate(eq(sessionToken));
+		Mockito.verify(mockAuthService, times(1)).revalidate(eq(sessionToken), eq(false));
 		ServletRequest modRequest = filterChain.getRequest();
 		assertNotNull(modRequest);
 		String sessionUsername = modRequest.getParameter(AuthorizationConstants.USER_ID_PARAM);
@@ -125,7 +126,7 @@ public class AuthenticationFilterTest {
 		filter.doFilter(request, response, filterChain);
 
 		// Session token should be recognized
-		verify(mockAuthService, times(1)).revalidate(eq(sessionToken));
+		verify(mockAuthService, times(1)).revalidate(eq(sessionToken), eq(false));
 		ServletRequest modRequest = filterChain.getRequest();
 		assertNotNull(modRequest);
 		String sessionUsername = modRequest.getParameter(AuthorizationConstants.USER_ID_PARAM);


### PR DESCRIPTION
Auth filter should check ToU for API key calls too, now that the boolean can be in any of the 3 states (before, you could only possess an API key if the ToU was True).

This pull also addresses a few EmptyResultDataAccessExceptions Bruce was hitting when try to authenticate non-individuals. Now the Auth DAO properly throws NotFoundExceptions. (Before it assumed that the caller of the DAO would only pass in individuals, which are expected to have credentials).
