### PR TITLE
PLFM-6049

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/KeyPairUtil.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/KeyPairUtil.java
@@ -32,7 +32,7 @@ public class KeyPairUtil {
 	
 	public static final String SHA_256 = "SHA-256";
 	
-	private static final String KEY_USE_SIGNATURE = "SIGNATURE";
+	private static final String KEY_USE_SIGNATURE = "sig";
 
 	public static X509Certificate getX509CertificateFromPEM(String pem) {
 		try {
@@ -121,7 +121,7 @@ public class KeyPairUtil {
 			RSAPublicKey rsaPublicKey = (RSAPublicKey)keyPair.getPublic();
 			JsonWebKeyRSA rsaKey = new JsonWebKeyRSA();
 			// these would be set for all algorithms
-			rsaKey.setKty(SignatureAlgorithm.RS256.name());
+			rsaKey.setKty(RSA);
 			rsaKey.setUse(KEY_USE_SIGNATURE);
 			rsaKey.setKid(kid);
 			// these are specific to the RSA algorithm

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/KeyPairUtilTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/KeyPairUtilTest.java
@@ -110,8 +110,8 @@ public class KeyPairUtilTest {
 		assertTrue(keys.get(0) instanceof JsonWebKeyRSA);
 		JsonWebKeyRSA key = (JsonWebKeyRSA)keys.get(0);
 		assertEquals("FPQF:TYN3:DMDM:URKQ:BRS4:BX2W:5VSW:3HXA:4D7Z:KOTS:EI26:GPJ6", key.getKid());
-		assertEquals("RS256", key.getKty());
-		assertEquals("SIGNATURE", key.getUse());
+		assertEquals("RSA", key.getKty());
+		assertEquals("sig", key.getUse());
 		assertNotNull(key.getE());
 		assertNotNull(key.getN());		
 	}


### PR DESCRIPTION
The metadata for the public keys used to verify JSON Web Token signatures includes the fields "kty" (Key Type) and "use" (what the key is used for).  In our [public key metadata](https://repo-prod.prod.sagebase.org/auth/v1/oauth2/jwks) we set kty="RS256" and use="SIGNATURE", but Google and Microsoft use the strings "RSA" and "sig", respectively.  The open source client Key Cloak seems to expect these strings and I believe that AWS (when acting as an OIDC client) also expects these strings.  So this pull request is to update our metadata accordingly.