### PR TITLE
PLFM-2509

### DIFF
--- a/client/fileUploadClient/src/test/java/org/sagebionetworks/client/FileUploaderTest.java
+++ b/client/fileUploadClient/src/test/java/org/sagebionetworks/client/FileUploaderTest.java
@@ -186,7 +186,7 @@ public class FileUploaderTest {
 		when(mockFuture1.get()).thenReturn(null);
 		Future<Entity> mockFuture2 = mock(Future.class);
 		when(mockFuture2.isDone()).thenReturn(true);
-		when(mockFuture2.get()).thenThrow(new ExecutionException("(409)", new SynapseUserException("(409)")));
+		when(mockFuture2.get()).thenThrow(new ExecutionException("(409)", new SynapseUserException(409, "(409)")));
 		Future<Entity> mockFuture3 = mock(Future.class);
 		when(mockFuture3.isDone()).thenReturn(true);
 		when(mockFuture3.get()).thenThrow(new ExecutionException("some reason", new SynapseException("Some other exception")));		

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
@@ -2619,7 +2619,7 @@ public class SynapseClientImpl extends BaseClientImpl implements SynapseClient {
 			File destinationFile) throws SynapseException {
 		List<LocationData> locations = locationable.getLocations();
 		if ((null == locations) || (0 == locations.size())) {
-			throw new SynapseUserException(
+			throw new SynapseException(
 					"No locations available for locationable " + locationable);
 		}
 

--- a/integration-test/src/test/java/org/sagebionetworks/IT501SynapseJavaClientMessagingTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT501SynapseJavaClientMessagingTest.java
@@ -20,6 +20,7 @@ import org.sagebionetworks.client.SynapseAdminClient;
 import org.sagebionetworks.client.SynapseAdminClientImpl;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.SynapseClientImpl;
+import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.client.exceptions.SynapseServiceException;
 import org.sagebionetworks.client.exceptions.SynapseUserException;
@@ -244,8 +245,8 @@ public class IT501SynapseJavaClientMessagingTest {
 			try {
 				oneToTwo = synapseOne.sendMessage(oneToTwo);
 				cleanup.add(oneToTwo.getId());
-			} catch (SynapseUserException e) {
-				if (e.getMessage().contains("429")) {
+			} catch (SynapseException e) {
+				if (e.getStatusCode()==429) {
 					gotNerfed = true;
 					break;
 				}

--- a/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
@@ -131,7 +131,7 @@ public class IT990AuthenticationController {
 		try {
 			synapse.createUser(user);
 		} catch (SynapseUserException e) {
-			assertTrue(e.getMessage().contains("409"));
+			assertTrue(e.getStatusCode()==409);
 		}
 	}
 	

--- a/lib/communicationUtilities/src/main/java/org/sagebionetworks/utils/HttpClientHelper.java
+++ b/lib/communicationUtilities/src/main/java/org/sagebionetworks/utils/HttpClientHelper.java
@@ -380,8 +380,7 @@ public class HttpClientHelper {
 			String responseBody = (null != response.getEntity()) ? EntityUtils
 					.toString(response.getEntity()) : null;
 			verboseMessage.append("\nResponse Content: " + responseBody);
-			throw new HttpClientHelperException(verboseMessage.toString(),
-					response);
+			throw new HttpClientHelperException(verboseMessage.toString(), response.getStatusLine().getStatusCode(), responseBody);
 		}
 		return response;
 	}
@@ -411,7 +410,8 @@ public class HttpClientHelper {
 				throw new HttpClientHelperException("Requested content("
 						+ requestUrl + ") is too large("
 						+ entity.getContentLength()
-						+ "), download it to a file instead", response);
+						+ "), download it to a file instead", response.getStatusLine().getStatusCode(), responseContent);
+
 			}
 			responseContent = EntityUtils.toString(entity);
 		}
@@ -477,7 +477,7 @@ public class HttpClientHelper {
 				throw new HttpClientHelperException("Requested content("
 						+ requestUrl + ") is too large("
 						+ entity.getContentLength()
-						+ "), download it to a file instead", response);
+						+ "), download it to a file instead", response.getStatusLine().getStatusCode(), responseContent);
 			}
 			responseContent = EntityUtils.toString(entity);
 		}
@@ -516,7 +516,7 @@ public class HttpClientHelper {
 				throw new HttpClientHelperException("Requested content("
 						+ requestUrl + ") is too large("
 						+ entity.getContentLength()
-						+ "), download it to a file instead", response);
+						+ "), download it to a file instead", response.getStatusLine().getStatusCode(), responseContent);
 			}
 			responseContent = EntityUtils.toString(entity);
 		}
