### PR TITLE
Stack 24 - Fix init of message manager

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
@@ -161,12 +161,6 @@ public class MessageManagerImpl implements MessageManager, InitializingBean {
 			throw new DatastoreException("Could not find the default group for all authenticated users");
 		}
 		authenticatedUsersId = authUsers.getId();
-		
-		UserGroup emailer = userGroupDAO.findGroup(StackConfiguration.getNotificationEmailAddress(), true);
-		if (emailer == null) {
-			throw new DatastoreException("Could not find the user that sends Synapse emails");
-		}
-		emailerId = emailer.getId();
 	}
 	
 	@Override


### PR DESCRIPTION
Can't check for the bootstrapped user that gets wiped out by migration.

This change has already be done in the bootstrap user refactor.  
