### PR TITLE
PLFM-5617: Send reset password email to the alias address

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManager.java
@@ -105,15 +105,6 @@ public interface MessageManager {
 	public void deleteMessage(UserInfo userInfo, String messageId);
 	
 	/**
-	 * Sends a password reset email based on a template via Amazon SES, using as destination the default
-	 * notification email of the user identified by the given reset token
-	 * 
-	 * @param passwordResetPrefix The url prefix for the verification callback in the portal
-	 * @param passwordResetToken  The reset token generated for the user that needs the password reset
-	 */
-	public void sendNewPasswordResetEmail(String passwordResetPrefix, PasswordResetSignedToken passwordResetToken);
-
-	/**
 	 * Sends a password reset email based on a template via Amazon SES, using as potential destination
 	 * the email defined by the given alias if of type {@link AliasType#USER_EMAIL}, otherwise falling
 	 * back to the default notification email for the user identified by the given alias.

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManager.java
@@ -12,8 +12,9 @@ import org.sagebionetworks.repo.model.message.MessageSortBy;
 import org.sagebionetworks.repo.model.message.MessageStatus;
 import org.sagebionetworks.repo.model.message.MessageStatusType;
 import org.sagebionetworks.repo.model.message.MessageToUser;
+import org.sagebionetworks.repo.model.principal.AliasType;
+import org.sagebionetworks.repo.model.principal.PrincipalAlias;
 import org.sagebionetworks.repo.web.NotFoundException;
-import sun.security.util.Password;
 
 public interface MessageManager {
 	
@@ -102,11 +103,30 @@ public interface MessageManager {
 	 * Deletes a message, only accessible to admins
 	 */
 	public void deleteMessage(UserInfo userInfo, String messageId);
+	
+	/**
+	 * Sends a password reset email based on a template via Amazon SES, using as destination the default
+	 * notification email of the user identified by the given reset token
+	 * 
+	 * @param passwordResetPrefix The url prefix for the verification callback in the portal
+	 * @param passwordResetToken  The reset token generated for the user that needs the password reset
+	 */
+	public void sendNewPasswordResetEmail(String passwordResetPrefix, PasswordResetSignedToken passwordResetToken);
 
 	/**
-	 * Sends a password reset email based on a template via Amazon SES
+	 * Sends a password reset email based on a template via Amazon SES, using as potential destination
+	 * the email defined by the given alias if of type {@link AliasType#USER_EMAIL}, otherwise falling
+	 * back to the default notification email for the user identified by the given alias.
+	 * 
+	 * @param passwordResetPrefix The url prefix for the verification callback in the portal
+	 * @param passwordResetToken  The reset token generated for the user that needs the password reset
+	 * @param alias               The alias to use as the destination, if the alias is not of type
+	 *                            {@link AliasType#USER_EMAIL} falls back to the default notification
+	 *                            email of the user that owns the given alias. The principal id in the
+	 *                            alias must match the user id of the signed token
 	 */
-	public void sendNewPasswordResetEmail(String passwordResetPrefix, PasswordResetSignedToken passwordResetToken) throws NotFoundException;
+	public void sendNewPasswordResetEmail(String passwordResetPrefix, PasswordResetSignedToken passwordResetToken,
+			PrincipalAlias alias) throws NotFoundException;
 
 	/**
 	 * Send an email confirming to user that their password has been changed

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
@@ -732,18 +732,18 @@ public class MessageManagerImpl implements MessageManager {
 		sesClient.sendRawEmail(sendEmailRequest);
 	}
 	
-	private String getEmailForAlias(PrincipalAlias alias) throws NotFoundException {
+	String getEmailForAlias(PrincipalAlias alias) throws NotFoundException {
 		if (AliasType.USER_EMAIL.equals(alias.getType())) {
 			return alias.getAlias();
 		}
 		return getEmailForUser(alias.getPrincipalId());
 	}
 	
-	private String getEmailForUser(Long principalId) throws NotFoundException {
+	String getEmailForUser(Long principalId) throws NotFoundException {
 		return notificationEmailDao.getNotificationEmailForPrincipal(principalId);
 	}
 	
-	private static String getPasswordResetUrl(String passwordResetUrlPrefix, PasswordResetSignedToken passwordResetToken) {
+	String getPasswordResetUrl(String passwordResetUrlPrefix, PasswordResetSignedToken passwordResetToken) {
 		String resetUrl = passwordResetUrlPrefix + SerializationUtils.serializeAndHexEncode(passwordResetToken);
 		EmailUtils.validateSynapsePortalHost(resetUrl);
 		return resetUrl;

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
@@ -47,6 +47,8 @@ import org.sagebionetworks.repo.model.message.MessageStatusType;
 import org.sagebionetworks.repo.model.message.MessageToUser;
 import org.sagebionetworks.repo.model.message.MessageToUserUtils;
 import org.sagebionetworks.repo.model.message.Settings;
+import org.sagebionetworks.repo.model.principal.AliasType;
+import org.sagebionetworks.repo.model.principal.PrincipalAlias;
 import org.sagebionetworks.repo.model.principal.PrincipalAliasDAO;
 import org.sagebionetworks.repo.transactions.WriteTransaction;
 import org.sagebionetworks.repo.web.NotFoundException;
@@ -59,7 +61,7 @@ import com.google.common.collect.Lists;
 
 
 public class MessageManagerImpl implements MessageManager {
-	
+
 	static private Logger log = LogManager.getLogger(MessageManagerImpl.class);
 	
 	/**
@@ -78,6 +80,17 @@ public class MessageManagerImpl implements MessageManager {
 	 * The maximum number of targets of a message
 	 */
 	protected static final long MAX_NUMBER_OF_RECIPIENTS = 50L;
+	
+	// Message templates
+	private static final String MESSAGE_TEMPLATE_PASSWORD_CHANGE_CONFIRMATION = "message/PasswordChangeConfirmationTemplate.txt";
+
+	private static final String MESSAGE_TEMPLATE_WELCOME = "message/WelcomeTemplate.txt";
+
+	private static final String MESSAGE_TEMPLATE_DELIVERY_FAILURE = "message/DeliveryFailureTemplate.txt";
+
+	private static final String MESSAGE_TEMPLATE_PASSWORD_RESET = "message/PasswordResetTemplate.txt";
+
+	private static final String MESSAGE_VALUE_ORIGIN_CLIENT = "Synapse";
 	
 	@Autowired
 	private MessageDAO messageDAO;
@@ -594,44 +607,39 @@ public class MessageManagerImpl implements MessageManager {
 		
 		messageDAO.deleteMessage(messageId);
 	}
-
-
+	
 	@Override
 	@WriteTransaction
-	public void sendNewPasswordResetEmail(String passwordResetUrlPrefix, PasswordResetSignedToken passwordResetToken){
+	public void sendNewPasswordResetEmail(String passwordResetUrlPrefix, PasswordResetSignedToken passwordResetToken) {
 		ValidateArgument.required(passwordResetToken, "passwordResetToken");
 		ValidateArgument.required(passwordResetUrlPrefix, "passwordResetPrefix");
 
-		String webLink = passwordResetUrlPrefix + SerializationUtils.serializeAndHexEncode(passwordResetToken);
-		EmailUtils.validateSynapsePortalHost(webLink);
+		long userId = Long.parseLong(passwordResetToken.getUserId());
+
+		String resetUrl = getPasswordResetUrl(passwordResetUrlPrefix, passwordResetToken);
+		String email = getEmailForUser(userId);
+
+		sendNewPasswordResetEmail(resetUrl, userId, email);
+	}
+
+	@Override
+	@WriteTransaction
+	public void sendNewPasswordResetEmail(String passwordResetUrlPrefix, PasswordResetSignedToken passwordResetToken,
+			PrincipalAlias alias) {
+		ValidateArgument.required(passwordResetToken, "passwordResetToken");
+		ValidateArgument.required(passwordResetUrlPrefix, "passwordResetPrefix");
+		ValidateArgument.required(alias, "alias");
 
 		long userId = Long.parseLong(passwordResetToken.getUserId());
 
+		ValidateArgument.requirement(alias.getPrincipalId().equals(userId),
+				String.format("The id of the alias principal must match the token user id: %d (Expected: %d)",
+						alias.getPrincipalId(), userId));
 
-		String subject = "Reset Synapse Password";
-		Map<String,String> fieldValues = new HashMap<String,String>();
+		String resetUrl = getPasswordResetUrl(passwordResetUrlPrefix, passwordResetToken);
+		String email = getEmailForAlias(alias);
 
-		String alias = principalAliasDAO.getUserName(userId);
-		UserProfile userProfile = userProfileManager.getUserProfile(Long.toString(userId));
-		String displayName = EmailUtils.getDisplayName(userProfile);
-
-		fieldValues.put(EmailUtils.TEMPLATE_KEY_ORIGIN_CLIENT, "Synapse");
-		fieldValues.put(EmailUtils.TEMPLATE_KEY_DISPLAY_NAME, displayName);
-		fieldValues.put(EmailUtils.TEMPLATE_KEY_USERNAME, alias);
-		fieldValues.put(EmailUtils.TEMPLATE_KEY_WEB_LINK, webLink);
-
-		String messageBody = EmailUtils.readMailTemplate("message/PasswordResetTemplate.txt", fieldValues);
-		String email = getEmailForUser(userId);
-		SendRawEmailRequest sendEmailRequest = new SendRawEmailRequestBuilder()
-				.withRecipientEmail(email)
-				.withSubject(subject)
-				.withBody(messageBody, BodyType.PLAIN_TEXT)
-				.withSenderUserName(alias)
-				.withSenderDisplayName(displayName)
-				.withUserId(Long.toString(userId))
-				.withIsNotificationMessage(true)
-				.build();
-		sesClient.sendRawEmail(sendEmailRequest);
+		sendNewPasswordResetEmail(resetUrl, userId, email);
 	}
 
 	@Override
@@ -643,11 +651,11 @@ public class MessageManagerImpl implements MessageManager {
 		UserProfile userProfile = userProfileManager.getUserProfile(Long.toString(userId));
 		String displayName = EmailUtils.getDisplayName(userProfile);
 
-		fieldValues.put(EmailUtils.TEMPLATE_KEY_ORIGIN_CLIENT, "Synapse");
+		fieldValues.put(EmailUtils.TEMPLATE_KEY_ORIGIN_CLIENT, MESSAGE_VALUE_ORIGIN_CLIENT);
 		fieldValues.put(EmailUtils.TEMPLATE_KEY_DISPLAY_NAME, displayName);
 		fieldValues.put(EmailUtils.TEMPLATE_KEY_USERNAME, alias);
 
-		String messageBody = EmailUtils.readMailTemplate("message/PasswordChangeConfirmationTemplate.txt", fieldValues);
+		String messageBody = EmailUtils.readMailTemplate(MESSAGE_TEMPLATE_PASSWORD_CHANGE_CONFIRMATION, fieldValues);
 		String email = getEmailForUser(userId);
 		SendRawEmailRequest sendEmailRequest = new SendRawEmailRequestBuilder()
 				.withRecipientEmail(email)
@@ -666,13 +674,13 @@ public class MessageManagerImpl implements MessageManager {
 	public void sendWelcomeEmail(Long recipientId, String notificationUnsubscribeEndpoint) throws NotFoundException {
 		String subject = "Welcome to Synapse!";
 		Map<String,String> fieldValues = new HashMap<String,String>();
-		fieldValues.put(EmailUtils.TEMPLATE_KEY_ORIGIN_CLIENT, "Synapse");
+		fieldValues.put(EmailUtils.TEMPLATE_KEY_ORIGIN_CLIENT, MESSAGE_VALUE_ORIGIN_CLIENT);
 		
 		String alias = principalAliasDAO.getUserName(recipientId);
 		fieldValues.put(EmailUtils.TEMPLATE_KEY_DISPLAY_NAME, alias);
 		
 		fieldValues.put(EmailUtils.TEMPLATE_KEY_USERNAME, alias);
-		String messageBody = EmailUtils.readMailTemplate("message/WelcomeTemplate.txt", fieldValues);
+		String messageBody = EmailUtils.readMailTemplate(MESSAGE_TEMPLATE_WELCOME, fieldValues);
 		String email = getEmailForUser(recipientId);
 		SendRawEmailRequest sendEmailRequest = new SendRawEmailRequestBuilder()
 				.withRecipientEmail(email)
@@ -701,7 +709,7 @@ public class MessageManagerImpl implements MessageManager {
 		fieldValues.put(EmailUtils.TEMPLATE_KEY_MESSAGE_SUBJECT, dto.getSubject());
 		fieldValues.put(EmailUtils.TEMPLATE_KEY_DETAILS, "- " + StringUtils.join(errors, "\n- "));
 		String email = getEmailForUser(senderId);
-		String messageBody = EmailUtils.readMailTemplate("message/DeliveryFailureTemplate.txt", fieldValues);
+		String messageBody = EmailUtils.readMailTemplate(MESSAGE_TEMPLATE_DELIVERY_FAILURE, fieldValues);
 		
 		SendRawEmailRequest sendEmailRequest = new SendRawEmailRequestBuilder()
 				.withRecipientEmail(email)
@@ -714,9 +722,51 @@ public class MessageManagerImpl implements MessageManager {
 		sesClient.sendRawEmail(sendEmailRequest);
 	}
 	
-	
+	private String getEmailForAlias(PrincipalAlias alias) throws NotFoundException {
+		if (AliasType.USER_EMAIL.equals(alias.getType())) {
+			return alias.getAlias();
+		}
+		return getEmailForUser(alias.getPrincipalId());
+	}
+
 	private String getEmailForUser(Long principalId) throws NotFoundException {
 		return notificationEmailDao.getNotificationEmailForPrincipal(principalId);
+	}
+
+	private void sendNewPasswordResetEmail(String resetUrl, long userId, String email) {
+
+		String subject = "Reset Synapse Password";
+		Map<String, String> fieldValues = new HashMap<String, String>();
+
+		String username = principalAliasDAO.getUserName(userId);
+		UserProfile userProfile = userProfileManager.getUserProfile(Long.toString(userId));
+		String displayName = EmailUtils.getDisplayName(userProfile);
+
+		fieldValues.put(EmailUtils.TEMPLATE_KEY_ORIGIN_CLIENT, MESSAGE_VALUE_ORIGIN_CLIENT);
+		fieldValues.put(EmailUtils.TEMPLATE_KEY_DISPLAY_NAME, displayName);
+		fieldValues.put(EmailUtils.TEMPLATE_KEY_USERNAME, username);
+		fieldValues.put(EmailUtils.TEMPLATE_KEY_WEB_LINK, resetUrl);
+
+		String messageBody = EmailUtils.readMailTemplate(MESSAGE_TEMPLATE_PASSWORD_RESET, fieldValues);
+
+		SendRawEmailRequest sendEmailRequest = new SendRawEmailRequestBuilder()
+				.withRecipientEmail(email)
+				.withSubject(subject)
+				.withBody(messageBody, BodyType.PLAIN_TEXT)
+				.withSenderUserName(username)
+				.withSenderDisplayName(displayName)
+				.withUserId(Long.toString(userId))
+				.withIsNotificationMessage(true)
+				.build();
+
+		sesClient.sendRawEmail(sendEmailRequest);
+	}
+
+	private static String getPasswordResetUrl(String passwordResetUrlPrefix,
+			PasswordResetSignedToken passwordResetToken) {
+		String resetUrl = passwordResetUrlPrefix + SerializationUtils.serializeAndHexEncode(passwordResetToken);
+		EmailUtils.validateSynapsePortalHost(resetUrl);
+		return resetUrl;
 	}
 
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/MessageManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/MessageManagerImplUnitTest.java
@@ -102,6 +102,8 @@ public class MessageManagerImplUnitTest {
 	private static final String UNSUBSCRIBE_ENDPOINT = "https://www.synapse.org/#unsub:";
 	private static final String PROFILE_SETTING_ENDPOINT = "https://www.synapse.org/#profile:edit";
 	private UserInfo creatorUserInfo = null;
+	private PrincipalAlias recipientUsernameAlias = null;
+	private PrincipalAlias recipientEmailAlias = null;
 	
 	@Before
 	public void setUp() throws Exception {
@@ -128,6 +130,16 @@ public class MessageManagerImplUnitTest {
 		creatorUserInfo = new UserInfo(false);
 		creatorUserInfo.setId(CREATOR_ID);
 		creatorUserInfo.setGroups(Collections.singleton(CREATOR_ID));
+		
+		recipientUsernameAlias = new PrincipalAlias();
+		recipientUsernameAlias.setAlias("bar");
+		recipientUsernameAlias.setPrincipalId(RECIPIENT_ID);
+		recipientUsernameAlias.setType(AliasType.USER_NAME);
+		
+		recipientEmailAlias = new PrincipalAlias();
+		recipientEmailAlias.setAlias(RECIPIENT_EMAIL_ALIAS);
+		recipientEmailAlias.setPrincipalId(RECIPIENT_ID);
+		recipientEmailAlias.setType(AliasType.USER_EMAIL);
 		
 		when(userManager.getUserInfo(CREATOR_ID)).thenReturn(creatorUserInfo);
 		
@@ -386,7 +398,7 @@ public class MessageManagerImplUnitTest {
 
 		String synapsePrefix = "https://synapse.org/";
 
-		messageManager.sendNewPasswordResetEmail(synapsePrefix, token);
+		messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientUsernameAlias);
 		
 		ArgumentCaptor<SendRawEmailRequest> argument = ArgumentCaptor.forClass(SendRawEmailRequest.class);
 		verify(sesClient).sendRawEmail(argument.capture());
@@ -406,11 +418,6 @@ public class MessageManagerImplUnitTest {
 		token.setUserId(Long.toString(RECIPIENT_ID));
 
 		String synapsePrefix = "https://synapse.org/";
-
-		PrincipalAlias recipientEmailAlias = new PrincipalAlias();
-		recipientEmailAlias.setAlias(RECIPIENT_EMAIL_ALIAS);
-		recipientEmailAlias.setPrincipalId(RECIPIENT_ID);
-		recipientEmailAlias.setType(AliasType.USER_EMAIL);
 
 		messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientEmailAlias);
 
@@ -448,9 +455,8 @@ public class MessageManagerImplUnitTest {
 		token.setUserId(Long.toString(RECIPIENT_ID));
 		String synapsePrefix = "https://NOTsynapse.org/";
 
-		messageManager.sendNewPasswordResetEmail(synapsePrefix, token);
+		messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientUsernameAlias);
 	}
-
 
 	@Test
 	public void testSendPasswordChangeConfirmationEmail() throws Exception{

--- a/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/AuthenticationController.java
@@ -2,16 +2,12 @@ package org.sagebionetworks.auth;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.sagebionetworks.auth.services.AuthenticationService;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.auth.ChangePasswordInterface;
-import org.sagebionetworks.repo.model.auth.ChangePasswordRequest;
 import org.sagebionetworks.repo.model.auth.LoginCredentials;
 import org.sagebionetworks.repo.model.auth.LoginRequest;
 import org.sagebionetworks.repo.model.auth.LoginResponse;
-import org.sagebionetworks.repo.model.auth.NewUser;
 import org.sagebionetworks.repo.model.auth.SecretKey;
 import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.repo.model.auth.Username;
@@ -58,8 +54,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @Controller
 @RequestMapping(UrlHelpers.AUTH_PATH)
 public class AuthenticationController {
-
-	private static Log log = LogFactory.getLog(AuthenticationController.class);
 
 	@Autowired
 	private AuthenticationService authenticationService;
@@ -118,7 +112,6 @@ public class AuthenticationController {
 	/**
 	 * Sends an email for resetting a user's password. <br/>
 	 * @param passwordResetEndpoint the Portal's url prefix for handling password resets.
-	 * @throws NotFoundException
 	 */
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@RequestMapping(value = UrlHelpers.AUTH_USER_PASSWORD_RESET, method = RequestMethod.POST)

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationService.java
@@ -3,10 +3,8 @@ package org.sagebionetworks.auth.services;
 import org.sagebionetworks.repo.model.TermsOfUseException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.auth.ChangePasswordInterface;
-import org.sagebionetworks.repo.model.auth.ChangePasswordRequest;
 import org.sagebionetworks.repo.model.auth.LoginRequest;
 import org.sagebionetworks.repo.model.auth.LoginResponse;
-import org.sagebionetworks.repo.model.auth.NewUser;
 import org.sagebionetworks.repo.model.auth.Session;
 import org.sagebionetworks.repo.model.oauth.OAuthAccountCreationRequest;
 import org.sagebionetworks.repo.model.oauth.OAuthProvider;
@@ -76,9 +74,10 @@ public interface AuthenticationService {
 	public boolean hasUserAcceptedTermsOfUse(Long userId) throws NotFoundException;
 
 	/**
-	 * Sends a password reset email to the user
-	 * @param email
-	 * @throws NotFoundException
+	 * Sends a password reset email to the user identified by the given alias (username or email)
+	 * 
+	 * @param passwordResetUrlPrefix The url prefix for the verification callback in the portal
+	 * @param usernameOrEmail An alias identifier for the user, might be a username or email
 	 */
 	public void sendPasswordResetEmail(String passwordResetUrlPrefix, String usernameOrEmail);
 

--- a/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/services/AuthenticationServiceImpl.java
@@ -1,17 +1,14 @@
 package org.sagebionetworks.auth.services;
 
 import org.sagebionetworks.repo.manager.AuthenticationManager;
-import org.sagebionetworks.repo.manager.EmailUtils;
 import org.sagebionetworks.repo.manager.MessageManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.oauth.AliasAndType;
 import org.sagebionetworks.repo.manager.oauth.OAuthManager;
 import org.sagebionetworks.repo.model.AuthorizationUtils;
-import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.ChangePasswordInterface;
-import org.sagebionetworks.repo.model.auth.ChangePasswordRequest;
 import org.sagebionetworks.repo.model.auth.LoginRequest;
 import org.sagebionetworks.repo.model.auth.LoginResponse;
 import org.sagebionetworks.repo.model.auth.NewUser;
@@ -27,7 +24,6 @@ import org.sagebionetworks.repo.model.principal.AliasType;
 import org.sagebionetworks.repo.model.principal.PrincipalAlias;
 import org.sagebionetworks.repo.transactions.WriteTransaction;
 import org.sagebionetworks.repo.web.NotFoundException;
-import org.sagebionetworks.util.SerializationUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class AuthenticationServiceImpl implements AuthenticationService {
@@ -113,13 +109,13 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 	}
 
 	@Override
-	public void sendPasswordResetEmail(String passwordResetUrlPrefix, String email) {
+	public void sendPasswordResetEmail(String passwordResetUrlPrefix, String usernameOrEmail) {
 		try {
-			PrincipalAlias pa = userManager.lookupUserByUsernameOrEmail(email);
-			PasswordResetSignedToken passwordRestToken = authManager.createPasswordResetToken(pa.getPrincipalId());
-			messageManager.sendNewPasswordResetEmail(passwordResetUrlPrefix, passwordRestToken);
-		}catch (NotFoundException e){
-			//should not indicate that a email/user could not be found
+			PrincipalAlias principalAlias = userManager.lookupUserByUsernameOrEmail(usernameOrEmail);
+			PasswordResetSignedToken passwordRestToken = authManager.createPasswordResetToken(principalAlias.getPrincipalId());
+			messageManager.sendNewPasswordResetEmail(passwordResetUrlPrefix, passwordRestToken, principalAlias);
+		} catch (NotFoundException e) {
+			// should not indicate that a email/user could not be found
 		}
 	}
 
@@ -193,4 +189,5 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 	public PrincipalAlias lookupUserForAuthentication(String alias) {
 		return userManager.lookupUserByUsernameOrEmail(alias);
 	}
+	
 }


### PR DESCRIPTION
- Added the possibility to specify a PrincipalAlias in the MessageManager
- Added relevant unit and integration tests
- Fixed existing related integration tests to actually check the result