@@ -555,7 +555,7 @@ public class HttpClientHelper {
 				throw new HttpClientHelperException("Requested content("
 						+ requestUrl + ") is too large("
 						+ entity.getContentLength()
-						+ "), download it to a file instead", response);
+						+ "), download it to a file instead", response.getStatusLine().getStatusCode(), responseContent);
 			}
 			responseContent = EntityUtils.toString(entity);
 		}
@@ -625,10 +625,11 @@ public class HttpClientHelper {
 			String errorMessage = "Request(" + requestUrl + ") failed: "
 					+ response.getStatusLine().getReasonPhrase();
 			HttpEntity responseEntity = response.getEntity();
+			String responseContent = EntityUtils.toString(responseEntity);
 			if (null != responseEntity) {
-				errorMessage += EntityUtils.toString(responseEntity);
+				errorMessage += responseContent;
 			}
-			throw new HttpClientHelperException(errorMessage, response);
+			throw new HttpClientHelperException(errorMessage, response.getStatusLine().getStatusCode(), responseContent);
 		}
 	}
 }

--- a/lib/communicationUtilities/src/main/java/org/sagebionetworks/utils/HttpClientHelperException.java
+++ b/lib/communicationUtilities/src/main/java/org/sagebionetworks/utils/HttpClientHelperException.java
@@ -3,6 +3,7 @@
  */
 package org.sagebionetworks.utils;
 
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
 
