### PR TITLE
PLFM-2901

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/ParentInTrashCanException.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/ParentInTrashCanException.java
@@ -4,7 +4,6 @@ public class ParentInTrashCanException extends RuntimeException {
 
 	private static final long serialVersionUID = -4218320662080445999L;
 	
-	//
 	public ParentInTrashCanException(String message) {
 		super(message);
 	}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/ParentInTrashCanException.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/ParentInTrashCanException.java
@@ -3,7 +3,8 @@ package org.sagebionetworks.repo.manager.trash;
 public class ParentInTrashCanException extends RuntimeException {
 
 	private static final long serialVersionUID = -4218320662080445999L;
-
+	
+	//
 	public ParentInTrashCanException(String message) {
 		super(message);
 	}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/ParentInTrashCanException.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/ParentInTrashCanException.java
@@ -1,0 +1,10 @@
+package org.sagebionetworks.repo.manager.trash;
+
+public class ParentInTrashCanException extends RuntimeException {
+
+	private static final long serialVersionUID = -4218320662080445999L;
+
+	public ParentInTrashCanException(String message) {
+		super(message);
+	}
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/TrashManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/TrashManagerImpl.java
@@ -136,11 +136,20 @@ public class TrashManagerImpl implements TrashManager {
 		if (nodeId == null) {
 			throw new IllegalArgumentException("Node ID cannot be null");
 		}
-
+		
 		// Make sure the node is in the trash can
 		final TrashedEntity trash = trashCanDao.getTrashedEntity(nodeId);
 		if (trash == null) {
 			throw new NotFoundException("The node " + nodeId + " is not in the trash can.");
+		}
+		
+		// Restore to its original parent if a new parent is not given
+		if (newParentId == null) {
+			newParentId = trash.getOriginalParentId();
+		}
+		
+		if (trashCanDao.getTrashedEntity(newParentId) != null) {
+			throw new EntityInTrashCanException("The parent " + newParentId + " is in the trash can and cannot be restored to.");
 		}
 
 		// Make sure the node was indeed deleted by the user
@@ -152,10 +161,7 @@ public class TrashManagerImpl implements TrashManager {
 					+ nodeId + ". The node was deleted by a different user.");
 		}
 
-		// Restore to its original parent if a new parent is not given
-		if (newParentId == null) {
-			newParentId = trash.getOriginalParentId();
-		}
+		
 
 		// Authorize on the new parent
 		String userName = currentUser.getId().toString();

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/TrashManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/TrashManagerImpl.java
@@ -142,11 +142,6 @@ public class TrashManagerImpl implements TrashManager {
 		if (trash == null) {
 			throw new NotFoundException("The node " + nodeId + " is not in the trash can.");
 		}
-		
-		// Make sure original parent is not in trash can.
-		if (trashCanDao.getTrashedEntity(trash.getOriginalParentId()) != null) {
-			throw new ParentInTrashCanException("The original parent " + trash.getOriginalParentId() + " is in the trash can and cannot be restored to.");
-		}
 
 		// Make sure the node was indeed deleted by the user
 		UserInfo.validateUserInfo(currentUser);
@@ -160,11 +155,11 @@ public class TrashManagerImpl implements TrashManager {
 		// Restore to its original parent if a new parent is not given
 		if (newParentId == null) {
 			newParentId = trash.getOriginalParentId();
-		} else {
-			// Make sure new parent is not in trash can.
-			if (trashCanDao.getTrashedEntity(newParentId) != null) {
-				throw new ParentInTrashCanException("The new parent " + newParentId + " is in the trash can and cannot be restored to.");
-			}
+		}
+		
+		// Make sure new parent is not in trash can.
+		if (trashCanDao.getTrashedEntity(newParentId) != null) {
+			throw new ParentInTrashCanException("The new parent " + newParentId + " is in the trash can and cannot be restored to.");
 		}
 
 		// Authorize on the new parent

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/TrashManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/trash/TrashManagerImpl.java
@@ -143,13 +143,9 @@ public class TrashManagerImpl implements TrashManager {
 			throw new NotFoundException("The node " + nodeId + " is not in the trash can.");
 		}
 		
-		// Restore to its original parent if a new parent is not given
-		if (newParentId == null) {
-			newParentId = trash.getOriginalParentId();
-		}
-		
-		if (trashCanDao.getTrashedEntity(newParentId) != null) {
-			throw new EntityInTrashCanException("The parent " + newParentId + " is in the trash can and cannot be restored to.");
+		// Make sure original parent is not in trash can.
+		if (trashCanDao.getTrashedEntity(trash.getOriginalParentId()) != null) {
+			throw new ParentInTrashCanException("The original parent " + trash.getOriginalParentId() + " is in the trash can and cannot be restored to.");
 		}
 
 		// Make sure the node was indeed deleted by the user
@@ -161,7 +157,15 @@ public class TrashManagerImpl implements TrashManager {
 					+ nodeId + ". The node was deleted by a different user.");
 		}
 
-		
+		// Restore to its original parent if a new parent is not given
+		if (newParentId == null) {
+			newParentId = trash.getOriginalParentId();
+		} else {
+			// Make sure new parent is not in trash can.
+			if (trashCanDao.getTrashedEntity(newParentId) != null) {
+				throw new ParentInTrashCanException("The new parent " + newParentId + " is in the trash can and cannot be restored to.");
+			}
+		}
 
 		// Authorize on the new parent
 		String userName = currentUser.getId().toString();

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/trash/TrashManagerImplAutowiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/trash/TrashManagerImplAutowiredTest.java
@@ -910,7 +910,7 @@ public class TrashManagerImplAutowiredTest {
 		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdC1)));
 	}
 	
-	@Test(expected=EntityInTrashCanException.class)
+	@Test(expected=ParentInTrashCanException.class)
 	public void testRestoreToParentThatIsInTrashCan() throws Exception {
 		// A --> Parent
 		final Node nodeA = new Node();

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/trash/TrashManagerImplAutowiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/trash/TrashManagerImplAutowiredTest.java
@@ -526,7 +526,7 @@ public class TrashManagerImplAutowiredTest {
 		//           /  \
 		//          A1  A2
 		//          |    |
-		//          B1  B2
+		//          B1  B
 		//          |
 		//          C1
 		//
@@ -555,14 +555,14 @@ public class TrashManagerImplAutowiredTest {
 		assertNotNull(nodeIdB1);
 		toClearList.add(nodeIdB1);
 		
-		final Node nodeB2 = new Node();
-		final String nodeNameB2 = "TrashManagerImplAutowiredTest.testPurge() B2";
-		nodeB2.setName(nodeNameB2);
-		nodeB2.setNodeType(EntityType.folder.name());
-		nodeB2.setParentId(nodeIdA2);
-		final String nodeIdB2 = nodeManager.createNewNode(nodeB2, testUserInfo);
-		assertNotNull(nodeIdB2);
-		toClearList.add(nodeIdB2);
+		final Node nodeB = new Node();
+		final String nodeNameB = "TrashManagerImplAutowiredTest.testPurge() B";
+		nodeB.setName(nodeNameB);
+		nodeB.setNodeType(EntityType.folder.name());
+		nodeB.setParentId(nodeIdA2);
+		final String nodeIdB = nodeManager.createNewNode(nodeB, testUserInfo);
+		assertNotNull(nodeIdB);
+		toClearList.add(nodeIdB);
 
 		final Node nodeC1 = new Node();
 		final String nodeNameC1 = "TrashManagerImplAutowiredTest.testPurge() C1";
@@ -577,18 +577,18 @@ public class TrashManagerImplAutowiredTest {
 		trashManager.moveToTrash(testUserInfo, nodeIdA1);
 		trashManager.moveToTrash(testUserInfo, nodeIdA2);
 
-		// Purge B2 (a child)
-		trashManager.purgeTrashForUser(testUserInfo, nodeIdB2);
+		// Purge B (a child)
+		trashManager.purgeTrashForUser(testUserInfo, nodeIdB);
 		results = trashManager.viewTrashForUser(testUserInfo, testUserInfo, 0L, 1000L);
 		assertEquals(4L, results.getTotalNumberOfResults());
 		assertEquals(4, results.getResults().size());
 		for (TrashedEntity trash : results.getResults()) {
-			if (nodeIdB2.equals(trash.getEntityId())) {
+			if (nodeIdB.equals(trash.getEntityId())) {
 				fail();
 			}
 		}
 		String testUserId = testUserInfo.getId().toString();
-		assertFalse(trashCanDao.exists(testUserId, nodeIdB2));
+		assertFalse(trashCanDao.exists(testUserId, nodeIdB));
 
 		// Purge A1 (a root with 2 descendants)
 		trashManager.purgeTrashForUser(testUserInfo, nodeIdA1);
@@ -620,7 +620,7 @@ public class TrashManagerImplAutowiredTest {
 		//           /  \
 		//          A1  A2
 		//          |    |
-		//          B1  B2
+		//          B1  B
 		//          |
 		//          C1
 		//
@@ -649,14 +649,14 @@ public class TrashManagerImplAutowiredTest {
 		assertNotNull(nodeIdB1);
 		toClearList.add(nodeIdB1);
 		
-		final Node nodeB2 = new Node();
-		final String nodeNameB2 = "TrashManagerImplAutowiredTest.testPurge() B2";
-		nodeB2.setName(nodeNameB2);
-		nodeB2.setNodeType(EntityType.folder.name());
-		nodeB2.setParentId(nodeIdA2);
-		final String nodeIdB2 = nodeManager.createNewNode(nodeB2, testUserInfo);
-		assertNotNull(nodeIdB2);
-		toClearList.add(nodeIdB2);
+		final Node nodeB = new Node();
+		final String nodeNameB = "TrashManagerImplAutowiredTest.testPurge() B";
+		nodeB.setName(nodeNameB);
+		nodeB.setNodeType(EntityType.folder.name());
+		nodeB.setParentId(nodeIdA2);
+		final String nodeIdB = nodeManager.createNewNode(nodeB, testUserInfo);
+		assertNotNull(nodeIdB);
+		toClearList.add(nodeIdB);
 
 		final Node nodeC1 = new Node();
 		final String nodeNameC1 = "TrashManagerImplAutowiredTest.testPurge() C1";
@@ -679,7 +679,7 @@ public class TrashManagerImplAutowiredTest {
 		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdA1)));
 		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdA2)));
 		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdB1)));
-		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdB2)));
+		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdB)));
 		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdC1)));
 	}
 
