### PR TITLE
Add flag to disable preview generation for new file handles

### DIFF
--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -220,9 +220,6 @@ public interface SynapseClient extends BaseClient {
 			Long versionNumber) throws ClientProtocolException,
 			MalformedURLException, IOException;
 
-	public S3FileHandle createFileHandle(File temp, String contentType)
-			throws SynapseException, IOException;
-
 	/**
 	 * Get a WikiPage using its key
 	 */
@@ -379,8 +376,24 @@ public interface SynapseClient extends BaseClient {
 
 	public JSONObject query(String query) throws SynapseException;
 
+	/**
+	 * Upload each file to Synapse creating a file handle for each.
+	 */
 	public FileHandleResults createFileHandles(List<File> files)
 			throws SynapseException;
+
+	/**
+	 * The high-level API for uploading a file to Synapse.
+	 */
+	public S3FileHandle createFileHandle(File temp, String contentType)
+			throws SynapseException, IOException;
+
+	/**
+	 * See {@link #createFileHandle(File, String)}
+	 * @param shouldPreviewBeCreated Default true
+	 */
+	public S3FileHandle createFileHandle(File temp, String contentType, Boolean shouldPreviewBeCreated)
+			throws SynapseException, IOException;
 
 	public ChunkedFileToken createChunkedFileUploadToken(
 			CreateChunkedFileTokenRequest ccftr) throws SynapseException;

--- a/integration-test/src/test/java/org/sagebionetworks/IT049FileHandleTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT049FileHandleTest.java
@@ -168,7 +168,7 @@ public class IT049FileHandleTest {
 		try{
 			synapse.getRawFileHandle(handle.getId());
 			fail("The handle should be deleted.");
-		}catch(SynapseException e){
+		}catch(SynapseNotFoundException e){
 			// expected.
 		}
 	}

--- a/integration-test/src/test/java/org/sagebionetworks/IT501SynapseJavaClientMessagingTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT501SynapseJavaClientMessagingTest.java
@@ -35,8 +35,6 @@ import org.sagebionetworks.repo.model.message.MessageToUser;
  * Related to IT500SynapseJavaClient
  */
 public class IT501SynapseJavaClientMessagingTest {
-	
-	private static final long MAX_WAIT_MS = 1000*10; // 10 sec
 
 	private static SynapseAdminClient adminSynapse;
 	private static SynapseClient synapseOne;
@@ -90,7 +88,7 @@ public class IT501SynapseJavaClientMessagingTest {
 				pw.close();
 			}
 		}
-		oneToRuleThemAll = synapseOne.createFileHandle(file, "text/plain");
+		oneToRuleThemAll = synapseOne.createFileHandle(file, "text/plain", false);
 	}
 	
 	@SuppressWarnings("serial")
