### PR TITLE
fix sql statement for performance

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/query/jdo/QueryUtils.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/query/jdo/QueryUtils.java
@@ -78,12 +78,17 @@ public class QueryUtils {
 	public static String buildAuthorizationFilter(boolean isAdmin, Set<Long> groups, Map<String, Object> parameters, String nodeAlias,
 			int groupIndexToStartFrom)
 			throws DatastoreException {
-		if (parameters == null)
-			throw new IllegalArgumentException("Parameters cannot be null");
 		// First off, if the user is an administrator then there is no filter
 		if (isAdmin) {
 			return "";
 		}
+		String sql = buildAuthorizationSelect(groups, parameters, groupIndexToStartFrom);
+		return nodeAlias + "." + SqlConstants.COL_NODE_BENEFACTOR_ID + " in (" + sql + ")";
+	}
+
+	public static String buildAuthorizationSelect(Set<Long> groups, Map<String, Object> parameters, int groupIndexToStartFrom) {
+		if (parameters == null)
+			throw new IllegalArgumentException("Parameters cannot be null");
 		// For all other cases we build up a filter
 		if (groups == null)
 			throw new IllegalArgumentException("User's groups cannot be null");
@@ -102,7 +107,7 @@ public class QueryUtils {
 			parameters.put(AuthorizationSqlUtil.BIND_VAR_PREFIX + index, ug);
 			index++;
 		}
-		return nodeAlias + "." + SqlConstants.COL_NODE_BENEFACTOR_ID + " in (" + sql + ")";
+		return sql;
 	}
 
 	/**


### PR DESCRIPTION
Before:

select 
    n.ID, n.NAME, n.NODE_TYPE
from
    (select distinct
        n.PROJECT_ID
    from
        JDONODE n
    where
        n.BENEFACTOR_ID in (select 
                acl.OWNER_ID ID
            from
                ACL acl, JDORESOURCEACCESS ra, JDORESOURCEACCESS_ACCESSTYPE at
            where
                (ra.GROUP_ID in (273949 , 2223475, 273948, 273957))
                    and acl.ID = ra.OWNER_ID
                    and acl.OWNER_TYPE = 'ENTITY'
                    and at.ID_OID = ra.ID
                    and at.STRING_ELE = 'READ')
            and n.PROJECT_ID is not null) pids
        join
    JDONODE n ON n.ID = pids.PROJECT_ID
        left join
    PROJECT_STAT ps ON n.ID = ps.PROJECT_ID
        and ps.USER_ID = '2223475'
order by coalesce(ps.LAST_ACCESSED, n.CREATED_ON) DESC
limit 20 offset 0;

After:

select n.ID, n.NAME, n.NODE_TYPE
from
(
    select distinct n.PROJECT_ID
    from
    (
        select acl.OWNER_ID ID
        from ACL acl, JDORESOURCEACCESS ra, JDORESOURCEACCESS_ACCESSTYPE at
        where
            (ra.GROUP_ID in (273949 , 2223475, 273948, 273957))
            and acl.ID = ra.OWNER_ID
            and acl.OWNER_TYPE = 'ENTITY'
            and at.ID_OID = ra.ID
            and at.STRING_ELE = 'READ'
    ) acls
    join JDONODE n on n.BENEFACTOR_ID = acls.ID
    where
        n.PROJECT_ID is not null
) pids
join JDONODE n ON n.ID = pids.PROJECT_ID
left join PROJECT_STAT ps ON n.ID = ps.PROJECT_ID and ps.USER_ID = '2223475'
where         n.BENEFACTOR_ID in (select 
                acl.OWNER_ID ID
            from
                ACL acl, JDORESOURCEACCESS ra, JDORESOURCEACCESS_ACCESSTYPE at
            where
                (ra.GROUP_ID in (273949 , 2223475, 273948, 273957))
                    and acl.ID = ra.OWNER_ID
                    and acl.OWNER_TYPE = 'ENTITY'
                    and at.ID_OID = ra.ID
                    and at.STRING_ELE = 'READ')
order by coalesce(ps.LAST_ACCESSED, n.CREATED_ON) DESC
limit 20 offset 0;