@@ -695,7 +695,7 @@ public class TrashManagerImplAutowiredTest {
 		//           /  \
 		//          A1  A2
 		//          |    |
-		//          B1  B2
+		//          B1  B
 		//          |
 		//          C1
 		//
@@ -724,14 +724,14 @@ public class TrashManagerImplAutowiredTest {
 		assertNotNull(nodeIdB1);
 		toClearList.add(nodeIdB1);
 		
-		final Node nodeB2 = new Node();
-		final String nodeNameB2 = "TrashManagerImplAutowiredTest.testPurge() B2";
-		nodeB2.setName(nodeNameB2);
-		nodeB2.setNodeType(EntityType.folder.name());
-		nodeB2.setParentId(nodeIdA2);
-		final String nodeIdB2 = nodeManager.createNewNode(nodeB2, testUserInfo);
-		assertNotNull(nodeIdB2);
-		toClearList.add(nodeIdB2);
+		final Node nodeB = new Node();
+		final String nodeNameB = "TrashManagerImplAutowiredTest.testPurge() B";
+		nodeB.setName(nodeNameB);
+		nodeB.setNodeType(EntityType.folder.name());
+		nodeB.setParentId(nodeIdA2);
+		final String nodeIdB = nodeManager.createNewNode(nodeB, testUserInfo);
+		assertNotNull(nodeIdB);
+		toClearList.add(nodeIdB);
 
 		final Node nodeC1 = new Node();
 		final String nodeNameC1 = "TrashManagerImplAutowiredTest.testPurge() C1";
@@ -746,7 +746,7 @@ public class TrashManagerImplAutowiredTest {
 		trashManager.moveToTrash(testUserInfo, nodeIdA1);
 		trashManager.moveToTrash(testUserInfo, nodeIdA2);
 
-		// Purge B1, C1, A2, B2, and keep A1
+		// Purge B1, C1, A2, B, and keep A1
 		List<TrashedEntity> allTrash = trashManager.viewTrashForUser(
 				testUserInfo, testUserInfo, 0L, 1000L).getResults();
 		List<TrashedEntity> purgeList = new ArrayList<TrashedEntity>(4);
@@ -757,7 +757,7 @@ public class TrashManagerImplAutowiredTest {
 			if (nodeIdB1.equals(trash.getEntityId())) {
 				purgeList.add(trash);
 			}
-			if (nodeIdB2.equals(trash.getEntityId())) {
+			if (nodeIdB.equals(trash.getEntityId())) {
 				purgeList.add(trash);
 			}
 			if (nodeIdA2.equals(trash.getEntityId())) {
@@ -772,7 +772,7 @@ public class TrashManagerImplAutowiredTest {
 		assertTrue(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdA1)));
 		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdA2)));
 		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdB1)));