@@ -36,16 +37,10 @@ public class HttpClientHelperException extends Exception {
 	 * @param message
 	 * @param response
 	 */
-	public HttpClientHelperException(String message, HttpResponse response) {
+	public HttpClientHelperException(String message, int responseStatusCode, String responseString) {
 		super(message);
-		this.httpStatus = response.getStatusLine().getStatusCode();
-		try {
-			this.response = (null != response.getEntity()) ? EntityUtils
-					.toString(response.getEntity()) : null;
-		} catch (Exception e) {
-			// This is okay to swallow because its just a best effort to
-			// retrieve more info when we are already in an exception situation
-		}
+		this.httpStatus = responseStatusCode;
+		this.response = responseString;
 	}
 
 	/**

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOReferenceDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOReferenceDaoImpl.java
@@ -23,11 +23,13 @@ import java.util.Set;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.EntityType;
+import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.QueryResults;
 import org.sagebionetworks.repo.model.Reference;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.dbo.DBOBasicDao;
 import org.sagebionetworks.repo.model.dbo.persistence.DBOReference;
+import org.sagebionetworks.repo.model.jdo.AuthorizationSqlUtil;
 import org.sagebionetworks.repo.model.jdo.KeyFactory;
 import org.sagebionetworks.repo.model.query.jdo.QueryUtils;
 import org.sagebionetworks.repo.model.query.jdo.SqlConstants;
@@ -136,6 +138,7 @@ public class DBOReferenceDaoImpl implements DBOReferenceDao {
 		} else {
 			queryTail = REFERRER_SELECT_SQL_WITH_REVISION_TAIL;
 		}
+		baseParameters.put(AuthorizationSqlUtil.RESOURCE_TYPE_BIND_VAR, ObjectType.ENTITY.name());
 		String authorizationFilter = QueryUtils.buildAuthorizationFilter(userInfo, baseParameters);
 		String fullQuery = null;
 		if (authorizationFilter.length()>0) {

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/query/jdo/JDONodeQueryDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/query/jdo/JDONodeQueryDaoImpl.java
@@ -11,7 +11,9 @@ import org.sagebionetworks.StackConfiguration;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.NodeQueryDao;
 import org.sagebionetworks.repo.model.NodeQueryResults;
+import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.model.jdo.AuthorizationSqlUtil;
 import org.sagebionetworks.repo.model.jdo.FieldTypeCache;
 import org.sagebionetworks.repo.model.jdo.KeyFactory;
 import org.sagebionetworks.repo.model.query.BasicQuery;
@@ -194,6 +196,7 @@ public class JDONodeQueryDaoImpl implements NodeQueryDao {
 			return false;
 		}
 		// Build the authorization filter
+		parameters.put(AuthorizationSqlUtil.RESOURCE_TYPE_BIND_VAR, ObjectType.ENTITY.name());
 		String authorizationFilter = QueryUtils.buildAuthorizationFilter(userInfo, parameters);
 		// Build the paging
 		String paging = QueryUtils.buildPaging(in.getOffset(), in.getLimit(), parameters);

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/query/jdo/QueryUtils.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/query/jdo/QueryUtils.java
@@ -90,7 +90,6 @@ public class QueryUtils {
 		String sql = AuthorizationSqlUtil.authorizationSQL(groups.size());
 		// Bind the variables
 		parameters.put(AuthorizationSqlUtil.ACCESS_TYPE_BIND_VAR, ACCESS_TYPE.READ.name());
-		parameters.put(AuthorizationSqlUtil.RESOURCE_TYPE_BIND_VAR, ObjectType.ENTITY.name());
 		// Bind each group
 		Iterator<Long> it = groups.iterator();
 		int index = 0;

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/query/jdo/JDONodeQueryUnitTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/query/jdo/JDONodeQueryUnitTest.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
+import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.jdo.AuthorizationSqlUtil;
@@ -49,6 +50,7 @@ public class JDONodeQueryUnitTest {
 		when(nonAdminUserInfo.getGroups()).thenReturn(null);
 		HashMap<String, Object> params = new HashMap<String, Object>();
 		// should throw an exception
+		params.put(AuthorizationSqlUtil.RESOURCE_TYPE_BIND_VAR, ObjectType.ENTITY.name());
 		String sql = QueryUtils.buildAuthorizationFilter(nonAdminUserInfo, params);
 	}
 	
@@ -59,6 +61,7 @@ public class JDONodeQueryUnitTest {
 		when(nonAdminUserInfo.getGroups()).thenReturn(new HashSet<Long>());
 		HashMap<String, Object> params = new HashMap<String, Object>();
 		// Should throw an exception.
+		params.put(AuthorizationSqlUtil.RESOURCE_TYPE_BIND_VAR, ObjectType.ENTITY.name());
 		String sql = QueryUtils.buildAuthorizationFilter(nonAdminUserInfo, params);
 	}
 	
@@ -76,6 +79,7 @@ public class JDONodeQueryUnitTest {
 		groups.add(Long.parseLong(group.getId()));
 		when(nonAdminUserInfo.getGroups()).thenReturn(groups);
 		// This should build a query with two groups
+		params.put(AuthorizationSqlUtil.RESOURCE_TYPE_BIND_VAR, ObjectType.ENTITY.name());
 		String sql = QueryUtils.buildAuthorizationFilter(nonAdminUserInfo, params);
 		assertNotNull(sql);
 		// It should not be an empty string.

--- a/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/SharedClientConnection.java
+++ b/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/SharedClientConnection.java
@@ -706,15 +706,15 @@ public class SharedClientConnection {
 						+ resultsStr + " " + e.getMessage();
 
 				if (statusCode == 401) {
-					throw new SynapseUnauthorizedException(exceptionContent);
+					throw new SynapseUnauthorizedException(resultsStr);
 				} else if (statusCode == 403) {
-					throw new SynapseForbiddenException(exceptionContent);
+					throw new SynapseForbiddenException(resultsStr);
 				} else if (statusCode == 404) {
-					throw new SynapseNotFoundException(exceptionContent);
+					throw new SynapseNotFoundException(resultsStr);
 				} else if (statusCode == 400) {
-					throw new SynapseBadRequestException(exceptionContent);
+					throw new SynapseBadRequestException(resultsStr);
 				} else if (statusCode >= 400 && statusCode < 500) {
-					throw new SynapseUserException(exceptionContent);
+					throw new SynapseUserException(resultsStr);
 				} else {
 					throw new SynapseServiceException("request content: "+requestContent+" exception content: "+exceptionContent+" status code: "+statusCode);
 				}

--- a/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/SharedClientConnection.java
+++ b/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/SharedClientConnection.java
@@ -265,7 +265,7 @@ public class SharedClientConnection {
 			HttpResponse response = clientProvider.execute(httppost);
 			int code = response.getStatusLine().getStatusCode();
 			if (code < 200 || code > 299) {
-				throw new SynapseException("Response code: " + code + " " + response.getStatusLine().getReasonPhrase()
+				throw new SynapseException(code, "Response code: " + code + " " + response.getStatusLine().getReasonPhrase()
 						+ " for " + url + " File: " + file.getName());
 			}
 			return EntityUtils.toString(response.getEntity());
@@ -297,7 +297,7 @@ public class SharedClientConnection {
 			HttpResponse response = clientProvider.execute(httppost);
 			int code = response.getStatusLine().getStatusCode();
 			if (code < 200 || code > 299) {
-				throw new SynapseException("Response code: " + code + " " + response.getStatusLine().getReasonPhrase()
+				throw new SynapseException(code, "Response code: " + code + " " + response.getStatusLine().getReasonPhrase()
 						+ " for " + url);
 			}
 			return EntityUtils.toString(response.getEntity());
@@ -327,7 +327,7 @@ public class SharedClientConnection {
 			int code = response.getStatusLine().getStatusCode();
 			String responseBody = (null != response.getEntity()) ? EntityUtils.toString(response.getEntity()) : null;
 			if(code < 200 || code > 299){
-				throw new SynapseException("Response code: "+code+" "+response.getStatusLine().getReasonPhrase()+" for "+url+" body: "+requestBody);
+				throw new SynapseException(code, "Response code: "+code+" "+response.getStatusLine().getReasonPhrase()+" for "+url+" body: "+requestBody);
 			}
 			return responseBody;
 		} catch (UnsupportedEncodingException e) {
@@ -381,7 +381,7 @@ public class SharedClientConnection {
 		int statusCode = response.getStatusLine().getStatusCode();
 		if(statusCode != 200) {
 			String message = EntityUtils.toString(entity);
-			throw new SynapseException("Status code: " + statusCode + ", " + message);
+			throw new SynapseException(statusCode, "Status code: " + statusCode + ", " + message);
 		}
 		return FileUtils.readCompressedStreamAsString(entity.getContent());
 	}
@@ -396,7 +396,7 @@ public class SharedClientConnection {
 				String localMd5 = MD5ChecksumHelper
 						.getMD5Checksum(destinationFile.getAbsolutePath());
 				if (!localMd5.equals(md5)) {
-					throw new SynapseUserException(
+					throw new SynapseException(
 							"md5 of downloaded file does not match the one in Synapse"
 									+ destinationFile);
 				}
@@ -714,7 +714,7 @@ public class SharedClientConnection {
 				} else if (statusCode == 400) {
 					throw new SynapseBadRequestException(resultsStr);
 				} else if (statusCode >= 400 && statusCode < 500) {
-					throw new SynapseUserException(resultsStr);
+					throw new SynapseUserException(statusCode, resultsStr);
 				} else {
 					throw new SynapseServiceException("request content: "+requestContent+" exception content: "+exceptionContent+" status code: "+statusCode);
 				}

--- a/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseBadRequestException.java
+++ b/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseBadRequestException.java
@@ -1,24 +1,28 @@
 package org.sagebionetworks.client.exceptions;
 
+import org.apache.http.HttpStatus;
+
 
 public class SynapseBadRequestException extends SynapseUserException {
 	
 	private static final long serialVersionUID = 1L;
 
+	private static final int STATUS_CODE = HttpStatus.SC_BAD_REQUEST;
+
 	public SynapseBadRequestException() {
-		super();
+		super(STATUS_CODE);
 	}
 
 	public SynapseBadRequestException(String message, Throwable cause) {
-		super(message, cause);
+		super(STATUS_CODE, message, cause);
 	}
 
 	public SynapseBadRequestException(String message) {
-		super(message);
+		super(STATUS_CODE, message);
 	}
 
 	public SynapseBadRequestException(Throwable cause) {
-		super(cause);
+		super(STATUS_CODE, cause);
 	}
 
 }

--- a/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseException.java
+++ b/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseException.java
@@ -1,30 +1,58 @@
 package org.sagebionetworks.client.exceptions;
 
+import org.apache.http.HttpStatus;
+
+
 public class SynapseException extends Exception {
+	private int statusCode;
+	
+	private static final int DEFAULT_STATUS_CODE = HttpStatus.SC_INTERNAL_SERVER_ERROR;
 
 	/**
 	 * 
 	 */
 	private static final long serialVersionUID = 1L;
 
+	public SynapseException(int httpStatus) {
+		super();
+		this.statusCode = httpStatus;
+	}
+
+	public SynapseException(int httpStatus, String arg0, Throwable arg1) {
+		super(arg0, arg1);
+		this.statusCode = httpStatus;
+	}
+
+	public SynapseException(int httpStatus, String arg0) {
+		super(arg0);
+		this.statusCode = httpStatus;
+	}
+
+	public SynapseException(int httpStatus, Throwable arg0) {
+		super(arg0);
+		this.statusCode = httpStatus;
+	}
+	
 	public SynapseException() {
 		super();
-		// TODO Auto-generated constructor stub
+		this.statusCode = DEFAULT_STATUS_CODE;
 	}
 
 	public SynapseException(String arg0, Throwable arg1) {
 		super(arg0, arg1);
-		// TODO Auto-generated constructor stub
+		this.statusCode = DEFAULT_STATUS_CODE;
 	}
 
 	public SynapseException(String arg0) {
 		super(arg0);
-		// TODO Auto-generated constructor stub
+		this.statusCode = DEFAULT_STATUS_CODE;
 	}
 
 	public SynapseException(Throwable arg0) {
 		super(arg0);
-		// TODO Auto-generated constructor stub
+		this.statusCode = DEFAULT_STATUS_CODE;
 	}
+	
+	public int getStatusCode() {return statusCode;}
 
 }

--- a/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseForbiddenException.java
+++ b/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseForbiddenException.java
@@ -1,24 +1,28 @@
 package org.sagebionetworks.client.exceptions;
 
+import org.apache.http.HttpStatus;
+
 
 public class SynapseForbiddenException extends SynapseUserException {
 	
 	private static final long serialVersionUID = 1L;
 
+	private static final int STATUS_CODE = HttpStatus.SC_FORBIDDEN;
+
 	public SynapseForbiddenException() {
-		super();
+		super(STATUS_CODE);
 	}
 
 	public SynapseForbiddenException(String message, Throwable cause) {
-		super(message, cause);
+		super(STATUS_CODE, message, cause);
 	}
 
 	public SynapseForbiddenException(String message) {
-		super(message);
+		super(STATUS_CODE, message);
 	}
 
 	public SynapseForbiddenException(Throwable cause) {
-		super(cause);
+		super(STATUS_CODE, cause);
 	}
 
 }

--- a/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseNotFoundException.java
+++ b/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseNotFoundException.java
@@ -1,23 +1,27 @@
 package org.sagebionetworks.client.exceptions;
 
+import org.apache.http.HttpStatus;
+
 public class SynapseNotFoundException extends SynapseUserException {
 	
 	private static final long serialVersionUID = 1L;
 
+	private static final int STATUS_CODE = HttpStatus.SC_NOT_FOUND;
+
 	public SynapseNotFoundException() {
-		super();
+		super(STATUS_CODE);
 	}
 
 	public SynapseNotFoundException(String message, Throwable cause) {
-		super(message, cause);
+		super(STATUS_CODE, message, cause);
 	}
 
 	public SynapseNotFoundException(String message) {
-		super(message);
+		super(STATUS_CODE, message);
 	}
 
 	public SynapseNotFoundException(Throwable cause) {
-		super(cause);
+		super(STATUS_CODE, cause);
 	}
 
 }

--- a/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseServiceException.java
+++ b/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseServiceException.java
@@ -3,6 +3,8 @@
  */
 package org.sagebionetworks.client.exceptions;
 
+import org.apache.http.HttpStatus;
+
 /**
  * @author deflaux
  *
@@ -14,27 +16,27 @@ public class SynapseServiceException extends SynapseException {
 	 */
 	private static final long serialVersionUID = 1L;
 
+	private static final int STATUS_CODE = HttpStatus.SC_INTERNAL_SERVER_ERROR;
+
 	/**
 	 * 
 	 */
 	public SynapseServiceException() {
-		// TODO Auto-generated constructor stub
+		super(STATUS_CODE);
 	}
 
 	/**
 	 * @param arg0
 	 */
 	public SynapseServiceException(String arg0) {
-		super(arg0);
-		// TODO Auto-generated constructor stub
+		super(STATUS_CODE, arg0);
 	}
 
 	/**
 	 * @param arg0
 	 */
 	public SynapseServiceException(Throwable arg0) {
-		super(arg0);
-		// TODO Auto-generated constructor stub
+		super(STATUS_CODE, arg0);
 	}
 
 	/**
@@ -42,8 +44,7 @@ public class SynapseServiceException extends SynapseException {
 	 * @param arg1
 	 */
 	public SynapseServiceException(String arg0, Throwable arg1) {
-		super(arg0, arg1);
-		// TODO Auto-generated constructor stub
+		super(STATUS_CODE, arg0, arg1);
 	}
 
 }

