### PR TITLE
update thread view should trigger thread etag to change

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/ITDiscussion.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITDiscussion.java
@@ -96,6 +96,9 @@ public class ITDiscussion {
 		assertEquals(synapse.getThread(threadId), bundle);
 		threads = synapse.getThreadsForForum(forumId, 100L, 0L, null, null, DiscussionFilter.NO_FILTER);
 		assertTrue(threads.getResults().size() == 1);
+		// etag has changed
+		bundle.setEtag(null);
+		threads.getResults().get(0).setEtag(null);
 		assertEquals(threads.getResults().get(0), bundle);
 		assertEquals(1L, threads.getTotalNumberOfResults());
 		assertEquals((Long)1L, synapse.getThreadCountForForum(forumId, DiscussionFilter.NO_FILTER).getCount());

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/discussion/DBODiscussionThreadDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/discussion/DBODiscussionThreadDAOImpl.java
@@ -127,6 +127,9 @@ public class DBODiscussionThreadDAOImpl implements DiscussionThreadDAO {
 			+COL_DISCUSSION_THREAD_ETAG+" = ?, "
 			+COL_DISCUSSION_THREAD_MODIFIED_ON+" = ? "
 			+" WHERE "+COL_DISCUSSION_THREAD_ID+" = ?";
+	private static final String SQL_UPDATE_THREAD_ETAG = "UPDATE "+TABLE_DISCUSSION_THREAD
+			+" SET "+COL_DISCUSSION_THREAD_ETAG+" = ?"
+			+" WHERE "+COL_DISCUSSION_THREAD_ID+" = ?";
 
 	private static final String SELECT_PROJECT_ID = "SELECT "
 			+TABLE_FORUM+"."+COL_FORUM_PROJECT_ID
@@ -248,6 +251,8 @@ public class DBODiscussionThreadDAOImpl implements DiscussionThreadDAO {
 	@Override
 	public void updateThreadView(long threadId, long userId) {
 		jdbcTemplate.update(SQL_UPDATE_THREAD_VIEW_TABLE, threadId, userId);
+		String etag = UUID.randomUUID().toString();
+		jdbcTemplate.update(SQL_UPDATE_THREAD_ETAG, etag, threadId);
 	}
 
 	@Override

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/discussion/DBODiscussionThreadDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/discussion/DBODiscussionThreadDAOImplTest.java
@@ -615,4 +615,12 @@ public class DBODiscussionThreadDAOImplTest {
 		assertEquals(1L, ids.size());
 		assertEquals(threadId.toString(), ids.get(0));
 	}
+
+	@Test
+	public void testUpdateThreadViewTriggerThreadEtagChange() {
+		DiscussionThreadBundle threadBundle = threadDao.createThread(forumId, threadId.toString(), "title", "messageKey", userId);
+		threadDao.updateThreadView(threadId, userId);
+		DiscussionThreadBundle updated = threadDao.getThread(threadId, DEFAULT_FILTER);
+		assertFalse(threadBundle.getEtag().equals(updated.getEtag()));
+	}
 }


### PR DESCRIPTION
since thread view is secondary table and will be migrated depending on
thread