-		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdB2)));
+		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdB)));
 		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdC1)));
 	}
 
@@ -789,12 +789,12 @@ public class TrashManagerImplAutowiredTest {
 		//           /  \
 		//          A1  A2
 		//          |    |
-		//          B1  B2
+		//          B1  B
 		//          |
 		//          C1
 		//
 		// A1, B1, C1 are created by test admin user
-		// A2, B2 are create by test user
+		// A2, B are create by test user
 		//
 		final Node nodeA1 = new Node();
 		final String nodeNameA1 = "TrashManagerImplAutowiredTest.testPurge() A1";
@@ -821,14 +821,14 @@ public class TrashManagerImplAutowiredTest {
 		assertNotNull(nodeIdB1);
 		toClearList.add(nodeIdB1);
 
-		final Node nodeB2 = new Node();
-		final String nodeNameB2 = "TrashManagerImplAutowiredTest.testPurge() B2";
-		nodeB2.setName(nodeNameB2);
-		nodeB2.setNodeType(EntityType.folder.name());
-		nodeB2.setParentId(nodeIdA2);
-		final String nodeIdB2 = nodeManager.createNewNode(nodeB2, testUserInfo);
-		assertNotNull(nodeIdB2);
-		toClearList.add(nodeIdB2);
+		final Node nodeB = new Node();
+		final String nodeNameB = "TrashManagerImplAutowiredTest.testPurge() B";
+		nodeB.setName(nodeNameB);
+		nodeB.setNodeType(EntityType.folder.name());
+		nodeB.setParentId(nodeIdA2);
+		final String nodeIdB = nodeManager.createNewNode(nodeB, testUserInfo);
+		assertNotNull(nodeIdB);
+		toClearList.add(nodeIdB);
 
 		final Node nodeC1 = new Node();
 		final String nodeNameC1 = "TrashManagerImplAutowiredTest.testPurge() C1";
@@ -905,9 +905,37 @@ public class TrashManagerImplAutowiredTest {
 		// Node A2 has been restored by admin
 		assertTrue(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdA2)));
 		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdB1)));
