### PR TITLE
PLFM-5268 add GET /entity/{id}/dockerTag

### DIFF
--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -2734,8 +2734,25 @@ public interface SynapseClient extends BaseClient {
 	 * @param ascending, optional (default is false)
 	 * @return a paginated list of commits (tag/digest pairs) for the given Docker repository.
 	 * @throws SynapseException
+	 *
+	 * TODO: Delete this method when no longer used
 	 */
+	@Deprecated
 	PaginatedResults<DockerCommit> listDockerCommits(String entityId, Long limit, Long offset, DockerCommitSortBy sortBy, Boolean ascending) throws SynapseException;
+
+
+	/**
+	 * Return a paginated list of tagged commits (tag/digest pairs) for the given Docker repository.
+	 *
+	 * @param entityId the ID of the Docker repository entity
+	 * @param limit pagination parameter, optional (default is 20)
+	 * @param offset pagination parameter, optional (default is 0)
+	 * @param sortBy TAG or CREATED_ON, optional (default is CREATED_ON)
+	 * @param ascending, optional (default is false)
+	 * @return a paginated list of tagged commits (tag/digest pairs) for the given Docker repository.
+	 * @throws SynapseException
+	 */
+	PaginatedResults<DockerCommit> listDockerTags(String entityId, Long limit, Long offset, DockerCommitSortBy sortBy, Boolean ascending) throws SynapseException;
 
 	/**
 	 * Get threads that reference the given entity

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
@@ -522,8 +522,9 @@ public class SynapseClientImpl extends BaseClientImpl implements SynapseClient {
 	private static final String OBJECT = "/object";	
 
 	private static final String PRINCIPAL_ID_REQUEST_PARAM = "principalId";
-	
+
 	private static final String DOCKER_COMMIT = "/dockerCommit";
+	private static final String DOCKER_TAG = "/dockerTag";
 
 	private static final String NEXT_PAGE_TOKEN_PARAM = "nextPageToken=";
 
@@ -4967,6 +4968,7 @@ public class SynapseClientImpl extends BaseClientImpl implements SynapseClient {
 		voidPost(getRepoEndpoint(), ENTITY+"/"+entityId+DOCKER_COMMIT, dockerCommit, null);
 	}
 
+	@Deprecated // TODO: Remove when no longer used
 	@Override
 	public PaginatedResults<DockerCommit> listDockerCommits(
 			String entityId, Long limit, Long offset, DockerCommitSortBy sortBy, Boolean ascending) throws SynapseException {
@@ -4988,7 +4990,32 @@ public class SynapseClientImpl extends BaseClientImpl implements SynapseClient {
 		if (!requestParams.isEmpty()) {
 			url += "?" + Joiner.on('&').join(requestParams);
 		}
-		
+
+		return getPaginatedResults(getRepoEndpoint(), url, DockerCommit.class);
+	}
+
+	@Override
+	public PaginatedResults<DockerCommit> listDockerTags(
+			String entityId, Long limit, Long offset, DockerCommitSortBy sortBy, Boolean ascending) throws SynapseException {
+		ValidateArgument.required(entityId, "entityId");
+		String url = ENTITY+"/"+entityId+DOCKER_TAG;
+		List<String> requestParams = new ArrayList<String>();
+		if (limit!=null) {
+			requestParams.add(LIMIT+"="+limit);
+		}
+		if (offset!=null) {
+			requestParams.add(OFFSET+"="+offset);
+		}
+		if (sortBy!=null) {
+			requestParams.add("sort="+sortBy.name());
+		}
+		if (ascending!=null) {
+			requestParams.add("ascending="+ascending);
+		}
+		if (!requestParams.isEmpty()) {
+			url += "?" + Joiner.on('&').join(requestParams);
+		}
+
 		return getPaginatedResults(getRepoEndpoint(), url, DockerCommit.class);
 	}
 

--- a/integration-test/src/test/java/org/sagebionetworks/ITDocker.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITDocker.java
@@ -14,7 +14,6 @@ import java.util.UUID;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpStatus;
-import org.json.JSONObject;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -160,7 +159,7 @@ public class ITDocker {
 		// now reassign the tag to a new commit
 		DockerCommit commit2 = createCommit(tag, UUID.randomUUID().toString());
 		synapseOne.addDockerCommit(dockerRepo.getId(), commit2);
-		PaginatedResults<DockerCommit> result = synapseOne.listDockerCommits(dockerRepo.getId(), 10L, 0L, DockerCommitSortBy.TAG, true);
+		PaginatedResults<DockerCommit> result = synapseOne.listDockerTags(dockerRepo.getId(), 10L, 0L, DockerCommitSortBy.TAG, true);
 		assertEquals(1L, result.getTotalNumberOfResults());
 		assertEquals(1, result.getResults().size());
 		DockerCommit retrieved = result.getResults().get(0);
@@ -171,7 +170,7 @@ public class ITDocker {
 		// make sure optional params are optional
 		assertEquals(
 				result,
-				synapseOne.listDockerCommits(dockerRepo.getId(), null, null, null, null)
+				synapseOne.listDockerTags(dockerRepo.getId(), null, null, null, null)
 				);
 	}
 	

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DockerCommitDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DockerCommitDaoImpl.java
@@ -110,7 +110,7 @@ public class DockerCommitDaoImpl implements DockerCommitDao {
 	}
 	
 	@Override
-	public List<DockerCommit> listDockerCommits(String entityId, 
+	public List<DockerCommit> listDockerTags(String entityId,
 			DockerCommitSortBy sortBy, boolean ascending, long limit, long offset) {
 		ValidateArgument.required(entityId, "entityId");
 		ValidateArgument.required(sortBy, "sortBy");

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DockerCommitDaoImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DockerCommitDaoImplTest.java
@@ -92,7 +92,7 @@ public class DockerCommitDaoImplTest {
 		
 		assertEquals(1, dockerCommitDao.countDockerCommits(dockerRepository1.getId()));			
 		
-		List<DockerCommit> commits = dockerCommitDao.listDockerCommits(
+		List<DockerCommit> commits = dockerCommitDao.listDockerTags(
 				dockerRepository1.getId(), DockerCommitSortBy.CREATED_ON, 
 				/*ascending*/true, 10, 0);
 		
