### PR TITLE
Do not allow deleting all ACL

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDaoImpl.java
@@ -67,8 +67,6 @@ public class DBOAccessControlListDaoImpl implements AccessControlListDAO {
 	private static final String SQL_SELECT_ACL_ID_FOR_RESOURCE = "SELECT "+COL_ACL_ID+" FROM "+TABLE_ACCESS_CONTROL_LIST+
 			" WHERE "+COL_ACL_OWNER_ID+" = ? AND "+COL_ACL_OWNER_TYPE+" = ?";
 
-	private static final String DELETE_ALL_ACL = "DELETE FROM "+TABLE_ACCESS_CONTROL_LIST;
-
 	/**
 	 * Keep a copy of the row mapper.
 	 */
@@ -283,10 +281,5 @@ public class DBOAccessControlListDaoImpl implements AccessControlListDAO {
 		param.addValue(COL_ACL_OWNER_ID, ownerId);
 		param.addValue(COL_ACL_OWNER_TYPE, ownerType.name());
 		return simpleJdbcTemplate.queryForObject(SELECT_FOR_UPDATE, aclRowMapper, param);
-	}
-
-	@Override
-	public void deleteAllAcl() {
-		simpleJdbcTemplate.update(DELETE_ALL_ACL);
 	}
 }

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplChangeMessageTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplChangeMessageTest.java
@@ -103,6 +103,7 @@ public class DBOAccessControlListDAOImplChangeMessageTest {
 		acl.setResourceAccess(new HashSet<ResourceAccess>());
 		String aclId = aclDAO.create(acl, ObjectType.ENTITY);
 		assertEquals(nodeId, aclId);
+		aclList.add(acl);
 
 		// Did a message get sent?
 		List<ChangeMessage> changes = changeDAO.listChanges(changeDAO.getCurrentChangeNumber(), ObjectType.ACCESS_CONTROL_LIST, Long.MAX_VALUE);
@@ -188,7 +189,9 @@ public class DBOAccessControlListDAOImplChangeMessageTest {
 
 	@After
 	public void cleanUp() throws Exception {
-		aclDAO.deleteAllAcl();
+		for (AccessControlList acl : aclList) {
+			aclDAO.delete(acl.getId(), ObjectType.ENTITY);
+		}
 		nodeList.clear();
 		aclList.clear();
 		for (UserGroup g : groupList) {

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplTest.java
@@ -200,13 +200,11 @@ public class DBOAccessControlListDAOImplTest {
 	 */
 	@Test
 	public void testGet() throws Exception {
-		
-		AccessControlList acl = aclList.iterator().next();
-		String id = acl.getId();
-		
-		AccessControlList acl2 = aclDAO.get(id, ObjectType.ENTITY);
-		
-		assertEquals(acl, acl2);
+		for (AccessControlList acl : aclList) {
+			String id = acl.getId();
+			AccessControlList acl2 = aclDAO.get(id, ObjectType.ENTITY);
+			assertEquals(acl, acl2);
+		}
 	}
 
 	/**
@@ -230,15 +228,14 @@ public class DBOAccessControlListDAOImplTest {
 	 */
 	@Test
 	public void testGetAclId() throws Exception {
-		// get an ownerId
-		AccessControlList acl = aclList.iterator().next();
-		String id = acl.getId();
-		// get the AclId using ownerId and ownerType
-		Long aclId = aclDAO.getAclId(id, ObjectType.ENTITY);
-		// get the acl using the AclId
-		AccessControlList acl2 = aclDAO.get(aclId);
-		assertEquals(acl, acl2);
-		
+		for (AccessControlList acl : aclList) {
+			String id = acl.getId();
+			// get the AclId using ownerId and ownerType
+			Long aclId = aclDAO.getAclId(id, ObjectType.ENTITY);
+			// get the acl using the AclId
+			AccessControlList acl2 = aclDAO.get(aclId);
+			assertEquals(acl, acl2);
+		}
 	}
 
 	@Test  (expected=NotFoundException.class)
@@ -254,12 +251,12 @@ public class DBOAccessControlListDAOImplTest {
 	 */
 	@Test
 	public void testGetOwnerType() throws Exception {
-		// get an ownerId
-		AccessControlList acl = aclList.iterator().next();
-		String id = acl.getId();
-		// get the AclId using ownerId and ownerType
-		Long aclId = aclDAO.getAclId(id, ObjectType.ENTITY);
-		assertEquals(ObjectType.ENTITY, aclDAO.getOwnerType(aclId));
+		for (AccessControlList acl : aclList) {
+			String id = acl.getId();
+			// get the AclId using ownerId and ownerType
+			Long aclId = aclDAO.getAclId(id, ObjectType.ENTITY);
+			assertEquals(ObjectType.ENTITY, aclDAO.getOwnerType(aclId));
+		}
 	}
 
 	@Test  (expected=NotFoundException.class)

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplTest.java
@@ -135,7 +135,9 @@ public class DBOAccessControlListDAOImplTest {
 
 	@After
 	public void tearDown() throws Exception {
-		aclDAO.deleteAllAcl();
+		for (AccessControlList acl : aclList){
+			aclDAO.delete(acl.getId(), ObjectType.ENTITY);
+		}
 		for (Node n : nodeList) {
 			nodeDAO.delete(n.getId());
 		}

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/AccessControlListDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/AccessControlListDAO.java
@@ -78,10 +78,4 @@ public interface AccessControlListDAO  {
 	 * @throws NotFoundException
 	 */
 	public void delete(String id, ObjectType ownerType) throws DatastoreException, NotFoundException;
-
-	/**
-	 * Delete all ACL in the database
-	 * only used to clean up tests
-	 */
-	public void deleteAllAcl();
 }

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -35,7 +35,6 @@ import org.sagebionetworks.repo.model.UserGroupDAO;
 import org.sagebionetworks.repo.model.audit.AclRecord;
 import org.sagebionetworks.repo.model.audit.ResourceAccessRecord;
 import org.sagebionetworks.repo.model.message.ChangeType;
-import org.sagebionetworks.repo.web.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -243,8 +242,6 @@ public class AclSnapshotWorkerIntegrationTest {
 		aclDao.delete(node.getId(), ObjectType.ENTITY);
 
 		assertTrue(waitForObjects(aclKeys, resourceAccessKeys, expectedAclRecord, null));
-		// only clean up the acl after verything is done
-		cleanUpAclList();
 	}
 
 	@After 
@@ -253,15 +250,12 @@ public class AclSnapshotWorkerIntegrationTest {
 		for (UserGroup g : groupList) {
 			userGroupDao.delete(g.getId());
 		}
-		groupList.clear();
-		aclRecordDao.deleteAllStackInstanceBatches();
-		resourceAccessRecordDao.deleteAllStackInstanceBatches();
-	}
-
-	private void cleanUpAclList() throws NotFoundException {
 		for (AccessControlList acl : aclList) {
 			aclDao.delete(acl.getId(), ObjectType.ENTITY);
 		}
+		groupList.clear();
+		aclRecordDao.deleteAllStackInstanceBatches();
+		resourceAccessRecordDao.deleteAllStackInstanceBatches();
 	}
 
 	/**

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -90,7 +90,7 @@ public class AclSnapshotWorkerIntegrationTest {
 
 		assertNotNull(s3Client);
 
-		// wait for 10 seconds
+		// wait 10 seconds for S3 to be in a consistent state before testing
 		Thread.sleep(10000);
 		// discard a few Ids
 		for (int i = 0; i < 100; i++){

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -34,7 +34,6 @@ import org.sagebionetworks.repo.model.UserGroupDAO;
 import org.sagebionetworks.repo.model.audit.AclRecord;
 import org.sagebionetworks.repo.model.audit.ResourceAccessRecord;
 import org.sagebionetworks.repo.model.message.ChangeType;
-import org.sagebionetworks.repo.web.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -56,7 +55,7 @@ public class AclSnapshotWorkerIntegrationTest {
 	private ResourceAccessRecordDAO resourceAccessRecordDao;
 	
 	@Autowired
-	private AccessControlListDAO aclDao;
+	private  AccessControlListDAO aclDao;
 	@Autowired
 	private NodeDAO nodeDao;
 	@Autowired
@@ -70,7 +69,7 @@ public class AclSnapshotWorkerIntegrationTest {
 	private UserGroup group2;
 	
 	private Collection<UserGroup> groupList = new ArrayList<UserGroup>();
-	private Collection<AccessControlList> aclList = new ArrayList<AccessControlList>();
+	private  Collection<AccessControlList> aclList = new ArrayList<AccessControlList>();
 	
 	private Long createdById;
 	private Long modifiedById;
@@ -257,7 +256,7 @@ public class AclSnapshotWorkerIntegrationTest {
 		cleanUpAclList();
 	}
 
-	@After 
+	@After
 	public void cleanUp() throws Exception {
 		nodeDao.delete(node.getId());
 		for (UserGroup g : groupList) {
@@ -268,7 +267,7 @@ public class AclSnapshotWorkerIntegrationTest {
 		resourceAccessRecordDao.deleteAllStackInstanceBatches();
 	}
 
-	private void cleanUpAclList() throws NotFoundException {
+	private void cleanUpAclList() throws Exception {
 		for (AccessControlList acl : aclList) {
 			aclDao.delete(acl.getId(), ObjectType.ENTITY);
 		}

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -90,6 +90,8 @@ public class AclSnapshotWorkerIntegrationTest {
 
 		assertNotNull(s3Client);
 
+		// wait for 10 seconds
+		Thread.sleep(10000);
 		// discard a few Ids
 		for (int i = 0; i < 100; i++){
 			idGenerator.generateNewId(TYPE.ACL_ID);

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -41,7 +41,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 
-// it's necessary to drop the database every time before running this test
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"classpath:test-context.xml"})
 public class AclSnapshotWorkerIntegrationTest {

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -34,6 +34,7 @@ import org.sagebionetworks.repo.model.UserGroupDAO;
 import org.sagebionetworks.repo.model.audit.AclRecord;
 import org.sagebionetworks.repo.model.audit.ResourceAccessRecord;
 import org.sagebionetworks.repo.model.message.ChangeType;
+import org.sagebionetworks.repo.web.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -55,7 +56,7 @@ public class AclSnapshotWorkerIntegrationTest {
 	private ResourceAccessRecordDAO resourceAccessRecordDao;
 	
 	@Autowired
-	private  AccessControlListDAO aclDao;
+	private AccessControlListDAO aclDao;
 	@Autowired
 	private NodeDAO nodeDao;
 	@Autowired
@@ -69,7 +70,7 @@ public class AclSnapshotWorkerIntegrationTest {
 	private UserGroup group2;
 	
 	private Collection<UserGroup> groupList = new ArrayList<UserGroup>();
-	private  Collection<AccessControlList> aclList = new ArrayList<AccessControlList>();
+	private Collection<AccessControlList> aclList = new ArrayList<AccessControlList>();
 	
 	private Long createdById;
 	private Long modifiedById;
@@ -256,7 +257,7 @@ public class AclSnapshotWorkerIntegrationTest {
 		cleanUpAclList();
 	}
 
-	@After
+	@After 
 	public void cleanUp() throws Exception {
 		nodeDao.delete(node.getId());
 		for (UserGroup g : groupList) {
@@ -267,7 +268,7 @@ public class AclSnapshotWorkerIntegrationTest {
 		resourceAccessRecordDao.deleteAllStackInstanceBatches();
 	}
 
-	private void cleanUpAclList() throws Exception {
+	private void cleanUpAclList() throws NotFoundException {
 		for (AccessControlList acl : aclList) {
 			aclDao.delete(acl.getId(), ObjectType.ENTITY);
 		}

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -2,13 +2,14 @@ package org.sagebionetworks.acl.worker;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -90,14 +91,10 @@ public class AclSnapshotWorkerIntegrationTest {
 
 		assertNotNull(s3Client);
 
-		// wait 10 seconds for S3 to be in a consistent state before testing
-		Thread.sleep(10000);
 		// discard a few Ids
 		for (int i = 0; i < 100; i++){
 			idGenerator.generateNewId(TYPE.ACL_ID);
 		}
-
-		// Setting up
 
 		createdById = BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId();
 
@@ -115,31 +112,32 @@ public class AclSnapshotWorkerIntegrationTest {
 		String nodeId = nodeDao.createNew(node);
 		assertNotNull(nodeId);
 		node = nodeDao.getNode(nodeId);
-		
+
 		// create a group to give the permissions to
 		group = new UserGroup();
 		group.setIsIndividual(false);
 		group.setId(userGroupDao.create(group).toString());
 		assertNotNull(group.getId());
 		groupList.add(group);
-		
+
 		// Create a second user
 		group2 = new UserGroup();
 		group2.setIsIndividual(false);
 		group2.setId(userGroupDao.create(group2).toString());
 		assertNotNull(group2.getId());
 		groupList.add(group2);
-		
 	}
-	
+
 	@Test
 	public void testCreate() throws Exception {
+		// wait 10 seconds for S3 to be in a consistent state
+		Thread.sleep(10000);
 		Set<String> aclKeys = aclRecordDao.listAllKeys();
 		Set<String> resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
 		assertNotNull(aclKeys);
 		assertNotNull(resourceAccessKeys);
 
-		// Create an ACL for this node
+		// Prepare the acl to create
 		AccessControlList acl = new AccessControlList();
 		acl.setId(node.getId());
 		acl.setCreationDate(new Date(System.currentTimeMillis()));
@@ -148,34 +146,27 @@ public class AclSnapshotWorkerIntegrationTest {
 				AclSnapshotWorkerTestUtils.createSetOfResourceAccess(Arrays.asList(
 						Long.parseLong(group.getId()), Long.parseLong(group2.getId())), 2, false);
 		acl.setResourceAccess(ras);
-
+		// create the acl
 		String aclId = aclDao.create(acl, ObjectType.ENTITY);
-		assertTrue(waitForObject(aclKeys, resourceAccessKeys, 1, 1));
 		assertEquals(node.getId(), aclId);
 
-		String key = getNewAclKey(aclKeys);
-		assertNotNull(key);
-		List<AclRecord> aclRecords = aclRecordDao.getBatch(key);
-		assertEquals(1, aclRecords.size());
-		AclRecord aclRecord = aclRecords.get(0);
-		assertNotNull(aclRecord);
-		assertEquals(ObjectType.ENTITY, aclRecord.getOwnerType());
-		assertEquals(node.getId(), aclRecord.getOwnerId());
-		assertEquals(ChangeType.CREATE, aclRecord.getChangeType());
+		// build the expecting aclRecord and raRecords
+		AclRecord expectedAclRecord = new AclRecord();
+		expectedAclRecord.setAclId(aclDao.getAclId(node.getId(), ObjectType.ENTITY).toString());
+		expectedAclRecord.setChangeType(ChangeType.CREATE);
+		expectedAclRecord.setCreationDate(acl.getCreationDate());
+		expectedAclRecord.setEtag(acl.getEtag());
+		expectedAclRecord.setOwnerId(node.getId());
+		expectedAclRecord.setOwnerType(ObjectType.ENTITY);
 
-		key = getNewResourceAccessRecordKey(resourceAccessKeys);
-		assertNotNull(key);
-		List<ResourceAccessRecord> raRecords = resourceAccessRecordDao.getBatch(key);
-		assertEquals(4, raRecords.size());
-		assertEquals(ras, AclSnapshotWorkerTestUtils.getSetOfResourceAccess(raRecords));
-		assertEquals(aclRecord.getChangeNumber(), raRecords.get(0).getChangeNumber());
+		Set<ResourceAccessRecord> expectedRaRecords = AclSnapshotWorkerTestUtils.createSetOfResourceAccessRecord(ras);
+
+		assertTrue(waitForObjects(aclKeys, resourceAccessKeys, expectedAclRecord, expectedRaRecords));
 	}
 
 	@Test
 	public void testUpdate() throws Exception {
-		Set<String> aclKeys = aclRecordDao.listAllKeys();
-		Set<String> resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
-		// Create an ACL for this node
+		// Prepare the acl to create
 		AccessControlList acl = new AccessControlList();
 		acl.setId(node.getId());
 		acl.setCreationDate(new Date(System.currentTimeMillis()));
@@ -184,13 +175,18 @@ public class AclSnapshotWorkerIntegrationTest {
 				AclSnapshotWorkerTestUtils.createSetOfResourceAccess(Arrays.asList(
 						Long.parseLong(group.getId()), Long.parseLong(group2.getId())), 2, false);
 		acl.setResourceAccess(ras);
+		// create the acl
 		String aclId = aclDao.create(acl, ObjectType.ENTITY);
 		assertEquals(node.getId(), aclId);
-		assertTrue(waitForObject(aclKeys, resourceAccessKeys, 1, 1));
 
-		aclKeys = aclRecordDao.listAllKeys();
-		resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
-		// Update ACL for this node
+		// wait 10 seconds for S3 to be in a consistent state
+		Thread.sleep(10000);
+		Set<String> aclKeys = aclRecordDao.listAllKeys();
+		Set<String> resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
+		assertNotNull(aclKeys);
+		assertNotNull(resourceAccessKeys);
+
+		// prepare the ACL to update
 		acl = aclDao.get(node.getId(), ObjectType.ENTITY);
 		assertNotNull(acl);
 		assertNotNull(acl.getEtag());
@@ -199,34 +195,26 @@ public class AclSnapshotWorkerIntegrationTest {
 				Long.parseLong(group.getId()), Long.parseLong(group2.getId())), 2, true);
 		acl.setResourceAccess(ras);
 
+		// update the ACL
 		aclDao.update(acl, ObjectType.ENTITY);
 
-		assertTrue(waitForObject(aclKeys, resourceAccessKeys, 1, 1));
+		// build the expecting aclRecord and raRecords
+		AclRecord expectedAclRecord = new AclRecord();
+		expectedAclRecord.setAclId(aclDao.getAclId(node.getId(), ObjectType.ENTITY).toString());
+		expectedAclRecord.setChangeType(ChangeType.UPDATE);
+		expectedAclRecord.setCreationDate(acl.getCreationDate());
+		expectedAclRecord.setEtag(acl.getEtag());
+		expectedAclRecord.setOwnerId(node.getId());
+		expectedAclRecord.setOwnerType(ObjectType.ENTITY);
 
-		String key = getNewAclKey(aclKeys);
-		assertNotNull(key);
-		List<AclRecord> aclRecords = aclRecordDao.getBatch(key);
-		assertEquals(1, aclRecords.size());
-		AclRecord aclRecord = aclRecords.get(0);
-		assertNotNull(aclRecord);
-		assertEquals(ObjectType.ENTITY, aclRecord.getOwnerType());
-		assertEquals(node.getId(), aclRecord.getOwnerId());
-		assertEquals(ChangeType.UPDATE, aclRecord.getChangeType());
-		
-		key = getNewResourceAccessRecordKey(resourceAccessKeys);
-		assertNotNull(key);
-		List<ResourceAccessRecord> raRecords = resourceAccessRecordDao.getBatch(key);
-		assertEquals(4, raRecords.size());
+		Set<ResourceAccessRecord> expectedRaRecords = AclSnapshotWorkerTestUtils.createSetOfResourceAccessRecord(ras);
+		assertTrue(waitForObjects(aclKeys, resourceAccessKeys, expectedAclRecord, expectedRaRecords));
 
-		assertEquals(ras, AclSnapshotWorkerTestUtils.getSetOfResourceAccess(raRecords));
-		assertEquals(aclRecord.getChangeNumber(), raRecords.get(0).getChangeNumber());
 	}
 
 	@Test
 	public void testDelete() throws Exception {
-		Set<String> aclKeys = aclRecordDao.listAllKeys();
-		Set<String> resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
-		// Create an ACL for this node
+		// Prepare the acl to create
 		AccessControlList acl = new AccessControlList();
 		acl.setId(node.getId());
 		acl.setCreationDate(new Date(System.currentTimeMillis()));
@@ -235,26 +223,26 @@ public class AclSnapshotWorkerIntegrationTest {
 				AclSnapshotWorkerTestUtils.createSetOfResourceAccess(Arrays.asList(
 						Long.parseLong(group.getId()), Long.parseLong(group2.getId())), 2, false);
 		acl.setResourceAccess(ras);
+		// create the acl
 		String aclId = aclDao.create(acl, ObjectType.ENTITY);
 		assertEquals(node.getId(), aclId);
-		assertTrue(waitForObject(aclKeys, resourceAccessKeys, 1, 1));
 
-		aclKeys = aclRecordDao.listAllKeys();
-		resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
+		// wait 10 seconds for S3 to be in a consistent state
+		Thread.sleep(10000);
+		Set<String> aclKeys = aclRecordDao.listAllKeys();
+		Set<String> resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
+		assertNotNull(aclKeys);
+		assertNotNull(resourceAccessKeys);
+
+		// build the expecting aclRecord before deleting the ACL
+		AclRecord expectedAclRecord = new AclRecord();
+		expectedAclRecord.setAclId(aclDao.getAclId(node.getId(), ObjectType.ENTITY).toString());
+		expectedAclRecord.setChangeType(ChangeType.DELETE);
 
 		// Delete the acl
 		aclDao.delete(node.getId(), ObjectType.ENTITY);
 
-		assertTrue(waitForObject(aclKeys, resourceAccessKeys, 1, 0));
-		String key = getNewAclKey(aclKeys);
-		assertNotNull(key);
-		List<AclRecord> aclRecords = aclRecordDao.getBatch(key);
-		assertEquals(1, aclRecords.size());
-		AclRecord aclRecord = aclRecords.get(0);
-		assertNotNull(aclRecord);
-		assertNull(aclRecord.getOwnerId());
-		assertNull(aclRecord.getOwnerType());
-		assertEquals(ChangeType.DELETE, aclRecord.getChangeType());
+		assertTrue(waitForObjects(aclKeys, resourceAccessKeys, expectedAclRecord, null));
 		// only clean up the acl after verything is done
 		cleanUpAclList();
 	}
@@ -277,24 +265,62 @@ public class AclSnapshotWorkerIntegrationTest {
 	}
 
 	/**
-	 * Helper method that continue looking into s3 bucket and find noAcl number
-	 * of new AclRecord log files compare to aclKeys - the list of old AclRecord
-	 * log files, and noRA number of new ResourceAccessRecord log files compare
-	 * to resourceAccessKeys - the list of old ResourceAccessRecord log files.
+	 * Helper method that continue looking into s3 bucket and find new AclRecord
+	 * log files and new ResourceAccessRecord log files.
 	 * 
-	 * @return true if found what was looking for in TIME_OUT milliseconds,
+	 * @return true if found the expectedAclRecord and expectedRaRecords in TIME_OUT milliseconds,
 	 *         false otherwise.
 	 */
-	private boolean waitForObject(Set<String> aclKeys, Set<String> resourceAccessKeys, int noAcl, int noRA) {
+	private boolean waitForObjects(Set<String> oldAclKeys, Set<String> oldResourceAccessKeys,
+			AclRecord expectedAclRecord, Set<ResourceAccessRecord> expectedRaRecords) throws Exception {
 		long start = System.currentTimeMillis();
+		boolean foundAclRecord = false;
+
 		while (System.currentTimeMillis() < start + TIME_OUT) {
-			Set<String> newAclKeys = aclRecordDao.listAllKeys();
-			Set<String> newResourceKeys = resourceAccessRecordDao.listAllKeys();
+			Set<String> newAclKeys = null;
+			if (!foundAclRecord) {
+				newAclKeys = aclRecordDao.listAllKeys();
+				newAclKeys.removeAll(oldAclKeys);
+			}
 
-			newAclKeys.removeAll(aclKeys);
-			newResourceKeys.removeAll(resourceAccessKeys);
+			if (!foundAclRecord && newAclKeys.size() != 0) {
+				foundAclRecord = findAclRecord(expectedAclRecord, newAclKeys);
+			}
 
-			if (noAcl == newAclKeys.size() && noRA == newResourceKeys.size()){
+			if (foundAclRecord && expectedRaRecords == null) {
+				return true;
+			}
+
+			Set<String> newResourceKeys = null;
+			if (foundAclRecord) {
+				newResourceKeys = resourceAccessRecordDao.listAllKeys();
+				newResourceKeys.removeAll(oldResourceAccessKeys);
+			}
+
+			if (foundAclRecord && newResourceKeys.size() != 0) {
+				if (findRaRecords(expectedRaRecords, newResourceKeys)) {
+					return true;
+				}
+			}
+
+			// wait for 1 second before calling the service again
+			Thread.sleep(1000);
+		}
+		return false;
+	}
+
+	/**
+	 * @param expectedRaRecords
+	 * @param newResourceKeys
+	 * @return true if the newResourceKeys contains expectedRaRecords 
+	 * @throws IOException
+	 */
+	private boolean findRaRecords(Set<ResourceAccessRecord> expectedRaRecords, Set<String> newResourceKeys) throws IOException {
+		// newResourceKeys should have size 1; otherwise, we are going over some old keys
+		for (String raKey : newResourceKeys) {
+			List<ResourceAccessRecord> newRaRecords = resourceAccessRecordDao.getBatch(raKey);
+
+			if (compareRaRecords(new HashSet<ResourceAccessRecord>(newRaRecords),expectedRaRecords)) {
 				return true;
 			}
 		}
@@ -302,20 +328,64 @@ public class AclSnapshotWorkerIntegrationTest {
 	}
 
 	/**
-	 * @return the first new Acl key in S3 compare to old aclKeys
+	 * 
+	 * @param expectedAclRecord
+	 * @param newAclKeys
+	 * @return true if the newAclKeys contains expectedAclRecord
+	 * @throws IOException
 	 */
-	private String getNewAclKey(Set<String> aclKeys) {
-		Set<String> newAclKeys = aclRecordDao.listAllKeys();
-		newAclKeys.removeAll(aclKeys);
-		return new ArrayList<String>(newAclKeys).get(0);
+	private boolean findAclRecord(AclRecord expectedAclRecord, Set<String> newAclKeys) throws IOException {
+		// newAclKeys should have size 1; otherwise, we are going over some old keys
+		for (String aclKey : newAclKeys) {
+			List<AclRecord> aclRecords = aclRecordDao.getBatch(aclKey);
+			assertEquals(1, aclRecords.size());
+			AclRecord newAclRecord = aclRecords.get(0);
+
+			if (compareAclRecords(newAclRecord, expectedAclRecord)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
-	 * @return the first new ResourceAccess key in S3 compare to old resourceAccessKeys
+	 * Since there are information that we do not know when constructing the
+	 * expected records, we only check the fields that we know.
+	 * @param newRaRecords
+	 * @param expectedRaRecords
+	 * @return true if newRaRecords and expectedRaRecords contains the same set
+	 * of records, ignoring the chamgeNumber field,
+	 *         false otherwise.
 	 */
-	private String getNewResourceAccessRecordKey(Set<String> resourceAccessKeys) {
-		Set<String> newResourceKeys = resourceAccessRecordDao.listAllKeys();
-		newResourceKeys.removeAll(resourceAccessKeys);
-		return new ArrayList<String>(newResourceKeys).get(0);
+	private boolean compareRaRecords(HashSet<ResourceAccessRecord> newRaRecords,
+			Set<ResourceAccessRecord> expectedRaRecords) {
+		if (newRaRecords.size() != expectedRaRecords.size()) {
+			return false;
+		}
+		for (ResourceAccessRecord newRaRecord : newRaRecords) {
+			newRaRecord.setChangeNumber(null);
+			if (!expectedRaRecords.contains(newRaRecord)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Since there are information that we do not know when constructing the
+	 * expected records, we only check the fields that we know.
+	 */
+	private boolean compareAclRecords(AclRecord newAclRecord,
+			AclRecord expectedAclRecord) {
+		return (newAclRecord.getAclId().equals(expectedAclRecord.getAclId()) &&
+				newAclRecord.getChangeType().equals(ChangeType.DELETE) &&
+				expectedAclRecord.getChangeType().equals(ChangeType.DELETE))
+				||
+				(newAclRecord.getAclId().equals(expectedAclRecord.getAclId()) &&
+				newAclRecord.getChangeType().equals(expectedAclRecord.getChangeType()) &&
+				(Math.abs(newAclRecord.getCreationDate().getTime() - expectedAclRecord.getCreationDate().getTime()) < 1000) &&
+				newAclRecord.getEtag().equals(expectedAclRecord.getEtag()) &&
+				newAclRecord.getOwnerId().equals(expectedAclRecord.getOwnerId()) &&
+				newAclRecord.getOwnerType().equals(expectedAclRecord.getOwnerType()));
 	}
 }

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -129,8 +129,6 @@ public class AclSnapshotWorkerIntegrationTest {
 
 	@Test
 	public void testCreate() throws Exception {
-		// wait 10 seconds for S3 to be in a consistent state
-		Thread.sleep(10000);
 		Set<String> aclKeys = aclRecordDao.listAllKeys();
 		Set<String> resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
 		assertNotNull(aclKeys);
@@ -178,8 +176,6 @@ public class AclSnapshotWorkerIntegrationTest {
 		String aclId = aclDao.create(acl, ObjectType.ENTITY);
 		assertEquals(node.getId(), aclId);
 
-		// wait 10 seconds for S3 to be in a consistent state
-		Thread.sleep(10000);
 		Set<String> aclKeys = aclRecordDao.listAllKeys();
 		Set<String> resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
 		assertNotNull(aclKeys);
@@ -226,8 +222,6 @@ public class AclSnapshotWorkerIntegrationTest {
 		String aclId = aclDao.create(acl, ObjectType.ENTITY);
 		assertEquals(node.getId(), aclId);
 
-		// wait 10 seconds for S3 to be in a consistent state
-		Thread.sleep(10000);
 		Set<String> aclKeys = aclRecordDao.listAllKeys();
 		Set<String> resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
 		assertNotNull(aclKeys);

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -75,7 +75,7 @@ public class AclSnapshotWorkerIntegrationTest {
 	private Long createdById;
 	private Long modifiedById;
 	
-	private int TIME_OUT = 60 * 1000;
+	private static final int TIME_OUT = 60 * 1000;
 	
 	@Before
 	public void before() throws Exception {

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -128,7 +128,6 @@ public class AclSnapshotWorkerIntegrationTest {
 
 		// Create an ACL for this node
 		AccessControlList acl = new AccessControlList();
-		aclList.add(acl);
 		acl.setId(node.getId());
 		acl.setCreationDate(new Date(System.currentTimeMillis()));
 
@@ -139,6 +138,7 @@ public class AclSnapshotWorkerIntegrationTest {
 
 		String aclId = aclDao.create(acl, ObjectType.ENTITY);
 		assertEquals(node.getId(), aclId);
+		aclList.add(acl);
 
 		assertTrue(waitForObject(aclKeys, resourceAccessKeys, 1, 1));
 		String key = getNewAclKey(aclKeys);
@@ -165,7 +165,6 @@ public class AclSnapshotWorkerIntegrationTest {
 		Set<String> resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
 		// Create an ACL for this node
 		AccessControlList acl = new AccessControlList();
-		aclList.add(acl);
 		acl.setId(node.getId());
 		acl.setCreationDate(new Date(System.currentTimeMillis()));
 		Set<ResourceAccess> ras =
@@ -174,6 +173,7 @@ public class AclSnapshotWorkerIntegrationTest {
 		acl.setResourceAccess(ras);
 		String aclId = aclDao.create(acl, ObjectType.ENTITY);
 		assertEquals(node.getId(), aclId);
+		aclList.add(acl);
 		assertTrue(waitForObject(aclKeys, resourceAccessKeys, 1, 1));
 
 		aclKeys = aclRecordDao.listAllKeys();
@@ -188,6 +188,7 @@ public class AclSnapshotWorkerIntegrationTest {
 		acl.setResourceAccess(ras);
 
 		aclDao.update(acl, ObjectType.ENTITY);
+		aclList.add(acl);
 
 		assertTrue(waitForObject(aclKeys, resourceAccessKeys, 1, 1));
 
@@ -216,7 +217,6 @@ public class AclSnapshotWorkerIntegrationTest {
 		Set<String> resourceAccessKeys = resourceAccessRecordDao.listAllKeys();
 		// Create an ACL for this node
 		AccessControlList acl = new AccessControlList();
-		aclList.add(acl);
 		acl.setId(node.getId());
 		acl.setCreationDate(new Date(System.currentTimeMillis()));
 		Set<ResourceAccess> ras =
@@ -225,6 +225,7 @@ public class AclSnapshotWorkerIntegrationTest {
 		acl.setResourceAccess(ras);
 		String aclId = aclDao.create(acl, ObjectType.ENTITY);
 		assertEquals(node.getId(), aclId);
+		aclList.add(acl);
 		assertTrue(waitForObject(aclKeys, resourceAccessKeys, 1, 1));
 
 		aclKeys = aclRecordDao.listAllKeys();
@@ -251,7 +252,9 @@ public class AclSnapshotWorkerIntegrationTest {
 		for (UserGroup g : groupList) {
 			userGroupDao.delete(g.getId());
 		}
-		aclDao.deleteAllAcl();
+		for (AccessControlList acl : aclList) {
+			aclDao.delete(acl.getId(), ObjectType.ENTITY);
+		}
 		groupList.clear();
 
 		aclRecordDao.deleteAllStackInstanceBatches();

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -259,8 +259,8 @@ public class AclSnapshotWorkerIntegrationTest {
 	}
 
 	/**
-	 * Helper method that continue looking into s3 bucket and find new AclRecord
-	 * log files and new ResourceAccessRecord log files.
+	 * Helper method that keep looking for new AclRecord log files and new 
+	 * ResourceAccessRecord log files in S3.
 	 * 
 	 * @return true if found the expectedAclRecord and expectedRaRecords in TIME_OUT milliseconds,
 	 *         false otherwise.

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -314,7 +314,7 @@ public class AclSnapshotWorkerIntegrationTest {
 		for (String raKey : newResourceKeys) {
 			List<ResourceAccessRecord> newRaRecords = resourceAccessRecordDao.getBatch(raKey);
 
-			if (compareRaRecords(new HashSet<ResourceAccessRecord>(newRaRecords),expectedRaRecords)) {
+			if (compareRaRecords(new HashSet<ResourceAccessRecord>(newRaRecords), expectedRaRecords)) {
 				return true;
 			}
 		}

--- a/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/acl/worker/AclSnapshotWorkerIntegrationTest.java
@@ -34,6 +34,7 @@ import org.sagebionetworks.repo.model.UserGroupDAO;
 import org.sagebionetworks.repo.model.audit.AclRecord;
 import org.sagebionetworks.repo.model.audit.ResourceAccessRecord;
 import org.sagebionetworks.repo.model.message.ChangeType;
+import org.sagebionetworks.repo.web.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -252,6 +253,8 @@ public class AclSnapshotWorkerIntegrationTest {
 		assertNull(aclRecord.getOwnerId());
 		assertNull(aclRecord.getOwnerType());
 		assertEquals(ChangeType.DELETE, aclRecord.getChangeType());
+		// only clean up the acl after verything is done
+		cleanUpAclList();
 	}
 
 	@After 
@@ -260,13 +263,15 @@ public class AclSnapshotWorkerIntegrationTest {
 		for (UserGroup g : groupList) {
 			userGroupDao.delete(g.getId());
 		}
-		for (AccessControlList acl : aclList) {
-			//aclDao.delete(acl.getId(), ObjectType.ENTITY);
-		}
 		groupList.clear();
-
 		aclRecordDao.deleteAllStackInstanceBatches();
 		resourceAccessRecordDao.deleteAllStackInstanceBatches();
+	}
+
+	private void cleanUpAclList() throws NotFoundException {
+		for (AccessControlList acl : aclList) {
+			aclDao.delete(acl.getId(), ObjectType.ENTITY);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Changes:
- Remove deleteAllAcl() method
- Discard a few ACL_ID before each test in AclSnapshotWorkerTest
- Wait for matching records instead of waiting for the right number of keys
