### PR TITLE
Do not set the destination back to rw.

### DIFF
--- a/tools/tool-migration-utility/src/main/java/org/sagebionetworks/tool/migration/v4/MigrationClient.java
+++ b/tools/tool-migration-utility/src/main/java/org/sagebionetworks/tool/migration/v4/MigrationClient.java
@@ -85,7 +85,7 @@ public class MigrationClient {
 			}
 		} finally {
 			// After migration is complete, re-enable read/write
-			setDestinationStatus(StatusEnum.READ_WRITE, "Synapse is ready for read/write");
+			// setDestinationStatus(StatusEnum.READ_WRITE, "Synapse is ready for read/write");
 		}
 		return failed;
 	}


### PR DESCRIPTION
Prep for manual table checksums.
Both source and destination will stay in RO mode after final sync.
If error, exec the CHECKSUM TABLEs manually and switch over.
Do not merge back into develop.
