### PR TITLE
PLFM-5769

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/IT049FileHandleTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT049FileHandleTest.java
@@ -628,7 +628,7 @@ public class IT049FileHandleTest {
 		om.setContentDisposition(ContentDispositionUtils.getContentDispositionValue(baseKey));
 		om.setContentLength(bytes.length);
 
-		synapseS3Client.putObject(bucket, baseKey + "owner.txt", new ByteArrayInputStream(bytes), om);
+		synapseS3Client.putObject(bucket, baseKey + "/owner.txt", new ByteArrayInputStream(bytes), om);
 	}
 
 

--- a/integration-test/src/test/java/org/sagebionetworks/IT049FileHandleTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT049FileHandleTest.java
@@ -25,6 +25,8 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.sagebionetworks.aws.AwsClientFactory;
+import org.sagebionetworks.aws.SynapseS3Client;
 import org.sagebionetworks.client.SynapseAdminClient;
 import org.sagebionetworks.client.SynapseAdminClientImpl;
 import org.sagebionetworks.client.SynapseClient;
@@ -59,6 +61,7 @@ import org.sagebionetworks.repo.model.file.UploadDestinationLocation;
 import org.sagebionetworks.repo.model.file.UploadType;
 import org.sagebionetworks.repo.model.project.ExternalGoogleCloudStorageLocationSetting;
 import org.sagebionetworks.repo.model.project.ExternalObjectStorageLocationSetting;
+import org.sagebionetworks.repo.model.project.ExternalS3StorageLocationSetting;
 import org.sagebionetworks.repo.model.project.ExternalStorageLocationSetting;
 import org.sagebionetworks.repo.model.project.ProjectSetting;
 import org.sagebionetworks.repo.model.project.ProjectSettingsType;