@@ -156,48 +156,48 @@ public class DockerCommitDaoImplTest {
 		// sort by created_on, ascending
 		assertEquals(
 				Arrays.asList(new DockerCommit[]{commitA, commitB}),
-				dockerCommitDao.listDockerCommits(dockerRepository1.getId(), 
+				dockerCommitDao.listDockerTags(dockerRepository1.getId(),
 						DockerCommitSortBy.CREATED_ON, /*ascending*/true, 10, 0)
 				);
 		assertEquals(
 				Arrays.asList(new DockerCommit[]{commitZ, commitY}),
-				dockerCommitDao.listDockerCommits(dockerRepository2.getId(), 
+				dockerCommitDao.listDockerTags(dockerRepository2.getId(),
 						DockerCommitSortBy.CREATED_ON, /*ascending*/true, 10, 0)
 				);
 		
 		// sort by created_on, descending
 		assertEquals(
 				Arrays.asList(new DockerCommit[]{commitB, commitA}),
-				dockerCommitDao.listDockerCommits(dockerRepository1.getId(), 
+				dockerCommitDao.listDockerTags(dockerRepository1.getId(),
 						DockerCommitSortBy.CREATED_ON, /*ascending*/false, 10, 0)
 				);
 		assertEquals(
 				Arrays.asList(new DockerCommit[]{commitY, commitZ}),
-				dockerCommitDao.listDockerCommits(dockerRepository2.getId(), 
+				dockerCommitDao.listDockerTags(dockerRepository2.getId(),
 						DockerCommitSortBy.CREATED_ON, /*ascending*/false, 10, 0)
 				);
 
 		// sort by tag, ascending
 		assertEquals(
 				Arrays.asList(new DockerCommit[]{commitA, commitB}),
-				dockerCommitDao.listDockerCommits(dockerRepository1.getId(), 
+				dockerCommitDao.listDockerTags(dockerRepository1.getId(),
 						DockerCommitSortBy.TAG, /*ascending*/true, 10, 0)
 				);
 		assertEquals(
 				Arrays.asList(new DockerCommit[]{commitY, commitZ}),
-				dockerCommitDao.listDockerCommits(dockerRepository2.getId(), 
+				dockerCommitDao.listDockerTags(dockerRepository2.getId(),
 						DockerCommitSortBy.TAG, /*ascending*/true, 10, 0)
 				);
 		
 		// sort by tag, descending
 		assertEquals(
 				Arrays.asList(new DockerCommit[]{commitB, commitA}),
-				dockerCommitDao.listDockerCommits(dockerRepository1.getId(), 
+				dockerCommitDao.listDockerTags(dockerRepository1.getId(),
 						DockerCommitSortBy.TAG, /*ascending*/false, 10, 0)
 				);
 		assertEquals(
 				Arrays.asList(new DockerCommit[]{commitZ, commitY}),
-				dockerCommitDao.listDockerCommits(dockerRepository2.getId(), 
+				dockerCommitDao.listDockerTags(dockerRepository2.getId(),
 						DockerCommitSortBy.TAG, /*ascending*/false, 10, 0)
 				);
 
@@ -211,7 +211,7 @@ public class DockerCommitDaoImplTest {
 		DockerCommit laterCommit = createCommit(new Date(now+1000L), "a", UUID.randomUUID().toString());
 		dockerCommitDao.createDockerCommit(dockerRepository1.getId(), creatorUserGroupId, laterCommit);
 		
-		List<DockerCommit> commits = dockerCommitDao.listDockerCommits(dockerRepository1.getId(), 
+		List<DockerCommit> commits = dockerCommitDao.listDockerTags(dockerRepository1.getId(),
 				DockerCommitSortBy.TAG, /*ascending*/false, 10, 0);
 		assertEquals(Collections.singletonList(laterCommit), commits);
 		
@@ -226,13 +226,13 @@ public class DockerCommitDaoImplTest {
 		DockerCommit commitB = createCommit(new Date(now+1000L), "B", UUID.randomUUID().toString());
 		dockerCommitDao.createDockerCommit(dockerRepository1.getId(), creatorUserGroupId, commitB);
 		
-		List<DockerCommit> commits = dockerCommitDao.listDockerCommits(dockerRepository1.getId(), 
+		List<DockerCommit> commits = dockerCommitDao.listDockerTags(dockerRepository1.getId(),
 				DockerCommitSortBy.TAG, /*ascending*/true, 1, 0);
 		assertEquals(Collections.singletonList(commitA), commits);
-		commits = dockerCommitDao.listDockerCommits(dockerRepository1.getId(), 
+		commits = dockerCommitDao.listDockerTags(dockerRepository1.getId(),
 				DockerCommitSortBy.TAG, /*ascending*/true, 1, 1);
 		assertEquals(Collections.singletonList(commitB), commits);
-		commits = dockerCommitDao.listDockerCommits(dockerRepository1.getId(), 
+		commits = dockerCommitDao.listDockerTags(dockerRepository1.getId(),
 				DockerCommitSortBy.TAG, /*ascending*/true, 10, 3);
 		assertTrue(commits.isEmpty());
 	}
@@ -256,12 +256,12 @@ public class DockerCommitDaoImplTest {
 	
 	@Test(expected=IllegalArgumentException.class)
 	public void testListDockerCommitsMissingEntityId() {
-		dockerCommitDao.listDockerCommits(null, DockerCommitSortBy.TAG, /*ascending*/true, 1, 0);
+		dockerCommitDao.listDockerTags(null, DockerCommitSortBy.TAG, /*ascending*/true, 1, 0);
 	}
 
 	@Test(expected=IllegalArgumentException.class)
 	public void testListDockerCommitsMissingSortyBy() {
-		dockerCommitDao.listDockerCommits(dockerRepository1.getId(), null, /*ascending*/true, 1, 0);
+		dockerCommitDao.listDockerTags(dockerRepository1.getId(), null, /*ascending*/true, 1, 0);
 	}
 
 	@Test(expected=IllegalArgumentException.class)

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/DockerCommitDao.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/DockerCommitDao.java
@@ -14,11 +14,10 @@ public interface DockerCommitDao {
 	String createDockerCommit(String entityId, long userId, DockerCommit commit);
 	
 	/*
-	 * returns all the commits for a given Docker repository, choosing just
+	 * returns all the tagged commits for a given Docker repository, choosing just
 	 * the *latest* commit for each tag.
 	 */
-	List<DockerCommit> listDockerCommits(String entityId, 
-			DockerCommitSortBy sortBy, boolean ascending,long limit, long offset);
+	List<DockerCommit> listDockerTags(String entityId, DockerCommitSortBy sortBy, boolean ascending, long limit, long offset);
 	
 	/*
 	 * Count the number of commits for a repository (just the latest commit for each tag).

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/DockerManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/DockerManager.java
@@ -47,6 +47,6 @@ public interface DockerManager {
 	 * @returnall the commits for a given Docker repository, choosing just
 	 * the *latest* commit for each tag.
 	 */
-	PaginatedResults<DockerCommit> listDockerCommits(UserInfo userInfo, String entityId, DockerCommitSortBy sortBy, boolean ascending, long limit, long offset);
+	PaginatedResults<DockerCommit> listDockerTags(UserInfo userInfo, String entityId, DockerCommitSortBy sortBy, boolean ascending, long limit, long offset);
 
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/DockerManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/DockerManagerImpl.java
@@ -186,7 +186,7 @@ public class DockerManagerImpl implements DockerManager {
 	}
 
 	@Override
-	public PaginatedResults<DockerCommit> listDockerCommits(UserInfo userInfo,
+	public PaginatedResults<DockerCommit> listDockerTags(UserInfo userInfo,
 			String entityId, DockerCommitSortBy sortBy, boolean ascending,
 			long limit, long offset) {
 		ValidateArgument.required(entityId, "entityId");
@@ -195,7 +195,7 @@ public class DockerManagerImpl implements DockerManager {
 		AuthorizationManagerUtil.checkAuthorizationAndThrowException(authStatus);
 		EntityType entityType = entityManager.getEntityType(userInfo, entityId);
 		if (!entityType.equals(EntityType.dockerrepo)) throw new IllegalArgumentException("Only Docker reposiory entities have commits.");
-		List<DockerCommit> commits = dockerCommitDao.listDockerCommits(entityId, sortBy, ascending, limit, offset);
+		List<DockerCommit> commits = dockerCommitDao.listDockerTags(entityId, sortBy, ascending, limit, offset);
 		return PaginatedResults.createWithLimitAndOffset(commits, limit, offset);
 	}
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/DockerManagerImplAutowiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/DockerManagerImplAutowiredTest.java
@@ -93,7 +93,7 @@ public class DockerManagerImplAutowiredTest {
 		assertNotNull(createdEntityId);
 
 		PaginatedResults<DockerCommit> pgs = 
-				dockerManager.listDockerCommits(adminUserInfo, createdEntityId, 
+				dockerManager.listDockerTags(adminUserInfo, createdEntityId,
 						DockerCommitSortBy.TAG, /*ascending*/true, 10, 0);
 		
 		assertEquals(1L, pgs.getTotalNumberOfResults());
@@ -119,7 +119,7 @@ public class DockerManagerImplAutowiredTest {
 		dockerManager.addDockerCommitToUnmanagedRespository(adminUserInfo, entityId, commit);
 		
 		PaginatedResults<DockerCommit> pgs = 
-				dockerManager.listDockerCommits(adminUserInfo, entityId, 
+				dockerManager.listDockerTags(adminUserInfo, entityId,
 						DockerCommitSortBy.TAG, /*ascending*/true, 10, 0);
 		
 		assertEquals(1L, pgs.getTotalNumberOfResults());

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/DockerManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/DockerManagerImplUnitTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -23,21 +22,16 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.sagebionetworks.StackConfigurationSingleton;
-import org.sagebionetworks.ids.IdGenerator;
-import org.sagebionetworks.ids.IdType;
 import org.sagebionetworks.reflection.model.PaginatedResults;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.DockerCommitDao;
 import org.sagebionetworks.repo.model.DockerNodeDao;
 import org.sagebionetworks.repo.model.Entity;
-import org.sagebionetworks.repo.model.EntityHeader;
 import org.sagebionetworks.repo.model.EntityType;
 import org.sagebionetworks.repo.model.NodeDAO;
 import org.sagebionetworks.repo.model.ObjectType;
-import org.sagebionetworks.repo.model.Project;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.docker.DockerAuthorizationToken;
@@ -330,13 +324,13 @@ public class DockerManagerImplUnitTest {
 		commits.add(createCommit());
 		commits.add(createCommit());
 		
-		when(dockerCommitDao.listDockerCommits(REPO_ENTITY_ID, DockerCommitSortBy.CREATED_ON, /*ascending*/true, 10, 0)).
+		when(dockerCommitDao.listDockerTags(REPO_ENTITY_ID, DockerCommitSortBy.CREATED_ON, /*ascending*/true, 10, 0)).
 			thenReturn(commits);
 		
 		when(dockerCommitDao.countDockerCommits(REPO_ENTITY_ID)).thenReturn(2L);
 		
 		// method under test
-		PaginatedResults<DockerCommit> pgs = dockerManager.listDockerCommits(
+		PaginatedResults<DockerCommit> pgs = dockerManager.listDockerTags(
 				USER_INFO, REPO_ENTITY_ID, DockerCommitSortBy.CREATED_ON, /*ascending*/true, 10, 0);
 		
 		assertEquals(2L, pgs.getTotalNumberOfResults());
@@ -350,7 +344,7 @@ public class DockerManagerImplUnitTest {
 				thenReturn(AuthorizationManagerUtil.ACCESS_DENIED);
 				
 		// method under test
-		dockerManager.listDockerCommits(
+		dockerManager.listDockerTags(
 				USER_INFO, REPO_ENTITY_ID, DockerCommitSortBy.CREATED_ON, /*ascending*/true, 10, 0);
 	}
 	
@@ -358,7 +352,7 @@ public class DockerManagerImplUnitTest {
 	public void listDockerCommitsforNONrepo() {
 		when(entityManager.getEntityType(USER_INFO, REPO_ENTITY_ID)).thenReturn(EntityType.project);
 		// method under test
-		dockerManager.listDockerCommits(
+		dockerManager.listDockerTags(
 				USER_INFO, REPO_ENTITY_ID, DockerCommitSortBy.CREATED_ON, /*ascending*/true, 10, 0);
 	}
 

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
@@ -972,6 +972,7 @@ public class UrlHelpers {
 	// Docker authorization services
 	public static final String DOCKER_AUTHORIZATION = "/bearerToken";
 	public static final String ENITY_ID_DOCKER_COMMIT = ENTITY_ID+"/dockerCommit";
+	public static final String ENTITY_ID_DOCKER_TAG = ENTITY_ID+"/dockerTag";
 	public static final String DOCKER_REGISTRY_EVENTS = "/events";
 
 	// Data Access Services

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/DockerCommitController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/DockerCommitController.java
@@ -5,7 +5,6 @@ import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.ServiceConstants;
 import org.sagebionetworks.repo.model.docker.DockerCommit;
 import org.sagebionetworks.repo.model.docker.DockerCommitSortBy;
-import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.repo.web.UrlHelpers;
 import org.sagebionetworks.repo.web.rest.doc.ControllerInfo;
 import org.sagebionetworks.repo.web.service.ServiceProvider;
@@ -26,8 +25,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  * Note that create, update and delete of the Docker repositories themselves are done using
  * the <a href="#org.sagebionetworks.repo.web.controller.EntityController">Entity Services</a>,
  * for external/unmanaged repositories, or by direct integration with the Docker registry, for managed
- * Docker repositories.  Commits for both managed and external/unmanaged repositories may be
- * retrieved using the 'listDockerCommits' API included in this service.
+ * Docker repositories.  Tagged commits for both managed and external/unmanaged repositories may be
+ * retrieved using the 'listDockerTags' API included in this service.
  *
  */
 @Controller
@@ -57,18 +56,11 @@ public class DockerCommitController {
 	}
 
 	/**
-	 * List the commits (tag/digest pairs) for the given Docker repository.  Only the most recent
-	 * digest for each tag is returned since, following Docker's convention, a tag may be reassigned
-	 * to a newer commit. The list may be sorted by date or tag.  The default is to sort by 
-	 * date, descending (newest first).
-	 * 
-	 * @param userId
-	 * @param entityId the ID of the Docker repository entity
-	 * @param limit pagination parameter, optional (default is 20)
-	 * @param offset pagination parameter, optional (default is 0)
-	 * @param sortBy TAG or CREATED_ON, optional (default is CREATED_ON)
-	 * @param ascending, optional (default is false)
+	 * This service has been deprecated. See <a href="${GET.entity.id.dockerTag}">GET /entity/{id}/dockerTag</a>.
+	 *
+	 * TODO: Remove when portal uses dockerTag instead of this URI
 	 */
+	@Deprecated
 	@ResponseStatus(HttpStatus.OK)
 	@RequestMapping(value = UrlHelpers.ENITY_ID_DOCKER_COMMIT, method = RequestMethod.GET)
 	public @ResponseBody
@@ -82,9 +74,37 @@ public class DockerCommitController {
 			) {
 		DockerCommitSortBy sortBy = sortByParam==null ? 
 				DockerCommitSortBy.CREATED_ON : DockerCommitSortBy.valueOf(sortByParam);
-		return serviceProvider.getDockerService().listDockerCommits(userId, entityId, 
+		return serviceProvider.getDockerService().listDockerTags(userId, entityId,
 				sortBy, ascending, limit, offset);
 	}
-	
 
+	/**
+	 * List the tagged commits (tag/digest pairs) for the given Docker repository.  Only the most recent
+	 * digest for each tag is returned since, following Docker's convention, a tag may be reassigned
+	 * to a newer commit. The list may be sorted by date or tag.  The default is to sort by
+	 * date, descending (newest first).
+	 *
+	 * @param userId
+	 * @param entityId the ID of the Docker repository entity
+	 * @param limit pagination parameter, optional (default is 20)
+	 * @param offset pagination parameter, optional (default is 0)
+	 * @param sortBy TAG or CREATED_ON, optional (default is CREATED_ON)
+	 * @param ascending, optional (default is false)
+	 */
+	@ResponseStatus(HttpStatus.OK)
+	@RequestMapping(value = UrlHelpers.ENTITY_ID_DOCKER_TAG, method = RequestMethod.GET)
+	public @ResponseBody
+	PaginatedResults<DockerCommit> listDockerTags(
+			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM) Long userId,
+			@PathVariable(value = UrlHelpers.ID_PATH_VARIABLE) String entityId,
+			@RequestParam(value = ServiceConstants.SORT_BY_PARAM, required = false) String sortByParam,
+			@RequestParam(value = ServiceConstants.ASCENDING_PARAM, required = false, defaultValue = "false") Boolean ascending,
+			@RequestParam(value = ServiceConstants.PAGINATION_LIMIT_PARAM, required = false, defaultValue = ServiceConstants.DEFAULT_PAGINATION_LIMIT_PARAM) Long limit,
+			@RequestParam(value = ServiceConstants.PAGINATION_OFFSET_PARAM, required = false, defaultValue = ServiceConstants.DEFAULT_PAGINATION_OFFSET_PARAM) Long offset
+			) {
+		DockerCommitSortBy sortBy = sortByParam==null ?
+				DockerCommitSortBy.CREATED_ON : DockerCommitSortBy.valueOf(sortByParam);
+		return serviceProvider.getDockerService().listDockerTags(userId, entityId,
+				sortBy, ascending, limit, offset);
+	}
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/DockerService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/DockerService.java
@@ -39,7 +39,7 @@ public interface DockerService {
 	 * @param offset
 	 * @return
 	 */
-	public PaginatedResults<DockerCommit> listDockerCommits(Long userId, 
+	public PaginatedResults<DockerCommit> listDockerTags(Long userId,
 			String entityId, DockerCommitSortBy sortBy, boolean ascending, long limit, long offset);
 	
 	

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/DockerServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/DockerServiceImpl.java
@@ -43,10 +43,10 @@ public class DockerServiceImpl implements DockerService {
 	}
 
 	@Override
-	public PaginatedResults<DockerCommit> listDockerCommits(Long userId, 
+	public PaginatedResults<DockerCommit> listDockerTags(Long userId,
 			String entityId, DockerCommitSortBy sortBy, boolean ascending, long limit, long offset) {
 				UserInfo userInfo = userManager.getUserInfo(userId);
-		return dockerManager.listDockerCommits(userInfo, entityId, sortBy, ascending, limit, offset);
+		return dockerManager.listDockerTags(userInfo, entityId, sortBy, ascending, limit, offset);
 	}
 	
 	public void log(Exception e) {


### PR DESCRIPTION
This PR deprecates (but maintains functionality of) GET /entity/{id}/dockerCommit in favor of the identical-in-functionality but more-appropriately-named GET /entity/{id}/dockerTag

The old dockerCommit endpoint should be removed after the web client is configured to use dockerTag (the web client is the only user of the endpoint, per warehouse records)