@@ -135,32 +133,13 @@ public class IT501SynapseJavaClientMessagingTest {
 	
 	@AfterClass
 	public static void afterClass() throws Exception {
-		// Delete the file handle and its preview
-		waitForPreviewToBeCreated(oneToRuleThemAll);
-		try {
-			adminSynapse.deleteFileHandle(oneToRuleThemAll.getPreviewId());
-		} catch (SynapseNotFoundException e) { }
+		// Delete the file handle
 		try {
 			adminSynapse.deleteFileHandle(oneToRuleThemAll.getId());
 		} catch (SynapseNotFoundException e) { }
 		
 		adminSynapse.deleteUser(user1ToDelete);
 		adminSynapse.deleteUser(user2ToDelete);
-	}
-
-	/**
-	 * Wait for a preview to be generated for the given file handle
-	 */
-	private static void waitForPreviewToBeCreated(S3FileHandle fileHandle) throws Exception {
-		long start = System.currentTimeMillis();
-		while (fileHandle.getPreviewId() == null) {
-			System.out.println("Waiting for a preview file to be created");
-			Thread.sleep(500);
-			assertTrue("Timed out waiting for a preview to be created",
-					(System.currentTimeMillis() - start) < MAX_WAIT_MS);
-			fileHandle = (S3FileHandle) adminSynapse.getRawFileHandle(fileHandle
-					.getId());
-		}
 	}
 
 	@SuppressWarnings("serial")

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOFileHandleDaoImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOFileHandleDaoImplTest.java
@@ -122,13 +122,13 @@ public class DBOFileHandleDaoImplTest {
 	@Test (expected=NotFoundException.class)
 	public void testGetCreatorNotFound() throws NotFoundException{
 		// Use an invalid file handle id.
-		String lookupCreator = fileHandleDao.getHandleCreator("99999");
+		fileHandleDao.getHandleCreator("99999");
 	}
 	
 	@Test (expected=NotFoundException.class)
 	public void testGetPreviewFileHandleNotFound() throws NotFoundException{
 		// Use an invalid file handle id.
-		String prewviewId = fileHandleDao.getPreviewFileHandleId("9999");
+		fileHandleDao.getPreviewFileHandleId("9999");
 	}
 	
 	@Test
@@ -451,4 +451,11 @@ public class DBOFileHandleDaoImplTest {
 		assertEquals(handle.getId(), list.get(0));
 	}
 
+	@Test
+	public void testCreateFileHandleWithNoPreview() {
+		S3FileHandle handle = TestUtils.createS3FileHandle(creatorUserGroupId);
+		handle = fileHandleDao.createFile(handle, false);
+		toDelete.add(handle.getId());
+		assertEquals(handle.getId(), handle.getPreviewId());
+	}
 }

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/file/CompleteAllChunksRequest.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/file/CompleteAllChunksRequest.json
@@ -11,6 +11,10 @@
 		"chunkedFileToken": {
 			"description":"The ChunkedFileToken created in the first step.  This is a required parameter.",
 			"$ref": "org.sagebionetworks.repo.model.file.ChunkedFileToken"
-		}
+		}, 
+        "shouldPreviewBeGenerated": {
+            "type": "boolean", 
+            "description": "When the upload completes successfully, should a preview eventually be generated for the file?"
+        }
 	}
 }

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/file/CompleteChunkedFileRequest.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/file/CompleteChunkedFileRequest.json
@@ -9,6 +9,10 @@
 			"items": {
 				"$ref": "org.sagebionetworks.repo.model.file.ChunkResult"
 			}
-		}
+		}, 
+        "shouldPreviewBeGenerated": {
+            "type": "boolean", 
+            "description": "When the upload completes successfully, should a preview eventually be generated for the file?"
+        }
 	}
 }

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/dao/FileHandleDao.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/dao/FileHandleDao.java
@@ -1,11 +1,11 @@
 package org.sagebionetworks.repo.model.dao;
 
-import java.net.MalformedURLException;
 import java.util.List;
 
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.file.FileHandle;
 import org.sagebionetworks.repo.model.file.FileHandleResults;
+import org.sagebionetworks.repo.model.file.S3FileHandle;
 import org.sagebionetworks.repo.web.NotFoundException;
 
 /**
@@ -18,12 +18,16 @@ public interface FileHandleDao {
 	
 	/**
 	 * Create S3 file metadata.
-	 * 
-	 * @param metadata
-	 * @return
-	 * @throws MalformedURLException 
 	 */
 	public <T extends FileHandle> T createFile(T metadata);
