### PR TITLE
Remove return-path from emails

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EmailUtils.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EmailUtils.java
@@ -39,7 +39,6 @@ public class EmailUtils {
 		if (sender != null) {
 			source = sender + " <" + source + ">";
 		}
-		String opsEmail = StackConfiguration.getSynapseOpsEmailAddress();
 		
 		// Construct an object to contain the recipient address
         Destination destination = new Destination().withToAddresses(recipientEmail);
@@ -66,8 +65,7 @@ public class EmailUtils {
 		SendEmailRequest request = new SendEmailRequest()
 				.withSource(source)
 				.withDestination(destination)
-				.withMessage(message)
-				.withReturnPath(opsEmail);
+				.withMessage(message);
 		return request;
 	}
 	

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/EmailUtilsTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/EmailUtilsTest.java
@@ -39,7 +39,6 @@ public class EmailUtilsTest {
 		assertEquals("<html>bar</html>", request.getMessage().getBody().getHtml().getData());
 		assertNull(request.getMessage().getBody().getText());
 		assertEquals("foobar <notifications@sagebase.org>", request.getSource());
-		assertEquals("synapse-ops@sagebase.org", request.getReturnPath());
 }
 	
 	@Test


### PR DESCRIPTION
So the build stops spamming the ops team.
