### PR TITLE
Rename semaphore lock key.

### DIFF
--- a/services/workers/src/main/resources/migration-sqs-spb.xml
+++ b/services/workers/src/main/resources/migration-sqs-spb.xml
@@ -28,7 +28,7 @@
 								<property name="runner">
 									<bean class="org.sagebionetworks.migration.worker.MigrationWorker" />
 								</property>
-								<property name="semaphoreLockKey" value="migration" />
+								<property name="semaphoreLockKey" value="migration2" />
 								<property name="semaphoreMaxLockCount" value="1" />
 								<property name="semaphoreLockAndMessageVisibilityTimeoutSec" value="600" />
 								<property name="queueName" ref="stackConfiguration.asyncQueueName[MIGRATION]"/>


### PR DESCRIPTION
To lock old workers out and allow the new ones in.