+	
+	/**
+	 * Create S3 file metadata
+	 * 
+	 * @param shouldPreviewBeGenerated If true, the previewId is set to null (default).
+	 *     If false, the previewId of the new file handle will be set to the new file handle's ID
+	 */
+	public S3FileHandle createFile(S3FileHandle metadata, boolean shouldPreviewBeGenerated);
 	
 	/**
 	 * Set the preview ID of a file.

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/CompleteUploadWorker.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/CompleteUploadWorker.java
@@ -88,6 +88,7 @@ public class CompleteUploadWorker implements Callable<Boolean>{
 			CompleteChunkedFileRequest ccfr = new CompleteChunkedFileRequest();
 			ccfr.setChunkedFileToken(cacf.getChunkedFileToken());
 			ccfr.setChunkResults(done);
+			ccfr.setShouldPreviewBeGenerated(cacf.getShouldPreviewBeGenerated());
 			S3FileHandle handle = multipartManager.completeChunkFileUpload(ccfr, bucket, userId);
 			if(handle == null) throw new RuntimeException("multipartManager.completeChunkFileUpload() returned null"); 
 			if(handle.getId() == null) throw new RuntimeException("multipartManager.completeChunkFileUpload() returned FileHandle ID"); 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/FileHandleManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/FileHandleManagerImpl.java
@@ -286,7 +286,7 @@ public class FileHandleManagerImpl implements FileHandleManager {
 			// If this file has a preview then we want to delete the preview as well.
 			if(handle instanceof HasPreviewId){
 				HasPreviewId hasPreview = (HasPreviewId) handle;
-				if(hasPreview.getPreviewId() != null){
+				if(hasPreview.getPreviewId() != null && !handle.getId().equals(hasPreview.getPreviewId())){
 					// Delete the preview.
 					deleteFileHandle(userInfo, hasPreview.getPreviewId());
 				}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/MultipartManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/MultipartManagerImpl.java
@@ -175,7 +175,13 @@ public class MultipartManagerImpl implements MultipartManager {
 		ObjectMetadata current = s3Client.getObjectMetadata(bucket, token.getKey());
 		// Capture the content length
 		fileHandle.setContentSize(current.getContentLength());
-		S3FileHandle result = fileHandleDao.createFile(fileHandle);
+		
+		// By default, previews are generated
+		if (ccfr.getShouldPreviewBeGenerated() == null) {
+			ccfr.setShouldPreviewBeGenerated(true);
+		}
+		
+		S3FileHandle result = fileHandleDao.createFile(fileHandle, ccfr.getShouldPreviewBeGenerated());
 		// Upon success we need to delete all of the parts.
 		for(ChunkResult cp: chunkParts){
 			String partKey = getChunkPartKey(token, cp.getChunkNumber().intValue());

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleManagerImplTest.java
@@ -301,6 +301,15 @@ public class FileHandleManagerImplTest {
 		verify(mockfileMetadataDao, times(1)).delete(handleId);
 	}
 	
+	@Test
+	public void testDeleteFileHandleDisablePreview() throws Exception {
+		// Deleting a file handle that has previews disabled should not StackOverflow :)
+		validResults.setPreviewId(validResults.getId());
+		when(mockfileMetadataDao.get(validResults.getId())).thenReturn(validResults);
+		when(mockAuthorizationManager.canAccessRawFileHandleByCreator(mockUser, validResults.getCreatedBy())).thenReturn(true);
+		manager.deleteFileHandle(mockUser, validResults.getId());
+	}
+	
 	@Test (expected=UnauthorizedException.class)
 	public void testClearPreviewUnauthroized() throws DatastoreException, NotFoundException{
 		// Deleting a handle that no longer exists should not throw an exception.

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/MultipartManagerImplAutowireTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/MultipartManagerImplAutowireTest.java
@@ -127,7 +127,7 @@ public class MultipartManagerImplAutowireTest {
 		// Next add the part
 		ChunkResult part = multipartManager.copyPart(token, 1, bucket);
 		
-		// We need a lsit of parts
+		// We need a list of parts
 		List<ChunkResult> partList = new LinkedList<ChunkResult>();
 		partList.add(part);
 		CompleteChunkedFileRequest ccfr = new CompleteChunkedFileRequest();

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/preview/StubFileMetadataDao.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/preview/StubFileMetadataDao.java
@@ -34,6 +34,19 @@ public class StubFileMetadataDao implements FileHandleDao {
 		map.put(id, metadata);
 		return metadata;
 	}
+	
+	@Override
+	public S3FileHandle createFile(S3FileHandle metadata, boolean shouldPreviewBeGenerated) {
+		// Create the metadata
+		String id = ""+map.size()+1;
+		metadata.setId(id);
+		if (shouldPreviewBeGenerated) {
+			metadata.setPreviewId(id);
+		}
+		metadata.setCreatedOn(new Date());
+		map.put(id, metadata);
+		return metadata;
+	}
 
 	@Override
 	public void setPreviewId(String fileId, String previewId)


### PR DESCRIPTION
Additive change to two request objects to include a new boolean flag.
If set to false, file handles should be deletable without race conditions with the PreviewWorker

If used correctly, should prevent timing related issues in some integration tests.  And can be used to reduce extraneous file handles and S3 files for messages and wikis.  
