### PR TITLE
PLFM-5913: Async message processing

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/IT501SynapseJavaClientMessagingTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT501SynapseJavaClientMessagingTest.java
@@ -10,6 +10,7 @@ import java.io.PrintWriter;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -50,7 +51,7 @@ public class IT501SynapseJavaClientMessagingTest {
 	private static final Long OFFSET = 0L;
 	private static final String MESSAGE_BODY = "Blah blah blah\n";
 	private static final String MESSAGE_BODY_WITH_EXTENDED_CHARS = "G\u00E9rard Depardieum, Camille Saint-Sa\u00EBns and Myl\u00E8ne Demongeot";
-
+	private static final long MAX_MESSAGE_WAIT = 60 * 1000;
 
 	private static String oneId;
 	private static String twoId;
@@ -107,28 +108,53 @@ public class IT501SynapseJavaClientMessagingTest {
 
 		oneToTwo = new MessageToUser();
 		oneToTwo.setFileHandleId(oneToRuleThemAll.getId());
-		oneToTwo.setRecipients(new HashSet<String>() {
-			{
-				add(twoId);
-			}
-		});
+		oneToTwo.setRecipients(Collections.singleton(twoId));
 		oneToTwo = synapseOne.sendMessage(oneToTwo);
 		cleanup.add(oneToTwo.getId());
+		
+		waitForMessage(synapseTwo, oneToTwo.getId());
 
 		twoToOne = new MessageToUser();
 		twoToOne.setFileHandleId(oneToRuleThemAll.getId());
-		twoToOne.setRecipients(new HashSet<String>() {
-			{
-				add(oneId);
-			}
-		});
+		twoToOne.setRecipients(Collections.singleton(oneId));
 		twoToOne.setInReplyTo(oneToTwo.getId());
 		twoToOne = synapseTwo.sendMessage(twoToOne);
 		cleanup.add(twoToOne.getId());
+		
+		waitForMessage(synapseOne, twoToOne.getId());
 
 		fileHandleIdWithExtendedChars = null;
 	}
 
+	/**
+	 * Wait for the message with the given id to reach the inbox of the given client with an UNREAD status
+	 * 
+	 * @param client
+	 * @param messageId
+	 * @throws Exception
+	 */
+	private void waitForMessage(SynapseClient client, String messageId) throws Exception {
+		long start = System.currentTimeMillis();
+		
+		while (true) {
+			
+			if (System.currentTimeMillis() - start >= MAX_MESSAGE_WAIT) {
+				throw new IllegalStateException("Timed out waiting for message: " + messageId);
+			}
+			
+			System.out.println("Waiting for message (" + messageId + ") to reach inbox...");
+			
+			PaginatedResults<MessageBundle> inbox = client.getInbox(Collections.singletonList(MessageStatusType.UNREAD), MessageSortBy.SEND_DATE, true, LIMIT, OFFSET);
+		
+			if (!inbox.getResults().isEmpty() && inbox.getResults().get(0).getMessage().getId().equals(messageId)) {
+				return;
+			}
+			
+			Thread.sleep(1000);
+			
+		}
+	}
+	
 	@After
 	public void after() throws Exception {
 		for (String id : cleanup) {
@@ -201,6 +227,8 @@ public class IT501SynapseJavaClientMessagingTest {
 		recipients.setRecipients(twoToOne.getRecipients());
 		MessageToUser forwarded = synapseOne.forwardMessage(oneToTwo.getId(), recipients);
 		cleanup.add(forwarded.getId());
+		
+		waitForMessage(synapseOne, forwarded.getId());
 		
 		PaginatedResults<MessageBundle> messages = synapseOne.getInbox(null,
 				null, null, LIMIT, OFFSET);
@@ -310,6 +338,8 @@ public class IT501SynapseJavaClientMessagingTest {
 		twoToOne.setRecipients(null);
 		MessageToUser message = synapseTwo.sendMessage(twoToOne, project.getId());
 		cleanup.add(message.getId());
+		
+		waitForMessage(synapseOne, message.getId());
 		
 		PaginatedResults<MessageBundle> messages = synapseOne.getInbox(null,
 				MessageSortBy.SEND_DATE, true, LIMIT, OFFSET);

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/message/MessageToUser.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/message/MessageToUser.json
@@ -39,7 +39,7 @@
 		},
 		"isNotificationMessage": {
 			"type": "boolean",
-			"description": "is this a notification message?"
+			"description": "A notification message is sent from a noreply email address, delivery failures are not sent back to the sender"
 		},
 		"to": {
 			"type": "string",

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManager.java
@@ -122,7 +122,7 @@ public interface MessageManager {
 	public void sendPasswordChangeConfirmationEmail(long userId);
 	
 	/**
-	 * Sends a delivery failure notification based on a template
+	 * Sends a delivery failure notification based on a template unless the message is a notification message
 	 */
 	public void sendDeliveryFailureEmail(String messageId, List<String> errors) throws NotFoundException;
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManager.java
@@ -31,12 +31,8 @@ public interface MessageManager {
 	public String getMessageFileRedirectURL(UserInfo userInfo, String messageId) throws NotFoundException;
 	
 	/**
-	 * Saves the message so that it can be processed by other queries.
-	 * If the message is going to exactly one recipient, then the message will be sent in this transaction  
-	 * and any failures will be propagated immediately.
-	 * </br> 
-	 * If the message is going to more than one recipient, a worker will asynchronously process the message.
-	 * In case of failure, the user will be notified via bounce message.  
+	 * Saves the message so that it can be processed by other queries. A worker will asynchronously process the message.
+	 * In case of failure, the user will be notified via bounce message.
 	 * </br>
 	 * This method also checks to see if file handles (message body) are accessible.  
 	 */
@@ -131,11 +127,7 @@ public interface MessageManager {
 	public void sendDeliveryFailureEmail(String messageId, List<String> errors) throws NotFoundException;
 
 	/**
-	 * Saves the message so that it can be processed by other queries.
-	 * If the message is going to exactly one recipient, then the message will be sent in this transaction  
-	 * and any failures will be propagated immediately.
-	 * </br> 
-	 * If the message is going to more than one recipient, a worker will asynchronously process the message.
+	 * Saves the message so that it can be processed by other queries. A worker will asynchronously process the message.
 	 * In case of failure, the user will be notified via bounce message.  
 	 * </br>
 	 * This method also handles throttling of message creation 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
@@ -636,6 +636,15 @@ public class MessageManagerImpl implements MessageManager {
 	public void sendDeliveryFailureEmail(String messageId, List<String> errors) throws NotFoundException {
 		// Build the subject and body of the message
 		MessageToUser dto = messageDAO.getMessage(messageId);
+		
+		// Notification messages are special system generated messages that might be sent on behalf of the user
+		// but that the user might not even be aware of, we avoid bouncing back to the user if the notification didn't go
+		// through
+		if (Boolean.TRUE.equals(dto.getIsNotificationMessage())) {
+			LOG.warn("Skipping delivery failure notification for notification message (Message: {}, Errors: {})", messageId, StringUtils.join(errors));
+			return;
+		}
+		
 		Long senderId = Long.parseLong(dto.getCreatedBy());
 		String subject = "Message " + messageId + " Delivery Failure(s)";
 		

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
@@ -23,7 +23,6 @@ import org.sagebionetworks.repo.model.ACLInheritanceException;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
 import org.sagebionetworks.repo.model.AuthorizationUtils;
-import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.GroupMembersDAO;
 import org.sagebionetworks.repo.model.MessageDAO;
 import org.sagebionetworks.repo.model.Node;
@@ -74,15 +73,15 @@ public class MessageManagerImpl implements MessageManager {
 	private static final long MAX_NUMBER_OF_NEW_MESSAGES = 10L;
 	
 	/**
+	 * The maximum number of targets of a message
+	 */
+	protected static final int MAX_NUMBER_OF_RECIPIENTS = 50;
+	
+	/**
 	 * The span of the interval, in milliseconds, in which created messages are counted
 	 * See {@link #MAX_NUMBER_OF_NEW_MESSAGES}  
 	 */
 	private static final long MESSAGE_CREATION_INTERVAL_MILLISECONDS = 60000L;
-	
-	/**
-	 * The maximum number of targets of a message
-	 */
-	protected static final long MAX_NUMBER_OF_RECIPIENTS = 50L;
 	
 	// Message templates
 	private static final String MESSAGE_TEMPLATE_PASSWORD_CHANGE_CONFIRMATION = "message/PasswordChangeConfirmationTemplate.txt";
@@ -246,33 +245,7 @@ public class MessageManagerImpl implements MessageManager {
 			throw new IllegalArgumentException("One or more of the following IDs are not recognized: " + dto.getRecipients());
 		}
 		
-		dto = messageDAO.createMessage(dto);
-		
-		// If the recipient list is only one element long, 
-		// process and send the message in this transaction 
-		if (dto.getRecipients().size() == 1) {
-			UserGroup ug;
-			try {
-				ug = userGroupDAO.get(Long.parseLong(dto.getRecipients().iterator().next()));
-			} catch (NotFoundException e) {
-				throw new DatastoreException("Could not get a user group that satisfied message creation constraints");
-			}
-			
-			// Defer the sending of messages to non-individuals 
-			// since there could be more than one actual recipient after finding the members
-			if (ug.getIsIndividual()) {
-				List<String> errors;
-				try {
-					errors = processMessage(dto.getId(), true, null);
-				} catch (NotFoundException e) {
-					throw new DatastoreException("Could not find a message that was created in the same transaction");
-				}
-				if (errors.size() > 0) {
-					throw new IllegalArgumentException(StringUtils.join(errors, "\n"));
-				}
-			}
-		}
-		return dto;
+		return messageDAO.createMessage(dto);
 	}
 	
 	@Override
@@ -371,21 +344,6 @@ public class MessageManagerImpl implements MessageManager {
 	@Override
 	@WriteTransaction
 	public List<String> processMessage(String messageId, ProgressCallback progressCallback) throws NotFoundException {
-		return processMessage(messageId, false, progressCallback);
-	}
-	
-	/**
-	 * See {@link #processMessage(String)}
-	 * Also used by {@link #createMessage(UserInfo, MessageToUser)}
-	 * 
-	 * @param singleTransaction Should the sending be done in one transaction or one transaction per recipient?
-	 *    This allows the sending of messages during creation to complete without deadlock. 
-	 *    Note: It is crucial to pass in "true" when creating *and* sending a message in the same operation together. 
-	 *      Otherwise the 'sending step' waits forever for the lock obtained by the 'creation step' to be released.
-	 * General usage of this method sets this parameter to false.
-	 * @throws  
-	 */
-	private List<String> processMessage(String messageId, boolean singleTransaction, ProgressCallback progressCallback) throws NotFoundException {
 		MessageToUser dto = messageDAO.getMessage(messageId);
 		FileHandle fileHandle = fileHandleDao.get(dto.getFileHandleId());
 		ContentType contentType = ContentType.parse(fileHandle.getContentType());
@@ -393,23 +351,19 @@ public class MessageManagerImpl implements MessageManager {
 
 		try {
 			String messageBody = fileHandleManager.downloadFileToString(dto.getFileHandleId());
-			return processMessage(dto, singleTransaction, messageBody, mimeType, progressCallback);
+			return processMessage(dto, messageBody, mimeType, progressCallback);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 	}
 	
 	/**
-	 * See {@link #processMessage(String, boolean)}
-	 * Also used by {@link #sendTemplateEmail(String, String, String, boolean)}
+	 * See {@link #processMessage(String, ProgressCallback)}
 	 * 
 	 * @param messageBody The body of any email(s) that get sent as a result of processing this message
 	 *    Note: This parameter is provided so that templated messages do not need to be uploaded then downloaded before sending
 	 */
-	private List<String> processMessage(
-			MessageToUser dto, boolean singleTransaction, 
-			String messageBody, String mimeType,
-			ProgressCallback progressCallback) throws NotFoundException {
+	private List<String> processMessage(MessageToUser dto, String messageBody, String mimeType, ProgressCallback progressCallback) throws NotFoundException {
 		List<String> errors = new ArrayList<String>();
 		
 		// Check to see if the message has already been sent
@@ -439,11 +393,6 @@ public class MessageManagerImpl implements MessageManager {
 		// Get the individual recipients
 		Set<String> recipients = expandRecipientSet(userInfo, dto.getRecipients(), errors);
 		
-		// Make sure the caller set the boolean correctly
-		if (recipients.size() > 1 && singleTransaction) {
-			throw new IllegalArgumentException("A message sent to multiple recipients must be done in separate transactions");
-		}
-		
 		// Now that the recipients list has been expanded, begin processing the message
 		for (String userId : recipients) {
 			// Try to send messages to each user individually
@@ -456,12 +405,8 @@ public class MessageManagerImpl implements MessageManager {
 					settings = new Settings();
 				}
 				MessageStatusType userMessageStatus = null; // setting to null tells the DAO to use the default value
-				// This marks a user as a recipient of the message
-				if (singleTransaction) {
-					messageDAO.createMessageStatus_SameTransaction(dto.getId(), userId, userMessageStatus);
-				} else {
-					messageDAO.createMessageStatus_NewTransaction(dto.getId(), userId, userMessageStatus);
-				}
+				
+				messageDAO.createMessageStatus_NewTransaction(dto.getId(), userId, userMessageStatus);	
 				
 				// Should emails be sent?
 				if (settings.getSendEmailNotifications() == null || settings.getSendEmailNotifications()) {
@@ -509,11 +454,7 @@ public class MessageManagerImpl implements MessageManager {
 					messageStatus.setMessageId(dto.getId());
 					messageStatus.setRecipientId(userId);
 					messageStatus.setStatus(userMessageStatus);
-					if (singleTransaction) {
-						messageDAO.updateMessageStatus_SameTransaction(messageStatus);
-					} else {
-						messageDAO.updateMessageStatus_NewTransaction(messageStatus);
-					}
+					messageDAO.updateMessageStatus_NewTransaction(messageStatus);
 				}
 			} catch (Exception e) {
 				LOG.info("Error caught while processing message", e);

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NotificationManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NotificationManager.java
@@ -5,20 +5,18 @@ import java.util.List;
 import org.sagebionetworks.repo.model.UserInfo;
 
 /**
- * This manager supports sending system generated messages to users.
+ * This manager supports sending system generated messages to users, the messages are sent from a noreply address 
+ * and delivery failures are ignored (e.g. no delivery failure notification is sent back to the original sender).
  * 
  * @author brucehoff
  *
  */
 public interface NotificationManager {
 
-	public static final String TEXT_PLAIN_MIME_TYPE = "text/plain";
-
 	/**
 	 * Send the given list of messages, the generated message will be send as a notification (from a system noreply sender).
 	 * <p/>
-	 * Notifications are sent asynchronously, if the messages could not be delivered a failure notification is sent back to
-	 * the sender.
+	 * Notifications are sent asynchronously, if the messages could not be delivered failure notifications are ignored
 	 * 
 	 * @param userInfo The user requesting the notification to be sent
 	 * @param messages The list of messages to be sent

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NotificationManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NotificationManager.java
@@ -3,8 +3,6 @@ package org.sagebionetworks.repo.manager;
 import java.util.List;
 
 import org.sagebionetworks.repo.model.UserInfo;
-import org.sagebionetworks.repo.model.message.MessageToUser;
-import org.sagebionetworks.repo.web.NotFoundException;
 
 /**
  * This manager supports sending system generated messages to users.
@@ -14,26 +12,17 @@ import org.sagebionetworks.repo.web.NotFoundException;
  */
 public interface NotificationManager {
 
-	/**
-	 * 
-	 * @param userInfo
-	 * @param mtu
-	 * @param message
-	 * @throws NotFoundException
-	 */
-	public void sendNotifications(UserInfo userInfo, List<MessageToUserAndBody> messages) throws NotFoundException;
-	
-	
 	public static final String TEXT_PLAIN_MIME_TYPE = "text/plain";
 
-
 	/**
-	 * Send a single message.
-	 * @param userInfo
-	 * @param message
-	 * @return
+	 * Send the given list of messages, the generated message will be send as a notification (from a system noreply sender).
+	 * <p/>
+	 * Notifications are sent asynchronously, if the messages could not be delivered a failure notification is sent back to
+	 * the sender.
+	 * 
+	 * @param userInfo The user requesting the notification to be sent
+	 * @param messages The list of messages to be sent
 	 */
-	MessageToUser sendNotification(UserInfo userInfo,
-			MessageToUserAndBody message);
+	public void sendNotifications(UserInfo userInfo, List<MessageToUserAndBody> messages);
 
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NotificationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NotificationManagerImpl.java
@@ -7,8 +7,6 @@ import java.util.List;
 import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.file.FileHandle;
-import org.sagebionetworks.repo.model.message.MessageToUser;
-import org.sagebionetworks.repo.web.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class NotificationManagerImpl implements NotificationManager {
@@ -19,37 +17,43 @@ public class NotificationManagerImpl implements NotificationManager {
 	@Autowired
 	private MessageManager messageManager;
 
-	public NotificationManagerImpl() {}
+	public NotificationManagerImpl() {
+	}
 
-	public NotificationManagerImpl(
-			FileHandleManager fileHandleManager, 
-			MessageManager messageManager) {
+	public NotificationManagerImpl(FileHandleManager fileHandleManager, MessageManager messageManager) {
 		this.fileHandleManager = fileHandleManager;
 		this.messageManager = messageManager;
 	}
 
 	@Override
-	public void sendNotifications(UserInfo userInfo, List<MessageToUserAndBody> messages) throws NotFoundException {
+	public void sendNotifications(UserInfo userInfo, List<MessageToUserAndBody> messages) {
 		for (MessageToUserAndBody message : messages) {
 			sendNotification(userInfo, message);
 		}
 	}
-	
-	@Override
-	public MessageToUser sendNotification(UserInfo userInfo, MessageToUserAndBody message){
-		try {
-			if (message.getMetadata().getRecipients().isEmpty()) return null;
-			FileHandle fileHandle = fileHandleManager.createCompressedFileFromString(
-					userInfo.getId().toString(), new Date(), message.getBody(), message.getMimeType());
 
-			message.getMetadata().setFileHandleId(fileHandle.getId());
-			message.getMetadata().setWithUnsubscribeLink(true);
-			message.getMetadata().setIsNotificationMessage(true);
-			message.getMetadata().setWithProfileSettingLink(false);
-			return messageManager.createMessage(userInfo, message.getMetadata());
+	private void sendNotification(UserInfo userInfo, MessageToUserAndBody message) {
+		
+		if (message.getMetadata().getRecipients().isEmpty()) {
+			return;
+		}
+		
+		FileHandle fileHandle;
+		
+		try {
+			fileHandle = fileHandleManager.createCompressedFileFromString(userInfo.getId().toString(), new Date(), message.getBody(),
+					message.getMimeType());
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
+
+		message.getMetadata().setFileHandleId(fileHandle.getId());
+		message.getMetadata().setWithUnsubscribeLink(true);
+		message.getMetadata().setIsNotificationMessage(true);
+		message.getMetadata().setWithProfileSettingLink(false);
+
+		messageManager.createMessage(userInfo, message.getMetadata());
+
 	}
 
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/team/MembershipRequestManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/team/MembershipRequestManagerImpl.java
@@ -122,8 +122,13 @@ public class MembershipRequestManagerImpl implements MembershipRequestManager {
 			String acceptRequestEndpoint, String notificationUnsubscribeEndpoint) {
 		ValidateArgument.required(acceptRequestEndpoint, "acceptRequestEndpoint");
 		ValidateArgument.required(notificationUnsubscribeEndpoint, "notificationUnsubscribeEndpoint");
+		
 		List<MessageToUserAndBody> result = new ArrayList<MessageToUserAndBody>();
-		if (mr.getCreatedOn() == null) mr.setCreatedOn(new Date());
+		
+		if (mr.getCreatedOn() == null) {
+			mr.setCreatedOn(new Date());
+		}
+		
 		UserProfile userProfile = userProfileManager.getUserProfile(mr.getCreatedBy());
 		String displayName = EmailUtils.getDisplayNameWithUsername(userProfile);
 		Map<String,String> fieldValues = new HashMap<String,String>();
@@ -131,6 +136,7 @@ public class MembershipRequestManagerImpl implements MembershipRequestManager {
 		fieldValues.put(TEMPLATE_KEY_USER_ID, mr.getCreatedBy());
 		fieldValues.put(TEMPLATE_KEY_TEAM_NAME, teamDAO.get(mr.getTeamId()).getName());
 		fieldValues.put(TEMPLATE_KEY_TEAM_ID, mr.getTeamId());
+		
 		if (mr.getMessage()==null || mr.getMessage().length()==0) {
 			fieldValues.put(TEMPLATE_KEY_REQUESTER_MESSAGE, "");
 		} else {
@@ -140,16 +146,21 @@ public class MembershipRequestManagerImpl implements MembershipRequestManager {
 		}
 		
 		Set<String> teamAdmins = new HashSet<>(teamDAO.getAdminTeamMemberIds(mr.getTeamId()));
+		
 		for (String recipientPrincipalId : teamAdmins) {
+
 			fieldValues.put(TEMPLATE_KEY_ONE_CLICK_JOIN, EmailUtils.createOneClickJoinTeamLink(
 					acceptRequestEndpoint, recipientPrincipalId, mr.getCreatedBy(), mr.getTeamId(), mr.getCreatedOn(), tokenGenerator));
+
 			String messageContent = EmailUtils.readMailTemplate(TEAM_MEMBERSHIP_REQUEST_CREATED_TEMPLATE, fieldValues);
+			
 			MessageToUser mtu = new MessageToUser();
 			mtu.setRecipients(Collections.singleton(recipientPrincipalId));
 			mtu.setSubject(TEAM_MEMBERSHIP_REQUEST_MESSAGE_SUBJECT);
 			mtu.setNotificationUnsubscribeEndpoint(notificationUnsubscribeEndpoint);
 			result.add(new MessageToUserAndBody(mtu, messageContent, ContentType.TEXT_HTML.getMimeType()));
 		}
+		
 		return result;
 	}
 	

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/team/TeamManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/team/TeamManagerImpl.java
@@ -536,14 +536,17 @@ public class TeamManagerImpl implements TeamManager {
 			String memberDisplayName = EmailUtils.getDisplayNameWithUsername(memberUserProfile);
 			fieldValues.put(TEMPLATE_KEY_DISPLAY_NAME, memberDisplayName);
 			fieldValues.put(TEMPLATE_KEY_USER_ID, memberInfo.getId().toString());
+			
+			String messageContent = EmailUtils.readMailTemplate(USER_HAS_JOINED_TEAM_TEMPLATE, fieldValues);
+			
 			for (String recipient : getInviters(Long.parseLong(teamId), memberInfo.getId())) {
 				MessageToUser mtu = new MessageToUser();
-				mtu.setSubject(JOIN_TEAM_CONFIRMATION_MESSAGE_SUBJECT);
-				String messageContent = EmailUtils.readMailTemplate(USER_HAS_JOINED_TEAM_TEMPLATE, fieldValues);
+				mtu.setSubject(JOIN_TEAM_CONFIRMATION_MESSAGE_SUBJECT);	
 				mtu.setRecipients(Collections.singleton(recipient));
 				mtu.setNotificationUnsubscribeEndpoint(notificationUnsubscribeEndpoint);
 				result.add(new MessageToUserAndBody(mtu, messageContent, ContentType.TEXT_HTML.getMimeType()));
 			}
+			
 		} else {
 			UserProfile joinerUserProfile = userProfileManager.getUserProfile(joinerInfo.getId().toString());
 			String joinerDisplayName = EmailUtils.getDisplayNameWithUsername(joinerUserProfile);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/MessageManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/MessageManagerImplUnitTest.java
@@ -509,6 +509,21 @@ public class MessageManagerImplUnitTest {
 	}
 	
 	@Test
+	public void testSendDeliveryFailureEmailToNotificationMessage() throws Exception {
+		
+		mtu.setIsNotificationMessage(true);
+		
+		when(messageDAO.getMessage(MESSAGE_ID)).thenReturn(mtu);
+		
+		List<String> errors = new ArrayList<String>();
+		
+		// Call under test
+		messageManager.sendDeliveryFailureEmail(MESSAGE_ID, errors);
+		
+		verifyZeroInteractions(sesClient);
+	}
+	
+	@Test
 	public void testSendDeliveryFailureEmailWithQuarantinedAddress() throws Exception {
 		when(principalAliasDAO.getUserName(CREATOR_ID)).thenReturn("foo");
 		when(notificationEmailDao.getNotificationEmailForPrincipal(CREATOR_ID)).thenReturn(CREATOR_EMAIL);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/NotificationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/NotificationManagerImplTest.java
@@ -1,8 +1,8 @@
 package org.sagebionetworks.repo.manager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -15,29 +15,29 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.file.S3FileHandle;
 import org.sagebionetworks.repo.model.message.MessageToUser;
 
+@ExtendWith(MockitoExtension.class)
 public class NotificationManagerImplTest {
 
+	@Mock
 	private FileHandleManager fileHandleManager;
+	@Mock
 	private MessageManager messageManager;
-	private NotificationManager notificationManager;
+	
+	@InjectMocks
+	private NotificationManagerImpl notificationManager;
 	
 	private static final Long USER_ID = 101L;
-
-	@Before
-	public void setUp() throws Exception {
-		fileHandleManager = Mockito.mock(FileHandleManager.class);
-		messageManager = Mockito.mock(MessageManager.class);
-		notificationManager = new NotificationManagerImpl(fileHandleManager, messageManager);
-	}
 
 	@Test
 	public void testSendNotification() throws Exception {
@@ -56,11 +56,15 @@ public class NotificationManagerImplTest {
 		MessageToUser mtu = new MessageToUser();
 		mtu.setRecipients(to);
 		mtu.setSubject(subject);
+		
+		// Call under test
 		notificationManager.sendNotifications(userInfo, Collections.singletonList(new MessageToUserAndBody(mtu, message, "text/plain")));
+		
 		verify(fileHandleManager).createCompressedFileFromString(eq(USER_ID.toString()), any(Date.class), anyString(), eq("text/plain"));
-		ArgumentCaptor<MessageToUser> mtuCaptor =
-				ArgumentCaptor.forClass(MessageToUser.class);
+		
+		ArgumentCaptor<MessageToUser> mtuCaptor = ArgumentCaptor.forClass(MessageToUser.class);
 		verify(messageManager).createMessage(eq(userInfo), mtuCaptor.capture());
+		
 		MessageToUser mtu2 = mtuCaptor.getValue();
 		assertEquals(fileHandleId, mtu2.getFileHandleId());
 		assertEquals(subject, mtu2.getSubject());
@@ -78,6 +82,8 @@ public class NotificationManagerImplTest {
 		MessageToUser mtu = new MessageToUser();
 		mtu.setRecipients(to);
 		String message = "message";
+		
+		// Call under test
 		notificationManager.sendNotifications(userInfo, Collections.singletonList(new MessageToUserAndBody(mtu, message, "text/plain")));
 		// there should be no message sent
 		verify(fileHandleManager, never()).createCompressedFileFromString(anyString(), any(Date.class), anyString());

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EvaluationServiceImpl.java
@@ -170,10 +170,13 @@ public class EvaluationServiceImpl implements EvaluationService {
 		Long versionNumber = submission.getVersionNumber();
 		EntityBundle bundle = serviceProvider.getEntityBundleService().getEntityBundle(userId, entityId, versionNumber, mask);
 		Submission created = submissionManager.createSubmission(userInfo, submission, entityEtag, submissionEligibilityHash, bundle);
+		
 		List<MessageToUserAndBody> messages = submissionManager.
 				createSubmissionNotifications(userInfo,created,submissionEligibilityHash,
 						challengeEndpoint, notificationUnsubscribeEndpoint);
+		
 		notificationManager.sendNotifications(userInfo, messages);
+		
 		return created;
 	}
 	

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/MembershipRequestServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/MembershipRequestServiceImpl.java
@@ -55,10 +55,12 @@ public class MembershipRequestServiceImpl implements MembershipRequestService {
 			InvalidModelException, DatastoreException, NotFoundException {
 		UserInfo userInfo = userManager.getUserInfo(userId);
 		MembershipRequest created = membershipRequestManager.create(userInfo, dto);
-		List<MessageToUserAndBody> messages = membershipRequestManager.
-				createMembershipRequestNotification(created,
+		
+		List<MessageToUserAndBody> messages = membershipRequestManager.createMembershipRequestNotification(created,
 						acceptRequestEndpoint, notificationUnsubscribeEndpoint);
+		
 		notificationManager.sendNotifications(userInfo, messages);
+		
 		return created;
 	}
 

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/TeamServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/TeamServiceImpl.java
@@ -258,7 +258,9 @@ public class TeamServiceImpl implements TeamService {
 		// the method is idempotent.  If the member is already added, it returns false
 		boolean memberAdded = teamManager.addMember(userInfo, teamId, memberUserInfo);
 		
-		if (memberAdded) notificationManager.sendNotifications(userInfo, messages);
+		if (memberAdded) {
+			notificationManager.sendNotifications(userInfo, messages);
+		}
 		
 		return memberAdded;
 	}

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/VerificationServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/VerificationServiceImpl.java
@@ -43,12 +43,16 @@ public class VerificationServiceImpl implements VerificationService {
 		UserInfo userInfo = userManager.getUserInfo(userId);
 		VerificationSubmission result = verificationManager.
 				createVerificationSubmission(userInfo, verificationSubmission);
+		
 		List<MessageToUserAndBody> createNotifications = verificationManager.
 				createSubmissionNotification(result, notificationUnsubscribeEndpoint);
+		
 		notificationManager.sendNotifications(userInfo, createNotifications);
+		
 		return result;
 	}
 	
+	@Override
 	public void deleteVerificationSubmission(Long userId, Long verificationId) {
 		UserInfo userInfo = userManager.getUserInfo(userId);
 		verificationManager.deleteVerificationSubmission(userInfo, verificationId);

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/MessageControllerAutowiredTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/MessageControllerAutowiredTest.java
@@ -16,6 +16,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.sagebionetworks.reflection.model.PaginatedResults;
+import org.sagebionetworks.repo.manager.MessageManager;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
@@ -49,6 +50,9 @@ public class MessageControllerAutowiredTest extends AbstractAutowiredControllerT
 	
 	@Autowired
 	private FileHandleManager fileHandleManager;
+	
+	@Autowired
+	private MessageManager messageManager;
 	
 	private String fileHandleId;
 	
@@ -176,6 +180,9 @@ public class MessageControllerAutowiredTest extends AbstractAutowiredControllerT
 		messageToBob = servletTestHelper.sendMessage(alice, messageToBob);
 		cleanup.add(messageToBob.getId());
 		
+		// Process the outgoing message (emulates a worker)
+		messageManager.processMessage(messageToBob.getId(), null);
+		
 		PaginatedResults<MessageToUser> outboxOfAlice = servletTestHelper.getOutbox(alice, SORT_ORDER, DESCENDING, LIMIT, OFFSET);
 		assertEquals(1L, outboxOfAlice.getTotalNumberOfResults());
 		assertEquals(1, outboxOfAlice.getResults().size());
@@ -237,6 +244,9 @@ public class MessageControllerAutowiredTest extends AbstractAutowiredControllerT
 		MessageToUser messageToAlice = servletTestHelper.forwardMessage(bob, messageToBob.getId(), bouncy);
 		cleanup.add(messageToAlice.getId());
 		
+		// Process the outgoing message (emulates a worker)
+		messageManager.processMessage(messageToAlice.getId(), null);
+		
 		PaginatedResults<MessageBundle> inboxOfAlice = servletTestHelper.getInbox(alice, inboxFilter, SORT_ORDER, DESCENDING, LIMIT, OFFSET);
 		assertEquals(1L, inboxOfAlice.getTotalNumberOfResults());
 		assertEquals(1, inboxOfAlice.getResults().size());
@@ -273,6 +283,9 @@ public class MessageControllerAutowiredTest extends AbstractAutowiredControllerT
 		MessageToUser messageToBob = getMessageDTO(toBob, null);
 		messageToBob = servletTestHelper.sendMessage(alice, messageToBob);
 		cleanup.add(messageToBob.getId());
+		
+		// Process the outgoing message (emulates a worker)
+		messageManager.processMessage(messageToBob.getId(), null);
 		
 		PaginatedResults<MessageBundle> inboxOfBob = servletTestHelper.getInbox(bob, inboxFilter, SORT_ORDER, DESCENDING, LIMIT, OFFSET);
 		assertEquals(1L, inboxOfBob.getTotalNumberOfResults());

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/service/EvaluationServiceTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/service/EvaluationServiceTest.java
@@ -1,8 +1,7 @@
 package org.sagebionetworks.repo.web.service;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -13,13 +12,12 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.evaluation.manager.EvaluationManager;
 import org.sagebionetworks.evaluation.manager.EvaluationPermissionsManager;
 import org.sagebionetworks.evaluation.manager.SubmissionManager;
@@ -30,16 +28,12 @@ import org.sagebionetworks.evaluation.model.SubmissionStatusEnum;
 import org.sagebionetworks.repo.manager.MessageToUserAndBody;
 import org.sagebionetworks.repo.manager.NotificationManager;
 import org.sagebionetworks.repo.manager.UserManager;
-import org.sagebionetworks.repo.model.EntityBundle;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.message.MessageToUser;
 import org.sagebionetworks.repo.model.query.QueryDAO;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EvaluationServiceTest {
-
-
-	private EvaluationServiceImpl evaluationService;
 
 	@Mock
 	private ServiceProvider mockServiceProvider;
@@ -57,25 +51,14 @@ public class EvaluationServiceTest {
 	private QueryDAO mockQueryDAO;
 	@Mock
 	private NotificationManager mockNotificationManager;
+	@InjectMocks
+	private EvaluationServiceImpl evaluationService;
 
 	UserInfo userInfo;
 	Long userId;
 	private String evalId;
 	private long limit;
 	private long offset;
-
-
-	@Before
-	public void before() throws Exception {
-		this.evaluationService = new EvaluationServiceImpl(
-				mockServiceProvider,
-				mockEvaluationManager,
-				mockSubmissionManager,
-				mockEvaluationPermissionsManager,
-				mockUserManager,
-				mockQueryDAO,
-				mockNotificationManager);
-	}
 
 	@Test
 	public void testCreateSubmission() throws Exception {

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/service/MembershipInvitationServiceTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/service/MembershipInvitationServiceTest.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.repo.web.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -9,10 +8,14 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.repo.manager.MessageToUserAndBody;
 import org.sagebionetworks.repo.manager.NotificationManager;
 import org.sagebionetworks.repo.manager.UserManager;
@@ -21,11 +24,17 @@ import org.sagebionetworks.repo.model.MembershipInvitation;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.message.MessageToUser;
 
+@ExtendWith(MockitoExtension.class)
 public class MembershipInvitationServiceTest {
-	private MembershipInvitationServiceImpl membershipInvitationService;
+	@Mock
 	private MembershipInvitationManager mockMembershipInvitationManager;
+	@Mock
 	private UserManager mockUserManager;
+	@Mock
 	private NotificationManager mockNotificationManager;
+	
+	@InjectMocks
+	private MembershipInvitationServiceImpl membershipInvitationService;
 	
 	private static final Long USER_ID = 111L;
 	private static final String ACCEPT_INVITATION_ENDPOINT = "acceptInvitationEndpoint:";
@@ -33,20 +42,11 @@ public class MembershipInvitationServiceTest {
 	private UserInfo userInfo; 
 
 	
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
-		mockMembershipInvitationManager = Mockito.mock(MembershipInvitationManager.class);
-		mockUserManager = Mockito.mock(UserManager.class);
-		mockNotificationManager = Mockito.mock(NotificationManager.class);
-
 		userInfo = new UserInfo(false); 
 		userInfo.setId(USER_ID);
 		when(mockUserManager.getUserInfo(USER_ID)).thenReturn(userInfo);
-
-		this.membershipInvitationService = new MembershipInvitationServiceImpl(
-				mockMembershipInvitationManager,
-				mockUserManager,
-				mockNotificationManager);
 	}
 
 	@Test
@@ -71,8 +71,7 @@ public class MembershipInvitationServiceTest {
 				mis, ACCEPT_INVITATION_ENDPOINT, NOTIFICATION_UNSUBSCRIBE_ENDPOINT);
 		
 		ArgumentCaptor<List> messageArg = ArgumentCaptor.forClass(List.class);
-		verify(mockNotificationManager).
-			sendNotifications(eq(userInfo), messageArg.capture());
+		verify(mockNotificationManager).sendNotifications(eq(userInfo), messageArg.capture());
 		assertEquals(1, messageArg.getValue().size());		
 		assertEquals(result, messageArg.getValue().get(0));
 	}
@@ -84,14 +83,10 @@ public class MembershipInvitationServiceTest {
 		mis.setInviteeEmail("me@domain.com");
 		when(mockMembershipInvitationManager.create(userInfo, mis)).thenReturn(mis);
 
-		try {
+		Assertions.assertThrows(IllegalArgumentException.class, ()-> {
 			// method under test
-			membershipInvitationService.create(USER_ID, mis,
-					ACCEPT_INVITATION_ENDPOINT,  NOTIFICATION_UNSUBSCRIBE_ENDPOINT);
-			fail("Expected IllegalArgumentException");
-		} catch (IllegalArgumentException e) {
-			// as expected
-		}
+			membershipInvitationService.create(USER_ID, mis, ACCEPT_INVITATION_ENDPOINT,  NOTIFICATION_UNSUBSCRIBE_ENDPOINT);
+		});
 
 	}
 
@@ -100,14 +95,10 @@ public class MembershipInvitationServiceTest {
 		MembershipInvitation mis = new MembershipInvitation();
 		when(mockMembershipInvitationManager.create(userInfo, mis)).thenReturn(mis);
 
-		try {
+		Assertions.assertThrows(IllegalArgumentException.class, ()-> {
 			// method under test
-			membershipInvitationService.create(USER_ID, mis,
-					ACCEPT_INVITATION_ENDPOINT,  NOTIFICATION_UNSUBSCRIBE_ENDPOINT);
-			fail("Expected IllegalArgumentException");
-		} catch (IllegalArgumentException e) {
-			// as expected
-		}
+			membershipInvitationService.create(USER_ID, mis, ACCEPT_INVITATION_ENDPOINT,  NOTIFICATION_UNSUBSCRIBE_ENDPOINT);
+		});
 
 	}
 

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/service/MembershipRequestServiceTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/service/MembershipRequestServiceTest.java
@@ -1,6 +1,6 @@
 package org.sagebionetworks.repo.web.service;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -8,10 +8,12 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.repo.manager.MessageToUserAndBody;
 import org.sagebionetworks.repo.manager.NotificationManager;
 import org.sagebionetworks.repo.manager.UserManager;
@@ -20,24 +22,17 @@ import org.sagebionetworks.repo.model.MembershipRequest;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.message.MessageToUser;
 
+@ExtendWith(MockitoExtension.class)
 public class MembershipRequestServiceTest {
-	private MembershipRequestServiceImpl membershipRequestService;
+	@Mock
 	private MembershipRequestManager mockMembershipRequestManager;
+	@Mock
 	private UserManager mockUserManager;
+	@Mock
 	private NotificationManager mockNotificationManager;
+	@InjectMocks
+	private MembershipRequestServiceImpl membershipRequestService;
 	
-	@Before
-	public void before() throws Exception {
-		mockMembershipRequestManager = Mockito.mock(MembershipRequestManager.class);
-		mockUserManager = Mockito.mock(UserManager.class);
-		mockNotificationManager = Mockito.mock(NotificationManager.class);
-
-		this.membershipRequestService = new MembershipRequestServiceImpl(
-				mockMembershipRequestManager,
-				mockUserManager,
-				mockNotificationManager);
-	}
-
 	@Test
 	public void testCreate() {
 		Long userId = 111L;
@@ -55,15 +50,17 @@ public class MembershipRequestServiceTest {
 		when(mockMembershipRequestManager.createMembershipRequestNotification(mrs,
 				acceptRequestEndpoint, notificationUnsubscribeEndpoint)).thenReturn(result);
 
+		// Call under test
 		membershipRequestService.create(userId, mrs, acceptRequestEndpoint, notificationUnsubscribeEndpoint);
+		
 		verify(mockUserManager).getUserInfo(userId);
 		verify(mockMembershipRequestManager).create(userInfo, mrs);
 		verify(mockMembershipRequestManager).createMembershipRequestNotification(mrs,
 				acceptRequestEndpoint, notificationUnsubscribeEndpoint);
 		
 		ArgumentCaptor<List> messageArg = ArgumentCaptor.forClass(List.class);
-		verify(mockNotificationManager).
-			sendNotifications(eq(userInfo), messageArg.capture());
+		
+		verify(mockNotificationManager).sendNotifications(eq(userInfo), messageArg.capture());
 		assertEquals(1, messageArg.getValue().size());		
 		assertEquals(result, messageArg.getValue());		
 

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/service/TeamServiceTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/service/TeamServiceTest.java
@@ -2,28 +2,26 @@ package org.sagebionetworks.repo.web.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.reflection.model.PaginatedResults;
 import org.sagebionetworks.repo.manager.MessageToUserAndBody;
 import org.sagebionetworks.repo.manager.NotificationManager;
@@ -42,12 +40,10 @@ import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.dbo.principal.PrincipalPrefixDAO;
 import org.sagebionetworks.repo.model.message.MessageToUser;
-import org.springframework.test.util.ReflectionTestUtils;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TeamServiceTest {
 	
-	private TeamServiceImpl teamService;
 	@Mock
 	private UserManager mockUserManager;
 	@Mock
@@ -60,11 +56,13 @@ public class TeamServiceTest {
 	private UserProfileManager mockUserProfileManager;
 	@Mock
 	private TokenGenerator mockTokenGenerator;
+	@InjectMocks
+	private TeamServiceImpl teamService;
 	
 	private Team team = null;
 	private TeamMember member = null;
 	
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
 			
 		team = new Team();
@@ -74,22 +72,6 @@ public class TeamServiceTest {
 		UserGroupHeader ugh = new UserGroupHeader();
 		ugh.setUserName("John Smith");
 		member.setMember(ugh);
-
-		Map<Team, Collection<TeamMember>> universe = new HashMap<Team, Collection<TeamMember>>();
-		universe.put(team, Arrays.asList(new TeamMember[]{member}));
-		when(mockTeamManager.listAllTeamsAndMembers()).thenReturn(universe);
-		
-		PaginatedResults<TeamMember> members = PaginatedResults.createWithLimitAndOffset(Arrays.asList(new TeamMember[]{member}), 100L, 0L);
-		when(mockTeamManager.listMembers(eq("101"), any(TeamMemberTypeFilterOptions.class), anyLong(), anyLong())).thenReturn(members);
-		
-		teamService = new TeamServiceImpl();
-		
-		ReflectionTestUtils.setField(teamService, "teamManager", mockTeamManager);
-		ReflectionTestUtils.setField(teamService, "principalPrefixDAO", mockPrincipalPrefixDAO);
-		ReflectionTestUtils.setField(teamService, "userManager", mockUserManager);
-		ReflectionTestUtils.setField(teamService, "notificationManager", mockNotificationManager);
-		ReflectionTestUtils.setField(teamService, "userProfileManager", mockUserProfileManager);
-		ReflectionTestUtils.setField(teamService, "tokenGenerator", mockTokenGenerator);
 	}
 	
 	@Test
@@ -118,7 +100,7 @@ public class TeamServiceTest {
 	}
 	
 	@Test
-	public void testGetTeamMembersByFragment() throws Exception {
+	public void testGetTeamMembersByFragment() throws Exception {		
 		List<TeamMember> tms1 = Collections.singletonList(member);
 		PaginatedResults<TeamMember> tms1paginated = PaginatedResults.createWithLimitAndOffset(tms1, 10L, 0L);
 		List<TeamMember> tms2 = Collections.emptyList();
@@ -131,22 +113,18 @@ public class TeamServiceTest {
 		when(mockPrincipalPrefixDAO.countTeamMembersForPrefix("john", teamId)).thenReturn(1L);
 		when(mockTeamManager.listMembersForPrefix("bas", teamId.toString(), TeamMemberTypeFilterOptions.ALL,1L, 0L)).thenReturn(tms2paginated);
 		when(mockPrincipalPrefixDAO.countTeamMembersForPrefix("bas", teamId)).thenReturn(0L);
-		List<TeamMember> expected = new ArrayList<TeamMember>();
-		expected.add(member);
-		ListWrapper<TeamMember> wrapper = new ListWrapper<TeamMember>();
-		wrapper.setList(expected);
-		when(mockTeamManager.listMembers(any(List.class), any(List.class))).thenReturn(wrapper);
+		
 		// test last name match
 		PaginatedResults<TeamMember> pr = teamService.getMembers("101", "Smith", TeamMemberTypeFilterOptions.ALL, 1, 0);
 		assertEquals(1L, pr.getTotalNumberOfResults());
-		assertEquals(expected, pr.getResults());
+		assertEquals(tms1, pr.getResults());
 		
 		assertEquals(1L, teamService.getMemberCount("101", "Smith").getCount().longValue());
 		
 		// test first name match, different case
 		pr = teamService.getMembers("101", "john", TeamMemberTypeFilterOptions.ALL, 1, 0);
 		assertEquals(1L, pr.getTotalNumberOfResults());
-		assertEquals(expected, pr.getResults());
+		assertEquals(tms1, pr.getResults());
 
 		assertEquals(1L, teamService.getMemberCount("101", "john").getCount().longValue());
 
@@ -163,19 +141,28 @@ public class TeamServiceTest {
 		verify(mockTeamManager).list(1, 0);
 	}
 
-	@Test (expected=IllegalArgumentException.class)
+	@Test
 	public void testGetTeamWithUnderMinLimit() {
-		teamService.get(null, 0, 0);
+		IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class, ()-> {
+			teamService.get(null, 0, 0);
+		});
+		assertEquals("limit must be between 1 and 50", ex.getMessage());
 	}
 
-	@Test (expected=IllegalArgumentException.class)
+	@Test
 	public void testGetTeamWithOverMaxLimit() {
-		teamService.get(null, 51, 0);
+		IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class, ()-> {
+			teamService.get(null, 51, 0);
+		});
+		assertEquals("limit must be between 1 and 50", ex.getMessage());
 	}
 
-	@Test (expected=IllegalArgumentException.class)
+	@Test
 	public void testGetTeamWithNegativeOffset() {
-		teamService.get(null, 50, -1);
+		IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class, ()-> {
+			teamService.get(null, 50, -1);
+		});
+		assertEquals("'offset' may not be negative", ex.getMessage());
 	}
 	
 	@Test
@@ -193,19 +180,28 @@ public class TeamServiceTest {
 		verify(mockTeamManager).countMembers("101");
 	}
 
-	@Test (expected=IllegalArgumentException.class)
+	@Test
 	public void testGetTeamMemberWithUnderMinLimit() {
-		teamService.getMembers("101", null, TeamMemberTypeFilterOptions.ALL, 0, 0);
+		IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class, ()-> {
+			teamService.getMembers("101", null, TeamMemberTypeFilterOptions.ALL, 0, 0);
+		});
+		assertEquals("limit must be between 1 and 50", ex.getMessage());
 	}
 
-	@Test (expected=IllegalArgumentException.class)
+	@Test
 	public void testGetTeamMemberWithOverMaxLimit() {
-		teamService.getMembers("101", null, TeamMemberTypeFilterOptions.ALL, 51, 0);
+		IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class, ()-> {
+			teamService.getMembers("101", null, TeamMemberTypeFilterOptions.ALL, 51, 0);
+		});
+		assertEquals("limit must be between 1 and 50", ex.getMessage());
 	}
 
-	@Test (expected=IllegalArgumentException.class)
+	@Test
 	public void testGetTeamMemberWithNegativeOffset() {
-		teamService.getMembers("101", null, TeamMemberTypeFilterOptions.ALL, 1, -1);
+		IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class, ()-> {
+			teamService.getMembers("101", null, TeamMemberTypeFilterOptions.ALL, 1, -1);
+		});
+		assertEquals("'offset' may not be negative", ex.getMessage());
 	}
 	
 	@Test
@@ -233,8 +229,7 @@ public class TeamServiceTest {
 		verify(mockUserManager).getUserInfo(principalId);
 				
 		ArgumentCaptor<List> messageArg = ArgumentCaptor.forClass(List.class);
-		verify(mockNotificationManager).
-			sendNotifications(eq(userInfo1), messageArg.capture());
+		verify(mockNotificationManager).sendNotifications(eq(userInfo1), messageArg.capture());
 		assertEquals(1, messageArg.getValue().size());		
 		assertEquals(result, messageArg.getValue().get(0));		
 
@@ -276,8 +271,7 @@ public class TeamServiceTest {
 		verify(mockUserManager).getUserInfo(principalId);
 				
 		ArgumentCaptor<List> messageArg = ArgumentCaptor.forClass(List.class);
-		verify(mockNotificationManager).
-			sendNotifications(eq(userInfo1), messageArg.capture());
+		verify(mockNotificationManager).sendNotifications(eq(userInfo1), messageArg.capture());
 		assertEquals(1, messageArg.getValue().size());		
 		assertEquals(result, messageArg.getValue().get(0));	
 		
@@ -320,7 +314,7 @@ public class TeamServiceTest {
 		verify(mockUserManager).getUserInfo(userId);
 		verify(mockUserManager).getUserInfo(principalId);
 				
-		verify(mockNotificationManager, never()).sendNotifications(eq(userInfo1), (List<MessageToUserAndBody>)any(List.class));
+		verifyZeroInteractions(mockNotificationManager);
 		
 		assertEquals("User auser is already in team foo bar.", message.getMessage());
 

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/service/VerificationServiceImplTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/service/VerificationServiceImplTest.java
@@ -7,9 +7,12 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.repo.manager.MessageToUserAndBody;
 import org.sagebionetworks.repo.manager.NotificationManager;
 import org.sagebionetworks.repo.manager.UserManager;
@@ -19,29 +22,26 @@ import org.sagebionetworks.repo.model.verification.VerificationState;
 import org.sagebionetworks.repo.model.verification.VerificationStateEnum;
 import org.sagebionetworks.repo.model.verification.VerificationSubmission;
 
+@ExtendWith(MockitoExtension.class)
 public class VerificationServiceImplTest {
-	private VerificationServiceImpl verificationService;
+	@Mock
 	private VerificationManager mockVerificationManager;
+	@Mock
 	private UserManager mockUserManager;
+	@Mock
 	private NotificationManager mockNotificationManager;
+	@InjectMocks
+	private VerificationServiceImpl verificationService;
+
 	private UserInfo userInfo; 
 		
 	private static final Long USER_ID = 111L;
 	private static final String NOTIFICATION_UNSUBSCRIBE_ENDPOINT = "notificationUnsubscribeEndpoint:";
 
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
 		userInfo = new UserInfo(false);
-		userInfo.setId(USER_ID);
-		mockUserManager = Mockito.mock(UserManager.class);
-		mockNotificationManager = Mockito.mock(NotificationManager.class);
-		mockVerificationManager = Mockito.mock(VerificationManager.class);
-
-		this.verificationService = new VerificationServiceImpl(
-				mockVerificationManager,
-				mockUserManager,
-				mockNotificationManager);
-		
+		userInfo.setId(USER_ID);		
 		when(mockUserManager.getUserInfo(USER_ID)).thenReturn(userInfo);
 	}
 
@@ -60,8 +60,8 @@ public class VerificationServiceImplTest {
 			 NOTIFICATION_UNSUBSCRIBE_ENDPOINT);
 		
 		verify(mockVerificationManager).createVerificationSubmission(userInfo, verificationSubmission);
-		verify(mockVerificationManager).
-			createSubmissionNotification(verificationSubmission, NOTIFICATION_UNSUBSCRIBE_ENDPOINT);
+		verify(mockVerificationManager).createSubmissionNotification(verificationSubmission, NOTIFICATION_UNSUBSCRIBE_ENDPOINT);
+		verify(mockNotificationManager).sendNotifications(userInfo, mtubList);
 		
 		assertEquals(created, verificationSubmission);
 	}
@@ -94,8 +94,8 @@ public class VerificationServiceImplTest {
 				USER_ID, verificationId, newState, NOTIFICATION_UNSUBSCRIBE_ENDPOINT);
 		
 		verify(mockVerificationManager).changeSubmissionState(userInfo, verificationId, newState);
-		verify(mockVerificationManager).
-		createStateChangeNotification(verificationId, newState, NOTIFICATION_UNSUBSCRIBE_ENDPOINT);
+		verify(mockVerificationManager).createStateChangeNotification(verificationId, newState, NOTIFICATION_UNSUBSCRIBE_ENDPOINT);
+		verify(mockNotificationManager).sendNotifications(userInfo, mtubList);
 
 	}
 


### PR DESCRIPTION
Always process messages in a worker independently from the number of recipients, before we would have a special case when there was a single recipient and the message was sent right away. We changed instead the system to always process the messages in a worker. Failures are sent as a notification to the sender.