@@ -68,8 +71,10 @@ import org.sagebionetworks.repo.model.project.StorageLocationSetting;
 import org.sagebionetworks.repo.model.project.UploadDestinationListSetting;
 import org.sagebionetworks.repo.model.table.TableEntity;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.sagebionetworks.util.ContentDispositionUtils;
 import org.sagebionetworks.utils.MD5ChecksumHelper;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.google.common.collect.Lists;
 
 public class IT049FileHandleTest {
@@ -93,6 +98,8 @@ public class IT049FileHandleTest {
 	private static StackConfiguration config;
 	private static SynapseGoogleCloudStorageClient googleCloudStorageClient;
 
+	private static SynapseS3Client synapseS3Client;
+
 	@BeforeClass
 	public static void beforeClass() throws Exception {
 		config = StackConfigurationSingleton.singleton();
@@ -106,6 +113,7 @@ public class IT049FileHandleTest {
 		synapse = new SynapseClientImpl();
 		userToDelete = SynapseClientHelper.createUser(adminSynapse, synapse);
 
+		synapseS3Client = AwsClientFactory.createAmazonS3Client();
 		if (config.getGoogleCloudEnabled()) {
 			googleCloudStorageClient = SynapseGoogleCloudClientFactory.createGoogleCloudStorageClient();
 		}
@@ -550,6 +558,34 @@ public class IT049FileHandleTest {
 		assertFalse(startStatus.getUploadId().equals(statusAgain.getUploadId()));
 	}
 
+	// See PLFM-5769
+	@Test
+	public void testMultipartUploadToExternalS3() throws FileNotFoundException, SynapseException, IOException{
+		assertNotNull(largeImageFile);
+		assertTrue(largeImageFile.exists());
+		String expectedMD5 = MD5ChecksumHelper.getMD5Checksum(largeImageFile);
+
+		// Upload the owner.txt to S3 so we can create the external storage location
+		String baseKey = "integration-test/IT049FileHandleTest-" + UUID.randomUUID().toString();
+
+		uploadOwnerTxtToS3(config.getS3Bucket(), baseKey, synapse.getUserProfile(userToDelete.toString()).getUserName());
+
+		// upload the little image using multi-part upload
+		ExternalS3StorageLocationSetting storageLocationSetting = new ExternalS3StorageLocationSetting();
+		storageLocationSetting.setBucket(config.getS3Bucket());
+		storageLocationSetting.setBaseKey(baseKey);
+		storageLocationSetting.setUploadType(UploadType.S3);
+		storageLocationSetting = synapse.createStorageLocationSetting(storageLocationSetting);
+
+		Boolean generatePreview = false;
+		Boolean forceRestart = null;
+		S3FileHandle result = (S3FileHandle) synapse.multipartUpload(this.largeImageFile, storageLocationSetting.getStorageLocationId(), generatePreview, forceRestart);
+		assertNotNull(result);
+		toDelete.add(result);
+		assertNotNull(result.getFileName());
+		assertEquals(expectedMD5, result.getContentMd5());
+	}
+
 	@Test
 	public void testMultipartUploadV2ToGoogleCloud() throws FileNotFoundException, SynapseException, IOException{
 		// Only run this test if Google Cloud is enabled.
@@ -581,6 +617,18 @@ public class IT049FileHandleTest {
 
 		// Verify that all parts have been deleted
 		assertTrue(IterableUtils.isEmpty(googleCloudStorageClient.getObjects(result.getBucketName(), result.getKey() + "/")));
+	}
+
+	private static void uploadOwnerTxtToS3(String bucket, String baseKey, String username) throws IOException {
+		byte[] bytes = username.getBytes(StandardCharsets.UTF_8);
+
+		ObjectMetadata om = new ObjectMetadata();
+		om.setContentType("text/plain");
+		om.setContentEncoding("UTF-8");
+		om.setContentDisposition(ContentDispositionUtils.getContentDispositionValue(baseKey));
+		om.setContentLength(bytes.length);
+
+		synapseS3Client.putObject(bucket, baseKey + "owner.txt", new ByteArrayInputStream(bytes), om);
 	}
 
 

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/persistence/DBOStorageLocationTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/persistence/DBOStorageLocationTest.java
@@ -1,0 +1,87 @@
+package org.sagebionetworks.repo.model.dbo.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.sagebionetworks.repo.model.dbo.dao.StorageLocationUtils;
+import org.sagebionetworks.repo.model.project.ExternalS3StorageLocationSetting;
+
+public class DBOStorageLocationTest {
+
+	/**
+	 * Test for PLFM-5769
+	 */
+	@Test
+	public void createDatabaseObjectFromBackupRemoveSlashes() {
+		String expected = "remove-trailing-slash";
+		ExternalS3StorageLocationSetting extS3sls = new ExternalS3StorageLocationSetting();
+		extS3sls.setBaseKey(expected + "/");
+
+		String prevHash = StorageLocationUtils.computeHash(extS3sls);
+
+		DBOStorageLocation dbo = new DBOStorageLocation();
+		dbo.setData(extS3sls);
+		dbo.setDataHash(prevHash);
+
+		// call under test
+		DBOStorageLocation result = dbo.getTranslator().createDatabaseObjectFromBackup(dbo);
+		assertNotNull(result);
+
+		ExternalS3StorageLocationSetting resultData = (ExternalS3StorageLocationSetting) result.getData();
+		assertEquals(expected, resultData.getBaseKey());
+
+		// The hash should change
+		assertNotEquals(prevHash, result.getDataHash());
+	}
+
+	/**
+	 * Test for PLFM-5769
+	 */
+	@Test
+	public void createDatabaseObjectFromBackupNoSlashesToRemove() {
+		String expected = "remove-trailing-slash";
+		ExternalS3StorageLocationSetting extS3sls = new ExternalS3StorageLocationSetting();
+		extS3sls.setBaseKey(expected);
+
+		String prevHash = StorageLocationUtils.computeHash(extS3sls);
+
+		DBOStorageLocation dbo = new DBOStorageLocation();
+		dbo.setData(extS3sls);
+		dbo.setDataHash(prevHash);
+
+		// call under test
+		DBOStorageLocation result = dbo.getTranslator().createDatabaseObjectFromBackup(dbo);
+		assertNotNull(result);
+
+		ExternalS3StorageLocationSetting resultData = (ExternalS3StorageLocationSetting) result.getData();
+		assertEquals(expected, resultData.getBaseKey());
+		assertEquals(prevHash, result.getDataHash());
+	}
+
+	/**
+	 * Test for PLFM-5769
+	 */
+	@Test
+	public void createDatabaseObjectFromBackupNullBaseKey() {
+		ExternalS3StorageLocationSetting extS3sls = new ExternalS3StorageLocationSetting();
+		extS3sls.setBaseKey(null);
+
+		String prevHash = StorageLocationUtils.computeHash(extS3sls);
+
+		DBOStorageLocation dbo = new DBOStorageLocation();
+		dbo.setData(extS3sls);
+		dbo.setDataHash(prevHash);
+
+		// call under test
+		DBOStorageLocation result = dbo.getTranslator().createDatabaseObjectFromBackup(dbo);
+		assertNotNull(result);
+
+		ExternalS3StorageLocationSetting resultData = (ExternalS3StorageLocationSetting) result.getData();
+		assertNull(resultData.getBaseKey());
+		assertEquals(prevHash, result.getDataHash());
+	}
+
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/MultipartUtils.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/MultipartUtils.java
@@ -47,7 +47,13 @@ public class MultipartUtils {
 		if (storageLocationSetting instanceof ExternalS3StorageLocationSetting) {
 			ExternalS3StorageLocationSetting externalS3StorageLocationSetting = (ExternalS3StorageLocationSetting) storageLocationSetting;
 			if (!StringUtils.isEmpty(externalS3StorageLocationSetting.getBaseKey())) {
-				base = externalS3StorageLocationSetting.getBaseKey() + FILE_TOKEN_TEMPLATE_SEPARATOR;
+				// PLFM-5769: S3 base keys must end with only one trailing slash, but may be stored with one or more
+				base = externalS3StorageLocationSetting.getBaseKey();
+				while (base.endsWith("/")){
+					// TODO: Migrate existing base keys to not have trailing slashes, delete this loop
+					base = base.substring(0, base.length() - 1);
+				}
+				base += FILE_TOKEN_TEMPLATE_SEPARATOR;
 			}
 		} else if (storageLocationSetting instanceof ExternalGoogleCloudStorageLocationSetting) {
 			ExternalGoogleCloudStorageLocationSetting externalGoogleCloudStorageLocationSetting = (ExternalGoogleCloudStorageLocationSetting) storageLocationSetting;

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/MultipartUtils.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/MultipartUtils.java
@@ -47,13 +47,7 @@ public class MultipartUtils {
 		if (storageLocationSetting instanceof ExternalS3StorageLocationSetting) {
 			ExternalS3StorageLocationSetting externalS3StorageLocationSetting = (ExternalS3StorageLocationSetting) storageLocationSetting;
 			if (!StringUtils.isEmpty(externalS3StorageLocationSetting.getBaseKey())) {
-				// PLFM-5769: S3 base keys must end with only one trailing slash, but may be stored with one or more
-				base = externalS3StorageLocationSetting.getBaseKey();
-				while (base.endsWith("/")){
-					// TODO: Migrate existing base keys to not have trailing slashes, delete this loop
-					base = base.substring(0, base.length() - 1);
-				}
-				base += FILE_TOKEN_TEMPLATE_SEPARATOR;
+				base = externalS3StorageLocationSetting.getBaseKey() + FILE_TOKEN_TEMPLATE_SEPARATOR;
 			}
 		} else if (storageLocationSetting instanceof ExternalGoogleCloudStorageLocationSetting) {
 			ExternalGoogleCloudStorageLocationSetting externalGoogleCloudStorageLocationSetting = (ExternalGoogleCloudStorageLocationSetting) storageLocationSetting;

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/ProjectSettingsImplAutowiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/ProjectSettingsImplAutowiredTest.java
@@ -40,12 +40,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.util.StringInputStream;
 import com.google.common.collect.Lists;
 
-/**
- * Tests message access requirement checking and the sending of messages Note: only the logic for sending messages is
- * tested, a separate test handles tests of sending emails
- * 
- * Sorting of messages is not tested. All tests order their results as most recent first.
- */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
 public class ProjectSettingsImplAutowiredTest {
@@ -114,7 +108,7 @@ public class ProjectSettingsImplAutowiredTest {
 
 		ObjectMetadata metadata = new ObjectMetadata();
 		metadata.setContentLength(username.length());
-		s3Client.putObject(externalS3LocationSetting.getBucket(), externalS3LocationSetting.getBaseKey() + "owner.txt",
+		s3Client.putObject(externalS3LocationSetting.getBucket(), externalS3LocationSetting.getBaseKey() + "/owner.txt",
 				new StringInputStream(username), metadata);
 
 		externalS3LocationSetting = projectSettingsManager.createStorageLocationSetting(userInfo, externalS3LocationSetting);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/ProjectSettingsManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/ProjectSettingsManagerImplUnitTest.java
@@ -249,6 +249,16 @@ public class ProjectSettingsManagerImplUnitTest {
 	}
 
 	@Test
+	public void testCreateExternalS3StorageLocationSetting_InvalidS3BaseKey() {
+		externalS3StorageLocationSetting.setBaseKey("CantHaveATrailingSlash/");
+
+		assertThrows(IllegalArgumentException.class, () -> {
+			// method under test
+			projectSettingsManagerImpl.createStorageLocationSetting(userInfo, externalS3StorageLocationSetting);
+		});
+	}
+
+	@Test
 	public void testCreateExternalObjectStorageLocationSetting_InvalidS3BucketName() {
 		ExternalObjectStorageLocationSetting externalObjectStorageLocationSetting = new ExternalObjectStorageLocationSetting();
 		externalObjectStorageLocationSetting.setBucket("s3://my-bucket-name-is-wrong/");

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleManagerImplAutowireTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleManagerImplAutowireTest.java
@@ -81,9 +81,7 @@ import com.google.common.collect.Sets;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
 public class FileHandleManagerImplAutowireTest {
-	
-	public static final long MAX_UPLOAD_WORKER_TIME_MS = 20*1000;
-	
+
 	private List<S3FileHandle> toDelete;
 	private List<WikiPageKey> wikisToDelete;
 	private final List<String> entitiesToDelete = Lists.newArrayList();
@@ -339,11 +337,11 @@ public class FileHandleManagerImplAutowireTest {
 		String nothing = "";
 		ObjectMetadata metadata = new ObjectMetadata();
 		metadata.setContentLength(nothing.length());
-		s3Client.putObject(externalS3LocationSetting.getBucket(), testBase + "owner.txt", new StringInputStream(nothing), metadata);
+		s3Client.putObject(externalS3LocationSetting.getBucket(), testBase + "/owner.txt", new StringInputStream(nothing), metadata);
 		
 		S3FileHandle fauxHandle = new S3FileHandle();
 		fauxHandle.setBucketName(externalS3LocationSetting.getBucket());
-		fauxHandle.setKey(testBase + "owner.txt");
+		fauxHandle.setKey(testBase + "/owner.txt");
 		toDelete.add(fauxHandle);
 
 		try {
@@ -355,7 +353,7 @@ public class FileHandleManagerImplAutowireTest {
 
 		String wrongName = "not me";
 		metadata.setContentLength(wrongName.length());
-		s3Client.putObject(externalS3LocationSetting.getBucket(), testBase + "owner.txt", new StringInputStream(wrongName), metadata);
+		s3Client.putObject(externalS3LocationSetting.getBucket(), testBase + "/owner.txt", new StringInputStream(wrongName), metadata);
 
 		try {
 			projectSettingsManager.createStorageLocationSetting(userInfo, externalS3LocationSetting);
@@ -365,7 +363,7 @@ public class FileHandleManagerImplAutowireTest {
 		}
 
 		metadata.setContentLength(username.length());
-		s3Client.putObject(externalS3LocationSetting.getBucket(), testBase + "owner.txt", new StringInputStream(username), metadata);
+		s3Client.putObject(externalS3LocationSetting.getBucket(), testBase + "/owner.txt", new StringInputStream(username), metadata);
 
 		externalS3LocationSetting = projectSettingsManager.createStorageLocationSetting(userInfo, externalS3LocationSetting);
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/MultipartUtilsTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/MultipartUtilsTest.java
@@ -90,18 +90,6 @@ public class MultipartUtilsTest {
 	}
 
 	@Test
-	public void testCreateNewKeyStorageLocationExternalBaseEndsWithSlash(){
-		ExternalS3StorageLocationSetting location = new ExternalS3StorageLocationSetting();
-		location.setBaseKey("aFolder////");
-		//call under test
-		String key = MultipartUtils.createNewKey(userId, fileName, location);
-		assertNotNull(key);
-		assertTrue(key.startsWith("aFolder/" + userId));
-		assertTrue(key.endsWith(fileName));
-	}
-
-
-	@Test
 	public void testCreateNewKeyStorageLocationExternalBaseNull(){
 		ExternalS3StorageLocationSetting location = new ExternalS3StorageLocationSetting();
 		location.setBaseKey(null);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/MultipartUtilsTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/MultipartUtilsTest.java
@@ -88,7 +88,19 @@ public class MultipartUtilsTest {
 		assertTrue(key.startsWith(userId));
 		assertTrue(key.endsWith(fileName));
 	}
-	
+
+	@Test
+	public void testCreateNewKeyStorageLocationExternalBaseEndsWithSlash(){
+		ExternalS3StorageLocationSetting location = new ExternalS3StorageLocationSetting();
+		location.setBaseKey("aFolder////");
+		//call under test
+		String key = MultipartUtils.createNewKey(userId, fileName, location);
+		assertNotNull(key);
+		assertTrue(key.startsWith("aFolder/" + userId));
+		assertTrue(key.endsWith(fileName));
+	}
+
+
 	@Test
 	public void testCreateNewKeyStorageLocationExternalBaseNull(){
 		ExternalS3StorageLocationSetting location = new ExternalS3StorageLocationSetting();


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/PLFM-5769

* Fixes the upload error when uploading to an external S3 storage location that has a non-null base key (e.g. s3://bucket/baseKey/file.txt).
* Remove trailing slashes from existing external S3 base keys, and explicitly add it when it is needed. Before this PR, different places in the code expected the base keys to have/not have a trailing slash.
* Input validation - new external S3 base keys must not have a trailing slash.
