### PR TITLE
Stack 25 - Try-catch failing integration test cleanup

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/IT049FileHandleTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT049FileHandleTest.java
@@ -23,6 +23,7 @@ import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
+import org.sagebionetworks.client.exceptions.SynapseServiceException;
 import org.sagebionetworks.repo.model.file.ExternalFileHandle;
 import org.sagebionetworks.repo.model.file.FileHandle;
 import org.sagebionetworks.repo.model.file.FileHandleResults;
@@ -69,13 +70,16 @@ public class IT049FileHandleTest {
 		for (FileHandle handle: toDelete) {
 			try {
 				synapse.deleteFileHandle(handle.getId());
-			} catch (SynapseNotFoundException e) {}
+			} catch (SynapseNotFoundException e) {
+			} catch (SynapseServiceException e) { }
 		}
 	}
 	
 	@AfterClass
 	public static void afterClass() throws Exception {
-		adminSynapse.deleteUser(userToDelete);
+		try {
+			adminSynapse.deleteUser(userToDelete);
+		} catch (SynapseServiceException e) { }
 	}
 	
 	@Test

--- a/integration-test/src/test/java/org/sagebionetworks/IT055WikiPageTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT055WikiPageTest.java
@@ -22,6 +22,7 @@ import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
+import org.sagebionetworks.client.exceptions.SynapseServiceException;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.PaginatedResults;
 import org.sagebionetworks.repo.model.Project;
@@ -32,7 +33,6 @@ import org.sagebionetworks.repo.model.file.PreviewFileHandle;
 import org.sagebionetworks.repo.model.file.S3FileHandle;
 import org.sagebionetworks.repo.model.wiki.WikiHeader;
 import org.sagebionetworks.repo.model.wiki.WikiPage;
-import org.sagebionetworks.utils.MD5ChecksumHelper;
 
 public class IT055WikiPageTest {
 
@@ -91,7 +91,8 @@ public class IT055WikiPageTest {
 		for (String id : handlesToDelete) {
 			try {
 				adminSynapse.deleteFileHandle(id);
-			} catch (SynapseNotFoundException e) {}
+			} catch (SynapseNotFoundException e) {
+			} catch (SynapseServiceException e) { }
 		}
 		
 		adminSynapse.deleteAndPurgeEntity(project);
@@ -102,7 +103,9 @@ public class IT055WikiPageTest {
 	
 	@AfterClass
 	public static void afterClass() throws Exception {
-		adminSynapse.deleteUser(userToDelete);
+		try {
+			adminSynapse.deleteUser(userToDelete);
+		} catch (SynapseServiceException e) { }
 	}
 	
 	@Test

--- a/integration-test/src/test/java/org/sagebionetworks/IT500SynapseJavaClient.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT500SynapseJavaClient.java
@@ -41,6 +41,7 @@ import org.sagebionetworks.client.exceptions.SynapseBadRequestException;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseForbiddenException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
+import org.sagebionetworks.client.exceptions.SynapseServiceException;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.AccessRequirement;
@@ -177,7 +178,8 @@ public class IT500SynapseJavaClient {
 		for (String id : handlesToDelete) {
 			try {
 				adminSynapse.deleteFileHandle(id);
-			} catch (SynapseNotFoundException e) {}
+			} catch (SynapseNotFoundException e) {
+			} catch (SynapseServiceException e) { }
 		}
 		
 		for (String id : teamsToDelete) {
@@ -189,8 +191,12 @@ public class IT500SynapseJavaClient {
 	
 	@AfterClass
 	public static void afterClass() throws Exception {
-		adminSynapse.deleteUser(user1ToDelete);
-		adminSynapse.deleteUser(user2ToDelete);
+		try {
+			adminSynapse.deleteUser(user1ToDelete);
+		} catch (SynapseServiceException e) { }
+		try {
+			adminSynapse.deleteUser(user2ToDelete);
+		} catch (SynapseServiceException e) { }
 	}
 	
 	@Test

--- a/integration-test/src/test/java/org/sagebionetworks/IT501SynapseJavaClientMessagingTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT501SynapseJavaClientMessagingTest.java
@@ -19,6 +19,8 @@ import org.sagebionetworks.client.SynapseAdminClient;
 import org.sagebionetworks.client.SynapseAdminClientImpl;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.SynapseClientImpl;
+import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
+import org.sagebionetworks.client.exceptions.SynapseServiceException;
 import org.sagebionetworks.client.exceptions.SynapseUserException;
 import org.sagebionetworks.repo.model.PaginatedResults;
 import org.sagebionetworks.repo.model.Project;
@@ -131,13 +133,18 @@ public class IT501SynapseJavaClientMessagingTest {
 		
 		try {
 			synapseOne.deleteFileHandle(oneToRuleThemAll.getId());
-		} catch (Exception e) { }
+		} catch (SynapseNotFoundException e) {
+		} catch (SynapseServiceException e) { }
 	}
 	
 	@AfterClass
 	public static void afterClass() throws Exception {
-		adminSynapse.deleteUser(user1ToDelete);
-		adminSynapse.deleteUser(user2ToDelete);
+		try {
+			adminSynapse.deleteUser(user1ToDelete);
+		} catch (SynapseServiceException e) { }
+		try {
+			adminSynapse.deleteUser(user2ToDelete);
+		} catch (SynapseServiceException e) { }
 	}
 
 	@SuppressWarnings("serial")

--- a/integration-test/src/test/java/org/sagebionetworks/IT520SynapseJavaClientEvaluationTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT520SynapseJavaClientEvaluationTest.java
@@ -27,6 +27,7 @@ import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
+import org.sagebionetworks.client.exceptions.SynapseServiceException;
 import org.sagebionetworks.evaluation.dbo.DBOConstants;
 import org.sagebionetworks.evaluation.model.Evaluation;
 import org.sagebionetworks.evaluation.model.EvaluationStatus;
@@ -190,14 +191,19 @@ public class IT520SynapseJavaClientEvaluationTest {
 		if(fileHandle != null){
 			try {
 				adminSynapse.deleteFileHandle(fileHandle.getId());
-			} catch (SynapseNotFoundException e) {}
+			} catch (SynapseNotFoundException e) {
+			} catch (SynapseServiceException e) { }
 		}
 	}
 	
 	@AfterClass
 	public static void afterClass() throws Exception {
-		adminSynapse.deleteUser(user1ToDelete);
-		adminSynapse.deleteUser(user2ToDelete);
+		try {
+			adminSynapse.deleteUser(user1ToDelete);
+		} catch (SynapseServiceException e) { }
+		try {
+			adminSynapse.deleteUser(user2ToDelete);
+		} catch (SynapseServiceException e) { }
 	}
 	
 	@Test


### PR DESCRIPTION
The cleanup of these tests cannot keep failing due to race conditions.  
For now, since the lack of cleanup does not affect other tests, we can silently catch the errors (and hopefully deal with them in the future).