--- a/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseTermsOfUseException.java
+++ b/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseTermsOfUseException.java
@@ -1,24 +1,28 @@
 package org.sagebionetworks.client.exceptions;
 
+import org.apache.http.HttpStatus;
+
 
 public class SynapseTermsOfUseException extends SynapseUserException {
 	
 	private static final long serialVersionUID = 1L;
+	
+	private static final int STATUS_CODE = HttpStatus.SC_FORBIDDEN;
 
 	public SynapseTermsOfUseException() {
-		super();
+		super(STATUS_CODE);
 	}
 
 	public SynapseTermsOfUseException(String message, Throwable cause) {
-		super(message, cause);
+		super(STATUS_CODE, message, cause);
 	}
 
 	public SynapseTermsOfUseException(String message) {
-		super(message);
+		super(STATUS_CODE, message);
 	}
 
 	public SynapseTermsOfUseException(Throwable cause) {
-		super(cause);
+		super(STATUS_CODE, cause);
 	}
 
 }

--- a/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseUnauthorizedException.java
+++ b/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseUnauthorizedException.java
@@ -1,23 +1,27 @@
 package org.sagebionetworks.client.exceptions;
 
+import org.apache.http.HttpStatus;
+
 public class SynapseUnauthorizedException extends SynapseUserException {
 	
 	private static final long serialVersionUID = 1L;
 
+	private static final int STATUS_CODE = HttpStatus.SC_UNAUTHORIZED;
+
 	public SynapseUnauthorizedException() {
-		super();
+		super(STATUS_CODE);
 	}
 
 	public SynapseUnauthorizedException(String message, Throwable cause) {
-		super(message, cause);
+		super(STATUS_CODE, message, cause);
 	}
 
 	public SynapseUnauthorizedException(String message) {
-		super(message);
+		super(STATUS_CODE, message);
 	}
 
 	public SynapseUnauthorizedException(Throwable cause) {
-		super(cause);
+		super(STATUS_CODE, cause);
 	}
 
 }

