### PR TITLE
PLFM-5145 remove support for DOI creator name identifiers

### DIFF
--- a/lib/lib-doi/src/main/java/org/sagebionetworks/doi/datacite/DataciteMetadataTranslatorImpl.java
+++ b/lib/lib-doi/src/main/java/org/sagebionetworks/doi/datacite/DataciteMetadataTranslatorImpl.java
@@ -1,11 +1,30 @@
 package org.sagebionetworks.doi.datacite;
 
-import com.sun.org.apache.xml.internal.serialize.OutputFormat;
-import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
-import org.apache.xerces.dom.DocumentImpl;
-import org.sagebionetworks.repo.model.doi.v2.*;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.CREATOR;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.CREATORS;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.CREATOR_NAME;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.IDENTIFIER;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.IDENTIFIER_TYPE;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.IDENTIFIER_TYPE_VALUE;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.ISNI_URI;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.NAMESPACE;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.NAMESPACE_PREFIX;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.NAMESPACE_PREFIX_VALUE;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.NAMESPACE_VALUE;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.NAME_IDENTIFIER;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.NAME_IDENTIFIER_SCHEME;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.ORCID_URI;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.PUBLICATION_YEAR;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.PUBLISHER;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.PUBLISHER_VALUE;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.RESOURCE;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.RESOURCE_TYPE;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.RESOURCE_TYPE_GENERAL;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.SCHEMA_LOCATION;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.SCHEMA_LOCATION_VALUE;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.SCHEME_URI;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.TITLE;
+import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.TITLES;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -13,7 +32,18 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.*;
+import org.apache.xerces.dom.DocumentImpl;
+import org.sagebionetworks.repo.model.doi.v2.DataciteMetadata;
+import org.sagebionetworks.repo.model.doi.v2.DoiCreator;
+import org.sagebionetworks.repo.model.doi.v2.DoiNameIdentifier;
+import org.sagebionetworks.repo.model.doi.v2.DoiResourceType;
+import org.sagebionetworks.repo.model.doi.v2.DoiTitle;
+import org.sagebionetworks.repo.model.doi.v2.NameIdentifierScheme;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import com.sun.org.apache.xml.internal.serialize.OutputFormat;
+import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
 
 /*
  * Translates our DoiV2 object into well-formed DataCite XML.
@@ -168,7 +198,9 @@ public class DataciteMetadataTranslatorImpl implements DataciteMetadataTranslato
 			throw new IllegalArgumentException("Creator names must be at least 1 character long.");
 		}
 		if (creator.getNameIdentifiers() != null) {
-			creator.getNameIdentifiers().forEach(DataciteMetadataTranslatorImpl::validateDoiNameIdentifier);
+			throw new UnsupportedOperationException("Synapse does not currently support name identifiers.");
+			// TODO: support name identifiers, see PLFM-5145
+			//creator.getNameIdentifiers().forEach(DataciteMetadataTranslatorImpl::validateDoiNameIdentifier);
 		}
 	}
 

--- a/lib/lib-doi/src/test/java/org/sagebionetworks/doi/datacite/DataciteMetadataTranslatorTest.java
+++ b/lib/lib-doi/src/test/java/org/sagebionetworks/doi/datacite/DataciteMetadataTranslatorTest.java
@@ -289,7 +289,7 @@ public class DataciteMetadataTranslatorTest {
 	}
 
 	@Test
-	@Ignore
+	@Ignore // Remove this annotation when PLFM-5145 is complete
 	public void testValidateCreatorWithNonNullNameIdentifiers() {
 		DoiCreator creator = new DoiCreator();
 		creator.setCreatorName("A name");

--- a/lib/lib-doi/src/test/java/org/sagebionetworks/doi/datacite/DataciteMetadataTranslatorTest.java
+++ b/lib/lib-doi/src/test/java/org/sagebionetworks/doi/datacite/DataciteMetadataTranslatorTest.java
@@ -96,16 +96,17 @@ public class DataciteMetadataTranslatorTest {
 		creators = new ArrayList<>();
 		c1 = new DoiCreator();
 		c1.setCreatorName("Last, First");
-		nameId1 = new DoiNameIdentifier();
-		nameId1.setIdentifier(validOrcid);
-		nameId1.setNameIdentifierScheme(NameIdentifierScheme.ORCID);
-		nameId2 = new DoiNameIdentifier();
-		nameId2.setIdentifier(validOrcid);
-		nameId2.setNameIdentifierScheme(NameIdentifierScheme.ISNI);
-		List<DoiNameIdentifier> ids = new ArrayList<>();
-		ids.add(nameId1);
-		ids.add(nameId2);
-		c1.setNameIdentifiers(ids);
+		// Uncomment the following lines upon supporting nameIdentifiers
+//		nameId1 = new DoiNameIdentifier();
+//		nameId1.setIdentifier(validOrcid);
+//		nameId1.setNameIdentifierScheme(NameIdentifierScheme.ORCID);
+//		nameId2 = new DoiNameIdentifier();
+//		nameId2.setIdentifier(validOrcid);
+//		nameId2.setNameIdentifierScheme(NameIdentifierScheme.ISNI);
+//		List<DoiNameIdentifier> ids = new ArrayList<>();
+//		ids.add(nameId1);
+//		ids.add(nameId2);
+//		c1.setNameIdentifiers(ids);
 		c2 = new DoiCreator();
 		c2.setCreatorName("Sample name");
 		creators.add(c1);
@@ -147,14 +148,14 @@ public class DataciteMetadataTranslatorTest {
 		assertEquals(c1.getCreatorName(), creatorNameActual.getTextContent());
 
 		// Test the name identifiers
-		assertEquals(2, actual.getElementsByTagName(NAME_IDENTIFIER).getLength());
-		Element nameIdActual = (Element) actual.getElementsByTagName(NAME_IDENTIFIER).item(0);
-		assertEquals(nameId1.getNameIdentifierScheme().name(), nameIdActual.getAttribute(NAME_IDENTIFIER_SCHEME));
-		assertEquals(nameId1.getIdentifier(), nameIdActual.getTextContent());
-
-		nameIdActual = (Element) actual.getElementsByTagName(NAME_IDENTIFIER).item(1);
-		assertEquals(nameId2.getNameIdentifierScheme().name(), nameIdActual.getAttribute(NAME_IDENTIFIER_SCHEME));
-		assertEquals(nameId2.getIdentifier(), nameIdActual.getTextContent());
+//		assertEquals(2, actual.getElementsByTagName(NAME_IDENTIFIER).getLength());
+//		Element nameIdActual = (Element) actual.getElementsByTagName(NAME_IDENTIFIER).item(0);
+//		assertEquals(nameId1.getNameIdentifierScheme().name(), nameIdActual.getAttribute(NAME_IDENTIFIER_SCHEME));
+//		assertEquals(nameId1.getIdentifier(), nameIdActual.getTextContent());
+//
+//		nameIdActual = (Element) actual.getElementsByTagName(NAME_IDENTIFIER).item(1);
+//		assertEquals(nameId2.getNameIdentifierScheme().name(), nameIdActual.getAttribute(NAME_IDENTIFIER_SCHEME));
+//		assertEquals(nameId2.getIdentifier(), nameIdActual.getTextContent());
 
 		// Test the second creator that has no name identifiers
 		actual = createCreatorElement(dom, c2);
@@ -306,6 +307,15 @@ public class DataciteMetadataTranslatorTest {
 	public void testEmptyCreatorName() {
 		DoiCreator creator = new DoiCreator();
 		creator.setCreatorName("");
+		// Call under test
+		validateDoiCreator(creator);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHasNonNullNameIdentifiers() {
+		DoiCreator creator = new DoiCreator();
+		creator.setCreatorName("");
+		creator.setNameIdentifiers(new ArrayList<>());
 		// Call under test
 		validateDoiCreator(creator);
 	}

--- a/lib/lib-doi/src/test/java/org/sagebionetworks/doi/datacite/DataciteMetadataTranslatorTest.java
+++ b/lib/lib-doi/src/test/java/org/sagebionetworks/doi/datacite/DataciteMetadataTranslatorTest.java
@@ -14,7 +14,6 @@ import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.NAMESPA
 import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.NAMESPACE_PREFIX_VALUE;
 import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.NAMESPACE_VALUE;
 import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.NAME_IDENTIFIER;
-import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.NAME_IDENTIFIER_SCHEME;
 import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.ORCID_URI;
 import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.PUBLICATION_YEAR;
 import static org.sagebionetworks.doi.datacite.DataciteMetadataConstants.PUBLISHER;
@@ -52,6 +51,7 @@ import java.util.List;
 
 import org.apache.xerces.dom.DocumentImpl;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.sagebionetworks.repo.model.doi.v2.DataciteMetadata;
 import org.sagebionetworks.repo.model.doi.v2.Doi;
@@ -71,8 +71,6 @@ public class DataciteMetadataTranslatorTest {
 	private List<DoiCreator> creators;
 	private DoiCreator c1;
 	private DoiCreator c2;
-	private DoiNameIdentifier nameId1;
-	private DoiNameIdentifier nameId2;
 	private List<DoiTitle> titles;
 	private DoiTitle t1;
 	private DoiTitle t2;
@@ -96,17 +94,6 @@ public class DataciteMetadataTranslatorTest {
 		creators = new ArrayList<>();
 		c1 = new DoiCreator();
 		c1.setCreatorName("Last, First");
-		// Uncomment the following lines upon supporting nameIdentifiers
-//		nameId1 = new DoiNameIdentifier();
-//		nameId1.setIdentifier(validOrcid);
-//		nameId1.setNameIdentifierScheme(NameIdentifierScheme.ORCID);
-//		nameId2 = new DoiNameIdentifier();
-//		nameId2.setIdentifier(validOrcid);
-//		nameId2.setNameIdentifierScheme(NameIdentifierScheme.ISNI);
-//		List<DoiNameIdentifier> ids = new ArrayList<>();
-//		ids.add(nameId1);
-//		ids.add(nameId2);
-//		c1.setNameIdentifiers(ids);
 		c2 = new DoiCreator();
 		c2.setCreatorName("Sample name");
 		creators.add(c1);
@@ -146,16 +133,6 @@ public class DataciteMetadataTranslatorTest {
 		Element creatorNameActual = (Element)actual.getElementsByTagName(CREATOR_NAME).item(0);
 		assertEquals(CREATOR_NAME, creatorNameActual.getTagName());
 		assertEquals(c1.getCreatorName(), creatorNameActual.getTextContent());
-
-		// Test the name identifiers
-//		assertEquals(2, actual.getElementsByTagName(NAME_IDENTIFIER).getLength());
-//		Element nameIdActual = (Element) actual.getElementsByTagName(NAME_IDENTIFIER).item(0);
-//		assertEquals(nameId1.getNameIdentifierScheme().name(), nameIdActual.getAttribute(NAME_IDENTIFIER_SCHEME));
-//		assertEquals(nameId1.getIdentifier(), nameIdActual.getTextContent());
-//
-//		nameIdActual = (Element) actual.getElementsByTagName(NAME_IDENTIFIER).item(1);
-//		assertEquals(nameId2.getNameIdentifierScheme().name(), nameIdActual.getAttribute(NAME_IDENTIFIER_SCHEME));
-//		assertEquals(nameId2.getIdentifier(), nameIdActual.getTextContent());
 
 		// Test the second creator that has no name identifiers
 		actual = createCreatorElement(dom, c2);
@@ -311,11 +288,25 @@ public class DataciteMetadataTranslatorTest {
 		validateDoiCreator(creator);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testHasNonNullNameIdentifiers() {
+	@Test
+	@Ignore
+	public void testValidateCreatorWithNonNullNameIdentifiers() {
 		DoiCreator creator = new DoiCreator();
-		creator.setCreatorName("");
-		creator.setNameIdentifiers(new ArrayList<>());
+		creator.setCreatorName("A name");
+
+		DoiNameIdentifier id1 = new DoiNameIdentifier();
+		id1.setIdentifier(validOrcid);
+		id1.setNameIdentifierScheme(NameIdentifierScheme.ORCID);
+
+		DoiNameIdentifier id2 = new DoiNameIdentifier();
+		id2.setIdentifier("Another Identifier");
+		id2.setNameIdentifierScheme(NameIdentifierScheme.ISNI);
+
+		List<DoiNameIdentifier> ids = new ArrayList<>();
+		ids.add(id1);
+		ids.add(id2);
+
+		creator.setNameIdentifiers(ids);
 		// Call under test
 		validateDoiCreator(creator);
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/doi/DoiManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/doi/DoiManagerImplTest.java
@@ -34,11 +34,9 @@ import org.sagebionetworks.repo.model.doi.v2.DataciteMetadata;
 import org.sagebionetworks.repo.model.doi.v2.Doi;
 import org.sagebionetworks.repo.model.doi.v2.DoiAssociation;
 import org.sagebionetworks.repo.model.doi.v2.DoiCreator;
-import org.sagebionetworks.repo.model.doi.v2.DoiNameIdentifier;
 import org.sagebionetworks.repo.model.doi.v2.DoiResourceType;
 import org.sagebionetworks.repo.model.doi.v2.DoiResourceTypeGeneral;
 import org.sagebionetworks.repo.model.doi.v2.DoiTitle;
-import org.sagebionetworks.repo.model.doi.v2.NameIdentifierScheme;
 import org.sagebionetworks.repo.web.ServiceUnavailableException;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
 import org.springframework.dao.DuplicateKeyException;
@@ -559,10 +557,6 @@ public class DoiManagerImplTest {
 			// Required metadata fields
 			DoiCreator doiCreator = new DoiCreator();
 			doiCreator.setCreatorName(author);
-			DoiNameIdentifier nameIdentifier = new DoiNameIdentifier();
-			nameIdentifier.setIdentifier(orcid);
-			nameIdentifier.setNameIdentifierScheme(NameIdentifierScheme.ORCID);
-			doiCreator.setNameIdentifiers(Collections.singletonList(nameIdentifier));
 			dto.setCreators(Collections.singletonList(doiCreator));
 
 			DoiTitle doiTitle = new DoiTitle();


### PR DESCRIPTION
add this back in if/when the web client supports them (essentially undo the changes in this commit)