### PR TITLE
PLFM-4876 attempt 2

### DIFF
--- a/lib/lib-shared-models/src/main/java/org/sagebionetworks/repo/model/util/ModelConstants.java
+++ b/lib/lib-shared-models/src/main/java/org/sagebionetworks/repo/model/util/ModelConstants.java
@@ -34,7 +34,7 @@ public class ModelConstants {
 					CHANGE_PERMISSIONS, UPDATE, DELETE, DELETE_SUBMISSION));
 
 	// Maximum permissions that may be granted to the public/anonymous user on evaluations
-	public static final Set<ACCESS_TYPE> EVALUATION_ANONYMOUS_MAXIMUM_ACCESS_PERMISSIONS = new HashSet<ACCESS_TYPE>(
+	public static final Set<ACCESS_TYPE> EVALUATION_PUBLIC_MAXIMUM_ACCESS_PERMISSIONS = new HashSet<ACCESS_TYPE>(
 			Collections.singletonList(READ));
 
 	public static final Set<ACCESS_TYPE> TEAM_ADMIN_PERMISSIONS = new HashSet<ACCESS_TYPE>(

--- a/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManagerImpl.java
@@ -101,7 +101,7 @@ public class EvaluationPermissionsManagerImpl implements EvaluationPermissionsMa
 		final Long evalOwnerId = KeyFactory.stringToKey(eval.getOwnerId());
 		PermissionsManagerUtils.validateACLContent(acl, userInfo, evalOwnerId);
 
-		validateAnonymousPermissions(acl.getResourceAccess());
+		validatePublicPermissions(acl.getResourceAccess());
 
 		aclDAO.update(acl, ObjectType.EVALUATION);
 		return aclDAO.get(evalId, ObjectType.EVALUATION);
@@ -182,7 +182,7 @@ public class EvaluationPermissionsManagerImpl implements EvaluationPermissionsMa
 		permission.setOwnerPrincipalId(KeyFactory.stringToKey(eval.getOwnerId()));
 
 		// Public read
-		UserInfo anonymousUser = userManager.getUserInfo(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId());
+		UserInfo anonymousUser = userManager.getUserInfo(BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId());
 		permission.setCanPublicRead(hasAccess(anonymousUser, evalId, READ).getAuthorized());
 
 		// Other permissions
@@ -199,14 +199,14 @@ public class EvaluationPermissionsManagerImpl implements EvaluationPermissionsMa
 	}
 
 	/*
-	 * Ensures that Anonymous users are not given more permissions than they should be allowed
+	 * Ensures that Public users are not given more permissions than they should be allowed
 	 */
-	private static void validateAnonymousPermissions(Set<ResourceAccess> resourceAccess) {
+	private static void validatePublicPermissions(Set<ResourceAccess> resourceAccess) {
 		for (ResourceAccess ra : resourceAccess) {
-			if (ra.getPrincipalId().equals(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId())) {
-				Set<ACCESS_TYPE> anonymousGrantCopy = new HashSet<>(ra.getAccessType());
-				anonymousGrantCopy.removeAll(ModelConstants.EVALUATION_ANONYMOUS_MAXIMUM_ACCESS_PERMISSIONS);
-				if (!anonymousGrantCopy.isEmpty()) {
+			if (ra.getPrincipalId().equals(BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId())) {
+				Set<ACCESS_TYPE> publicGrantCopy = new HashSet<>(ra.getAccessType());
+				publicGrantCopy.removeAll(ModelConstants.EVALUATION_PUBLIC_MAXIMUM_ACCESS_PERMISSIONS);
+				if (!publicGrantCopy.isEmpty()) {
 					throw new IllegalArgumentException("Anonymous users may only have read access.");
 				}
 			}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManagerImplAutowiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/evaluation/manager/EvaluationPermissionsManagerImplAutowiredTest.java
@@ -62,7 +62,7 @@ public class EvaluationPermissionsManagerImplAutowiredTest {
 
 	private UserInfo adminUserInfo;
 	private UserInfo userInfo;
-	private UserInfo anonymousUserInfo;
+	private UserInfo publicUserInfo;
 
 	private List<String> aclsToDelete;
 	private List<String> evalsToDelete;
@@ -75,7 +75,7 @@ public class EvaluationPermissionsManagerImplAutowiredTest {
 		user.setUserName(UUID.randomUUID().toString());
 		userInfo = userManager.getUserInfo(userManager.createUser(user));
 		userInfo.getGroups().add(BOOTSTRAP_PRINCIPAL.CERTIFIED_USERS.getPrincipalId());
-		anonymousUserInfo = userManager.getUserInfo(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId());
+		publicUserInfo = userManager.getUserInfo(BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId());
 		adminUserInfo = userManager.getUserInfo(BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId());
 
 		aclsToDelete = new ArrayList<String>();
@@ -490,8 +490,8 @@ public class EvaluationPermissionsManagerImplAutowiredTest {
 	}
 
 	@Test
-	public void anonymousUserGrantAndRevokeRead() throws Exception {
-		String nodeName = "EvaluationPermissionsManagerImplAutowiredTest.anonymousUserCanBeGrantedRead";
+	public void publicUserGrantAndRevokeRead() throws Exception {
+		String nodeName = "EvaluationPermissionsManagerImplAutowiredTest.publicUserGrantAndRevokeRead";
 		String nodeId = createNode(nodeName, EntityType.project, adminUserInfo);
 		String evalName = nodeName;
 		String evalId = createEval(evalName, nodeId, adminUserInfo);
@@ -507,7 +507,7 @@ public class EvaluationPermissionsManagerImplAutowiredTest {
 		evaluationPermissionsManager.updateAcl(adminUserInfo, acl);
 
 		// Call under test (granted READ)
-		assertTrue(evaluationPermissionsManager.hasAccess(anonymousUserInfo, evalId, ACCESS_TYPE.READ).getAuthorized());
+		assertTrue(evaluationPermissionsManager.hasAccess(publicUserInfo, evalId, ACCESS_TYPE.READ).getAuthorized());
 
 		acl = evaluationPermissionsManager.getAcl(adminUserInfo, evalId);
 		raSet = new HashSet<>();
@@ -515,12 +515,12 @@ public class EvaluationPermissionsManagerImplAutowiredTest {
 		evaluationPermissionsManager.updateAcl(adminUserInfo, acl);
 
 		// Call under test (revoked READ)
-		assertFalse(evaluationPermissionsManager.hasAccess(anonymousUserInfo, evalId, ACCESS_TYPE.READ).getAuthorized());
+		assertFalse(evaluationPermissionsManager.hasAccess(publicUserInfo, evalId, ACCESS_TYPE.READ).getAuthorized());
 	}
 
 	@Test
-	public void anonymousUserCannotBeGrantedNonRead() throws Exception {
-		String nodeName = "EvaluationPermissionsManagerImplAutowiredTest.anonymousUserCanBeGrantedRead";
+	public void publicUserCannotBeGrantedNonRead() throws Exception {
+		String nodeName = "EvaluationPermissionsManagerImplAutowiredTest.publicUserCannotBeGrantedNonRead";
 		String nodeId = createNode(nodeName, EntityType.project, adminUserInfo);
 		String evalName = nodeName;
 		String evalId = createEval(evalName, nodeId, adminUserInfo);
@@ -531,7 +531,7 @@ public class EvaluationPermissionsManagerImplAutowiredTest {
 				AccessControlList acl = evaluationPermissionsManager.getAcl(adminUserInfo, evalId);
 				Set<ResourceAccess> raSet = new HashSet<>();
 				ResourceAccess ra = new ResourceAccess();
-				ra.setPrincipalId(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId());
+				ra.setPrincipalId(BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId());
 				ra.setAccessType(Collections.singleton(type));
 				raSet.add(ra);
 				acl.setResourceAccess(raSet);


### PR DESCRIPTION
restrict public users on evaluations, not anonymous. the previous PR incorrectly restricted anonymous, which is already unable to access evaluations.