### PR TITLE
PLFM-4817

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/principal/PrincipalPrefixDAO.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/principal/PrincipalPrefixDAO.java
@@ -47,16 +47,25 @@ public interface PrincipalPrefixDAO {
 	List<Long> listPrincipalsForPrefix(String prefix, Long limit, Long offset);
 	
 	/**
-	 * List a single page of users or teams that match the given prefix;
+	 * List a single page of users or usergroups that match the given prefix.
 	 * 
 	 * @param prefix
-	 * @param isIndividual True for users, false for teams.
+	 * @param isIndividual True for users, false for user groups.
 	 * @param limit
 	 * @param offset
-	 * @return
+	 * @return A list of IDs corresponding to matching users or usergroups.
 	 */
 	List<Long> listPrincipalsForPrefix(String prefix, boolean isIndividual, Long limit, Long offset);
 
+	/**
+	 * List a single page of teams that match the given prefix;
+	 *
+	 * @param prefix
+	 * @param limit
+	 * @param offset
+	 * @return A list of IDs corresponding to matching teams.
+	 */
+	List<Long> listTeamsForPrefix(String prefix, Long limit, Long offset);
 
 	/**
 	 * For a given team, list all members that share the given prefix.

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/principal/PrincipalPrefixDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/principal/PrincipalPrefixDAOImpl.java
@@ -48,7 +48,7 @@ public class PrincipalPrefixDAOImpl implements PrincipalPrefixDAO {
 			+ " WHERE "
 			+ COL_PRINCIPAL_PREFIX_TOKEN
 			+ " LIKE ? LIMIT ? OFFSET ?";
-	
+
 	private static final String SQL_LIST_PRINCIPALS_FOR_PREFIX_BY_TYPE =
 			"SELECT DISTINCT P."+COL_PRINCIPAL_PREFIX_PRINCIPAL_ID
 			+ " FROM "
@@ -57,6 +57,16 @@ public class PrincipalPrefixDAOImpl implements PrincipalPrefixDAO {
 					+" AND U."+COL_USER_GROUP_IS_INDIVIDUAL+" = ?)"
 			+ " WHERE"
 			+ " P.TOKEN LIKE ? LIMIT ? OFFSET ?";
+
+	private static final String SQL_LIST_TEAMS_FOR_PREFIX =
+			"SELECT DISTINCT P." + COL_PRINCIPAL_PREFIX_PRINCIPAL_ID
+					+ " FROM "
+					+ TABLE_PRINCIPAL_PREFIX + " P JOIN " + TABLE_USER_GROUP + " U ON P."
+					+ COL_PRINCIPAL_PREFIX_PRINCIPAL_ID + " = U." + COL_USER_GROUP_ID
+					+ " JOIN " + TABLE_TEAM + " T ON U." + COL_USER_GROUP_ID + " = T."
+					+ COL_TEAM_ID + " WHERE P." + COL_PRINCIPAL_PREFIX_TOKEN
+					+ " LIKE ? LIMIT ? OFFSET ?";
+
 
 	private static final String SQL_CLEAR_PRINCIPAL = "DELETE FROM "
 			+ TABLE_PRINCIPAL_PREFIX + " WHERE "
@@ -173,6 +183,17 @@ public class PrincipalPrefixDAOImpl implements PrincipalPrefixDAO {
 			Long offset) {
 		String processed = preProcessToken(prefix);
 		return jdbcTemplate.queryForList(SQL_LIST_PRINCIPALS_FOR_PREFIX,
+				Long.class, processed + WILDCARD, limit, offset);
+	}
+
+	/**
+	 * (non-Javadoc)
+	 * @see org.sagebionetworks.repo.model.dbo.principal.PrincipalPrefixDAO#listTeamsForPrefix(java.lang.String, java.lang.Long, java.lang.Long)
+	 */
+	@Override
+	public List<Long> listTeamsForPrefix(String prefix, Long limit, Long offset) {
+		String processed = preProcessToken(prefix);
+		return jdbcTemplate.queryForList(SQL_LIST_TEAMS_FOR_PREFIX,
 				Long.class, processed + WILDCARD, limit, offset);
 	}
 	

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/UserGroupTestUtils.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/UserGroupTestUtils.java
@@ -11,7 +11,6 @@ public class UserGroupTestUtils {
 	}
 
 	public static UserGroup createGroup() {
-		// need an arbitrary user to own the project
 		UserGroup group = new UserGroup();
 		group.setIsIndividual(false);
 		return group;

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/TeamServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/TeamServiceImpl.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.sagebionetworks.repo.web.service;
 
 import java.util.Arrays;
@@ -109,8 +106,7 @@ public class TeamServiceImpl implements TeamService {
 		if (fragment==null || fragment.trim().length()==0) {
 			return teamManager.list(limit, offset);
 		}
-		boolean isIndividual = false;
-		List<Long> teamIds = principalPrefixDAO.listPrincipalsForPrefix(fragment, isIndividual, limit, offset);
+		List<Long> teamIds = principalPrefixDAO.listTeamsForPrefix(fragment, limit, offset);
 		List<Team> teams = teamManager.list(teamIds).getList();
 		return PaginatedResults.createWithLimitAndOffset(teams, limit, offset);
 	}
@@ -140,10 +136,10 @@ public class TeamServiceImpl implements TeamService {
 		List<TeamMember> members = listTeamMembers(Arrays.asList(teamIdLong), memberIds).getList();
 		return PaginatedResults.createWithLimitAndOffset(members, limit, offset);
 	}
-	
+
 	/**
-	 * 
-	 * @param id
+	 *
+	 * @param teamId
 	 * @param fragment
 	 * @return
 	 */

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/service/TeamServiceTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/service/TeamServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -24,7 +23,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.sagebionetworks.reflection.model.PaginatedResults;
 import org.sagebionetworks.repo.manager.MessageToUserAndBody;
@@ -33,7 +31,6 @@ import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.UserProfileManager;
 import org.sagebionetworks.repo.manager.team.TeamManager;
 import org.sagebionetworks.repo.manager.token.TokenGenerator;
-import org.sagebionetworks.repo.manager.token.TokenGeneratorSingleton;
 import org.sagebionetworks.repo.model.JoinTeamSignedToken;
 import org.sagebionetworks.repo.model.ListWrapper;
 import org.sagebionetworks.repo.model.ResponseMessage;
@@ -95,12 +92,14 @@ public class TeamServiceTest {
 	}
 	
 	@Test
-	public void testGetTeamsByFragment() throws Exception {
-		boolean isIndividual = false;
-		when(mockPrincipalPrefixDAO.listPrincipalsForPrefix("foo", isIndividual, 1L, 0L)).thenReturn(Arrays.asList(99L));
-		when(mockPrincipalPrefixDAO.listPrincipalsForPrefix("ba", isIndividual, 1L, 0L)).thenReturn(Arrays.asList(99L));
-		when(mockPrincipalPrefixDAO.listPrincipalsForPrefix("bas", isIndividual, 1L, 0L)).thenReturn(new LinkedList<Long>());
-		
+	public void testGetTeamsByFragment() {
+		List<Long> listWithTeam = Arrays.asList(99L);
+		List<Long> emptyList = new LinkedList<>();
+
+		when(mockPrincipalPrefixDAO.listTeamsForPrefix("foo", 1L, 0L)).thenReturn(listWithTeam);
+		when(mockPrincipalPrefixDAO.listTeamsForPrefix("ba", 1L, 0L)).thenReturn(listWithTeam);
+		when(mockPrincipalPrefixDAO.listTeamsForPrefix("bas", 1L, 0L)).thenReturn(emptyList);
+
 		List<Team> expected = new ArrayList<Team>(); expected.add(team);
 		ListWrapper<Team> wrapped = new ListWrapper<Team>();
 		wrapped.setList(expected);


### PR DESCRIPTION
use a new team search sql query to search for only usergroups that have an associated team (currently teamsearch retrieves usergroups, which causes a notfounderror to be thrown when finding a matching usergroup that does not have a team)