### PR TITLE
Principal Header table/worker revisions

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/persistence/DBOPrincipalHeader.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/persistence/DBOPrincipalHeader.java
@@ -5,7 +5,6 @@ import org.sagebionetworks.repo.model.PrincipalType;
 import org.sagebionetworks.repo.model.dbo.AutoTableMapping;
 import org.sagebionetworks.repo.model.dbo.DatabaseObject;
 import org.sagebionetworks.repo.model.dbo.Field;
-import org.sagebionetworks.repo.model.dbo.ForeignKey;
 import org.sagebionetworks.repo.model.dbo.Table;
 import org.sagebionetworks.repo.model.dbo.TableMapping;
 import org.sagebionetworks.repo.model.query.jdo.SqlConstants;
@@ -21,8 +20,11 @@ public class DBOPrincipalHeader implements DatabaseObject<DBOPrincipalHeader> {
 		return tableMapping;
 	}
 
+	// Note: There is no FK (nor cascade delete) on UserGroup because the FK introduces a few locks that may deadlock user actions
+	//   For example, the PrincipalHeaderWorker updates a Principal, read-locking the UserGroup row
+	//   If a separate (to be implemented) method tries to query on the PrincipalHeader table in the same transaction as an update on 
+	//     the UserGroup (or a secondary) table, then there is the possibility that the worker will cause the user's action to fail.  
 	@Field(name = SqlConstants.COL_PRINCIPAL_HEADER_ID, primary = true, nullable = false)
