### PR TITLE
Fix for PLFM-4623

### DIFF
--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/TeamSortOrder.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/TeamSortOrder.json
@@ -1,6 +1,10 @@
 {
   "type": "string",
+  "description": "All possible fields by which to sort the results",
   "enum": [
-    "TEAM_NAME"
+    {
+      "name": "TEAM_NAME",
+      "description": "The name of the team"
+    }
   ]
 }


### PR DESCRIPTION
The hudson build failed because TeamSortOrder.json didn't include descriptions.