--- a/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseUserException.java
+++ b/lib/lib-javaclient/src/main/java/org/sagebionetworks/client/exceptions/SynapseUserException.java
@@ -3,6 +3,7 @@
  */
 package org.sagebionetworks.client.exceptions;
 
+
 /**
  * @author deflaux
  *
@@ -17,33 +18,31 @@ public class SynapseUserException extends SynapseException {
 	/**
 	 * 
 	 */
-	public SynapseUserException() {
-		// TODO Auto-generated constructor stub
+	public SynapseUserException(int httpStatus) {
+		super(httpStatus);
 	}
 
 	/**
 	 * @param arg0
 	 */
-	public SynapseUserException(String arg0) {
-		super(arg0);
-		// TODO Auto-generated constructor stub
+	public SynapseUserException(int httpStatus, String arg0) {
+		super(httpStatus, arg0);
 	}
 
 	/**
 	 * @param arg0
 	 */
-	public SynapseUserException(Throwable arg0) {
-		super(arg0);
-		// TODO Auto-generated constructor stub
+	public SynapseUserException(int httpStatus, Throwable arg0) {
+		super(httpStatus, arg0);
 	}
 
 	/**
 	 * @param arg0
 	 * @param arg1
 	 */
-	public SynapseUserException(String arg0, Throwable arg1) {
-		super(arg0, arg1);
-		// TODO Auto-generated constructor stub
+	public SynapseUserException(int httpStatus, String arg0, Throwable arg1) {
+		super(httpStatus, arg0, arg1);
+
 	}
 
 }

--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationFilter.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationFilter.java
@@ -68,7 +68,7 @@ public class AuthenticationFilter implements Filter {
 		//      http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.47
 		//      http://www.ietf.org/rfc/rfc2617.txt
 		resp.setHeader("WWW-Authenticate", "\"Digest\" your email");
-		resp.getWriter().println("{\"reason\", \""+reason+"\"}");
+		resp.getWriter().println("{\"reason\": \""+reason+"\"}");
 	}
 
 	@Override


### PR DESCRIPTION
This PR addresses two problems:
1) Fixed a bug in HttpClientHelperException constructor which was throwing and swallowing an exception;
2) In SharedClientConnection, user exceptions should wrap user messages but instead these exceptions were being passed bundles of information suitable for logging.  For such user exceptions I stripped away all but the user messages.