-	@ForeignKey(table = SqlConstants.TABLE_USER_GROUP, field = SqlConstants.COL_USER_GROUP_ID, cascadeDelete = true)
 	private Long principalId;
 
 	@Field(name = SqlConstants.COL_PRINCIPAL_HEADER_FRAGMENT, primary = true, varchar = 256, nullable = false)

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOPrincipalHeaderDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOPrincipalHeaderDAOImplTest.java
@@ -62,6 +62,9 @@ public class DBOPrincipalHeaderDAOImplTest {
 	public void tearDown() throws Exception {
 		userGroupDAO.delete("" + principalOne);
 		userGroupDAO.delete("" + principalTwo);
+		
+		prinHeadDAO.delete(principalOne);
+		prinHeadDAO.delete(principalTwo);
 	}
 	
 	@Test

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/PrincipalHeaderDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/PrincipalHeaderDAO.java
@@ -24,6 +24,9 @@ public interface PrincipalHeaderDAO {
 	/**
 	 * Performs a prefix search over the entries within the table
 	 * 
+	 * Note: There is no FK on UserGroup so not all results are guaranteed to have an associated UserGroup
+	 *   See comments in DBOPrincipalHeader for more info.  
+	 * 
 	 * @param nameFilter The string to match.  If null/empty and the exactMatch=false, then all results will be returned
 	 * @param exactMatch Should the result be an exact match?
 	 * @param principals The type(s) of principal to include.  If null or empty, all principals are included

--- a/services/workers/src/main/java/org/sagebionetworks/search/workers/sqs/search/PrincipalHeaderWorker.java
+++ b/services/workers/src/main/java/org/sagebionetworks/search/workers/sqs/search/PrincipalHeaderWorker.java
@@ -73,14 +73,16 @@ public class PrincipalHeaderWorker implements Callable<List<Message>> {
 			
 			// We only care about PRINCIPAL or TEAM messages here
 			if (ObjectType.PRINCIPAL == change.getObjectType() || ObjectType.TEAM == change.getObjectType()) {
+				Long principalId = Long.parseLong(change.getObjectId());
 				try {
 					switch (change.getChangeType()) {
 					case CREATE:
 					case UPDATE:
-						processPrincipal(Long.parseLong(change.getObjectId()));
+						processPrincipal(principalId);
 						break;
 					case DELETE:
-						// The table cascade deletes, so there's nothing to do here
+						// Clear the associated entries
+						prinHeadDAO.delete(principalId);
 						break;
 					default:
 						throw new IllegalArgumentException("Unknown change type: " + change.getChangeType());

--- a/services/workers/src/main/resources/principal-header-sqs-spb.xml
+++ b/services/workers/src/main/resources/principal-header-sqs-spb.xml
@@ -25,7 +25,7 @@
 		<constructor-arg ref="awsCredentials" />
 	</bean>
 
-	<!-- Setups the search message queue. -->
+	<!-- Setups the principal header message queue -->
 	<bean id="principalHeaderMessageQueue"
 			class="org.sagebionetworks.asynchronous.workers.sqs.MessageQueueImpl"
 			depends-on="stackConfiguration">
@@ -34,13 +34,13 @@
 		<constructor-arg index="2" value="true" />
 	</bean>
 
-	<!-- provides search message queue workers -->
+	<!-- Provides principal header message queue workers -->
 	<bean id="principalHeaderQueueWorkerFactory"
 		class="org.sagebionetworks.search.workers.sqs.search.PrincipalHeaderWorkerFactory"
 		scope="singleton" />
 
-	<!-- Pull messages off the search queue, create works, deletes successfully 
-		processed messages -->
+	<!-- Pull messages off the principal header queue, create workers, and deletes 
+		successfully processed messages -->
 	<bean id="principalHeaderQueueMessageReceiver"
 		class="org.sagebionetworks.asynchronous.workers.sqs.MessageReceiverImpl"
 		scope="singleton">
@@ -48,7 +48,7 @@
 		<property name="workerFactory" ref="principalHeaderQueueWorkerFactory" />
 		<property name="maxNumberOfWorkerThreads" value="1" />
 		<property name="maxMessagePerWorker" value="10" />
-		<property name="visibilityTimeoutSec" value="600" />
+		<property name="visibilityTimeoutSec" value="60" />
 	</bean>
 	
 	<!-- This gate ensures we never run more than the max number or runners across the entire cluster for this worker  -->
@@ -60,7 +60,7 @@
 		<property name="runner" ref="principalHeaderQueueMessageReceiver" />
 	</bean>
 
-	<!-- This trigger is used to process messages from the search queue. -->
+	<!-- This trigger is used to process messages from the principal header queue. -->
 	<bean id="principalHeaderQueueMessageReceiverTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerBean"
 		scope="singleton">
 		<property name="jobDetail">
@@ -72,8 +72,8 @@
 			</bean>
 		</property>
 		<!-- We stagger the start delay of each trigger to spread out the timing -->
-		<property name="startDelay" value="125" />
-		<property name="repeatInterval" value="7000" />
+		<property name="startDelay" value="127" />
+		<property name="repeatInterval" value="7129" />
 	</bean>
 
 </beans>

--- a/services/workers/src/test/java/org/sagebionetworks/search/workers/sqs/search/PrincipalHeaderWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/search/workers/sqs/search/PrincipalHeaderWorkerIntegrationTest.java
@@ -57,8 +57,9 @@ public class PrincipalHeaderWorkerIntegrationTest {
 	
 	@Before
 	public void before() throws Exception {
-		// Before we start, make sure the queue is empty
+		// Before we start, make sure the queue and table is empty
 		emptyQueue();
+		emptyPrefixTable();
 		
 		adminUserInfo = userManager.getUserInfo(BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId());
 		
@@ -79,7 +80,7 @@ public class PrincipalHeaderWorkerIntegrationTest {
 	/**
 	 * Empty the queue by processing all messages on the queue.
 	 */
-	public void emptyQueue() throws InterruptedException {
+	private void emptyQueue() throws InterruptedException {
 		long start = System.currentTimeMillis();
 		int count = 0;
 		do {
@@ -93,6 +94,19 @@ public class PrincipalHeaderWorkerIntegrationTest {
 						"Timed out waiting process all messages that were on the queue before the tests started.");
 		} while (count > 0);
 	}
+	
+	/**
+	 * Deletes all entries in the PrincipalHeader table
+	 */
+	private void emptyPrefixTable() throws Exception {
+		List<Long> results;
+		do {
+			results = prinHeadDAO.query(null, false, null, null, 10, 0);
+			for (Long id : results) {
+				prinHeadDAO.delete(id);
+			}
+		} while (results.size() > 0);
+	}
 
 	@After
 	public void after() throws Exception {
@@ -100,6 +114,8 @@ public class PrincipalHeaderWorkerIntegrationTest {
 		
 		userManager.deletePrincipal(adminUserInfo, userId);
 		userManager.deletePrincipal(adminUserInfo, teamId);
+		
+		emptyPrefixTable();
 	}
 	
 	@Test


### PR DESCRIPTION
- Removes FK from PrincipalHeaders to UserGroup
- Adds/modifies comments
- Adds extra cleanup now that there's no delete cascade