-		// Node B2 has been restored by admin
-		assertTrue(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdB2)));
+		// Node B has been restored by admin
+		assertTrue(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdB)));
 		assertFalse(nodeDAO.doesNodeExist(KeyFactory.stringToKey(nodeIdC1)));
+	}
+	
+	@Test(expected=EntityInTrashCanException.class)
+	public void testRestoreToParentThatIsInTrashCan() throws Exception {
+		// A --> Parent
+		final Node nodeA = new Node();
+		final String nodeNameA = "TrashManagerImplAutowiredTest.testPurge() A";
+		nodeA.setName(nodeNameA);
+		nodeA.setNodeType(EntityType.project.name());
+		final String nodeIdA = nodeManager.createNewNode(nodeA, testUserInfo);
+		assertNotNull(nodeIdA);
+		toClearList.add(nodeIdA);
+		
+		// B --> Child
+		final Node nodeB = new Node();
+		final String nodeNameB = "TrashManagerImplAutowiredTest.testPurge() B";
+		nodeB.setName(nodeNameB);
+		nodeB.setNodeType(EntityType.folder.name());
+		nodeB.setParentId(nodeIdA);
+		final String nodeIdB = nodeManager.createNewNode(nodeB, testUserInfo);
+		assertNotNull(nodeIdB);
+		toClearList.add(nodeIdB);
+		
+		// Move both to trash.
+		trashManager.moveToTrash(testUserInfo, nodeIdA);
+		
+		// Restore B from trash.
+		trashManager.restoreFromTrash(testUserInfo, nodeIdB, nodeIdA);
 	}
 
 	@Test(expected=EntityInTrashCanException.class)

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/trash/TrashManagerImplAutowiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/trash/TrashManagerImplAutowiredTest.java
@@ -914,7 +914,7 @@ public class TrashManagerImplAutowiredTest {
 	public void testRestoreToParentThatIsInTrashCan() throws Exception {
 		// A --> Parent
 		final Node nodeA = new Node();
-		final String nodeNameA = "TrashManagerImplAutowiredTest.testPurge() A";
+		final String nodeNameA = "TrashManagerImplAutowiredTest.testRestoreToParentThatIsInTrashCan() A";
 		nodeA.setName(nodeNameA);
 		nodeA.setNodeType(EntityType.project.name());
 		final String nodeIdA = nodeManager.createNewNode(nodeA, testUserInfo);
@@ -923,7 +923,7 @@ public class TrashManagerImplAutowiredTest {
 		
 		// B --> Child
 		final Node nodeB = new Node();
-		final String nodeNameB = "TrashManagerImplAutowiredTest.testPurge() B";
+		final String nodeNameB = "TrashManagerImplAutowiredTest.testRestoreToParentThatIsInTrashCan() B";
 		nodeB.setName(nodeNameB);
 		nodeB.setNodeType(EntityType.folder.name());
 		nodeB.setParentId(nodeIdA);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/trash/TrashManagerImplAutowiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/trash/TrashManagerImplAutowiredTest.java
@@ -47,39 +47,39 @@ public class TrashManagerImplAutowiredTest {
 
 	@Autowired 
 	private TrashManager trashManager;
-
+	
 	@Autowired 
 	private NodeManager nodeManager;
-
+	
 	@Autowired 
 	private NodeInheritanceManager nodeInheritanceManager;
-
+	
 	@Autowired 
 	private EntityPermissionsManager entityPermissionsManager;
-
+	
 	@Autowired 
 	private TrashCanDao trashCanDao;
-
+	
 	@Autowired 
 	private NodeDAO nodeDAO;
-
+	
 	@Autowired
 	private UserManager userManager;
-
+	
 	@Autowired 
 	private AccessRequirementManager accessRequirementManager;
-
+	
 	private UserInfo testAdminUserInfo;
 	private UserInfo testUserInfo;
 	private String trashCanId;
 	private List<String> toClearList;
-
+	
 	private AccessRequirement accessRequirementToDelete;
 
 	@Before
 	public void before() throws Exception {
 		testAdminUserInfo = userManager.getUserInfo(BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId());
-
+		
 		NewUser user = new NewUser();
 		user.setEmail(UUID.randomUUID().toString() + "@test.com");
 		user.setUserName(UUID.randomUUID().toString());
@@ -104,17 +104,17 @@ public class TrashManagerImplAutowiredTest {
 	@After
 	public void after() throws Exception {
 		cleanUp();
-
+		
 		userManager.deletePrincipal(testAdminUserInfo, testUserInfo.getId());
 	}
-
+	
 	private QueryResults<TrashedEntity> inspectUsersTrashCan(UserInfo userInfo, int expectedSize) throws Exception {
 		QueryResults<TrashedEntity> results = trashManager.viewTrashForUser(userInfo, userInfo, 0L, 1000L);
 		assertEquals((long)expectedSize, results.getTotalNumberOfResults());
 		assertEquals(expectedSize, results.getResults().size());
 		return results;
 	}
-
+	
 	private Node createNode(final String name, EntityType type, String parentId) throws DatastoreException, InvalidModelException, UnauthorizedException, NotFoundException {
 		Node node = new Node();
 		node.setName(name);
@@ -167,7 +167,7 @@ public class TrashManagerImplAutowiredTest {
 		assertEquals(nodeParentId, nodeChildRetrieved.getParentId());
 		assertEquals(nodeParentId, nodeInheritanceManager.getBenefactor(nodeChildRetrieved.getId()));
 	}
-
+	
 	@Test
 	public void testRestrictedNodeRoundTrip() throws Exception {
 		inspectUsersTrashCan(testUserInfo, 0);
@@ -179,7 +179,7 @@ public class TrashManagerImplAutowiredTest {
 
 		// add an access requirement to the parent
 		accessRequirementToDelete = accessRequirementManager.createLockAccessRequirement(testUserInfo, nodeParentId);
-
+		
 		// delete and try to restore to some other (unrestricted) parent
 		trashManager.moveToTrash(testUserInfo, nodeChildId);
 		Node adoptiveParent = createNode("TrashManagerImplAutowiredTest.testSingleNodeRoundTrip() Adoptive Parent",EntityType.project, null);
@@ -190,7 +190,7 @@ public class TrashManagerImplAutowiredTest {
 		} catch (UnauthorizedException e) {
 			// as expected
 		}
-
+		
 		// restore to original parent
 		trashManager.restoreFromTrash(testUserInfo, nodeChildId, nodeParentId);
 	}
@@ -206,11 +206,11 @@ public class TrashManagerImplAutowiredTest {
 
 		// delete and try to restore to some other (unrestricted) parent
 		trashManager.moveToTrash(testUserInfo, nodeChildId);
-
+		
 		// now delete the original parent
 		nodeManager.delete(testUserInfo, nodeParentId);
 		toClearList.remove(nodeParentId);
-
+		
 		Node adoptiveParent = createNode("TrashManagerImplAutowiredTest.testSingleNodeRoundTrip() Adoptive Parent",EntityType.project, null);
 		final String adoptiveParentId = adoptiveParent.getId();
 		try {
@@ -554,7 +554,7 @@ public class TrashManagerImplAutowiredTest {
 		final String nodeIdB1 = nodeManager.createNewNode(nodeB1, testUserInfo);
 		assertNotNull(nodeIdB1);
 		toClearList.add(nodeIdB1);
-
+		
 		final Node nodeB2 = new Node();
 		final String nodeNameB2 = "TrashManagerImplAutowiredTest.testPurge() B2";
 		nodeB2.setName(nodeNameB2);
@@ -572,7 +572,7 @@ public class TrashManagerImplAutowiredTest {
 		final String nodeIdC1 = nodeManager.createNewNode(nodeC1, testUserInfo);
 		assertNotNull(nodeIdC1);
 		toClearList.add(nodeIdC1);
-
+		
 		// Move all of them to trash can
 		trashManager.moveToTrash(testUserInfo, nodeIdA1);
 		trashManager.moveToTrash(testUserInfo, nodeIdA2);
@@ -648,7 +648,7 @@ public class TrashManagerImplAutowiredTest {
 		final String nodeIdB1 = nodeManager.createNewNode(nodeB1, testUserInfo);
 		assertNotNull(nodeIdB1);
 		toClearList.add(nodeIdB1);
-
+		
 		final Node nodeB2 = new Node();
 		final String nodeNameB2 = "TrashManagerImplAutowiredTest.testPurge() B2";
 		nodeB2.setName(nodeNameB2);
@@ -723,7 +723,7 @@ public class TrashManagerImplAutowiredTest {
 		final String nodeIdB1 = nodeManager.createNewNode(nodeB1, testUserInfo);
 		assertNotNull(nodeIdB1);
 		toClearList.add(nodeIdB1);
-
+		
 		final Node nodeB2 = new Node();
 		final String nodeNameB2 = "TrashManagerImplAutowiredTest.testPurge() B2";
 		nodeB2.setName(nodeNameB2);

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/BaseController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/BaseController.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.sagebionetworks.StackConfiguration;
 import org.sagebionetworks.repo.manager.trash.EntityInTrashCanException;
+import org.sagebionetworks.repo.manager.trash.ParentInTrashCanException;
 import org.sagebionetworks.repo.model.ACLInheritanceException;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
 import org.sagebionetworks.repo.model.DatastoreException;
@@ -690,6 +691,24 @@ public abstract class BaseController {
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	public @ResponseBody
 	ErrorResponse handleEntityInTrashCanException(EntityInTrashCanException ex,
+			HttpServletRequest request) {
+		return handleException(ex, request, true);
+	}
+	
+	/**
+	 * When an entity's parent is in the trash can.
+	 *
+	 * @param ex
+	 *            the exception to be handled
+	 * @param request
+	 *            the client request
+	 * @return an ErrorResponse object containing the exception reason or some
+	 *         other human-readable response
+	 */
+	@ExceptionHandler(ParentInTrashCanException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public @ResponseBody
+	ErrorResponse handleParentInTrashCanException(ParentInTrashCanException ex,
 			HttpServletRequest request) {
 		return handleException(ex, request, true);
 	}

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/BaseController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/BaseController.java
@@ -706,7 +706,7 @@ public abstract class BaseController {
 	 *         other human-readable response
 	 */
 	@ExceptionHandler(ParentInTrashCanException.class)
-	@ResponseStatus(HttpStatus.NOT_FOUND)
+	@ResponseStatus(HttpStatus.FORBIDDEN)
 	public @ResponseBody
 	ErrorResponse handleParentInTrashCanException(ParentInTrashCanException ex,
 			HttpServletRequest request) {


### PR DESCRIPTION
This was the fix to the issue of allowing an entity in the trash to be restored to a parent that is also in the trash.

Note: A bunch of the changes on "TrashManagerImplAutowiredTest.java" can be ignored, as they're just whitespace stuff that were the result of an accidental "replace all" call I made. Sorry about that.
