### PR TITLE
PLFM-3590: Extend owner.txt to multiple users

### DIFF
--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/project/BucketOwnerStorageLocationSetting.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/project/BucketOwnerStorageLocationSetting.json
@@ -1,5 +1,5 @@
 {
-	"description": "A storage location that defines an external bucket that needs to be verified for ownership. For this type of storage location, upon creation there is a process of verification that will check that a owner.txt file is uploaded to the bucket (and if present within the baseKey folder) that contains the username of requesting user.",
+	"description": "A storage location that defines an external bucket that needs to be verified for ownership. For this type of storage location, upon creation there is a process of verification that will check that a owner.txt file is uploaded to the bucket (and if present within the baseKey folder) and that contains a line separated list of user identifiers. Valid user identifiers for verifications are: user id, user name, user email address or id of a team the user is part of.",
 	"type": "interface",
 	"implements": [
 		{

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/storagelocation/BucketOwnerVerifier.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/storagelocation/BucketOwnerVerifier.java
@@ -9,7 +9,10 @@ import org.sagebionetworks.repo.model.project.BucketOwnerStorageLocationSetting;
  * @author Marco
  */
 public interface BucketOwnerVerifier {
+	// Maximum number of lines we read from the owner.txt
+	public static final int OWNER_TXT_MAX_LINES = 100;
 	
+	// The file name that contains the bucket owner information to verify
 	public static final String OWNER_MARKER = "owner.txt";
 
 	/**

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/storagelocation/BucketOwnerVerifierImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/storagelocation/BucketOwnerVerifierImpl.java
@@ -1,15 +1,18 @@
 package org.sagebionetworks.repo.manager.storagelocation;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
+import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.principal.AliasType;
 import org.sagebionetworks.repo.model.principal.PrincipalAlias;
@@ -19,14 +22,24 @@ import org.sagebionetworks.util.ValidateArgument;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.google.common.collect.ImmutableSet;
+
 @Service
 public class BucketOwnerVerifierImpl implements BucketOwnerVerifier {
-
+	
 	public static final String EXTERNAL_STORAGE_HELP = "http://docs.synapse.org/articles/custom_storage_location.html for more information on how to create a new external upload destination.";
 
-	private static final String SECURITY_EXPLANATION = "For security purposes, Synapse needs to establish that %s has permission to write to the bucket. Please create an object in bucket '%s' with key '%s' that contains the text '%s'. Also see "
+	private static final String SECURITY_EXPLANATION = "For security purposes, Synapse needs to establish that the user has permission to write to the bucket. Please create an object in bucket '%s' with key '%s' that contains a "
+			+ "line separated list of identifiers for the user. Valid identifiers are the id of the user, its username, email address or id of a team the user is part of. Also see "
 			+ EXTERNAL_STORAGE_HELP;
-
+	
+	// Set of teams that are not allowed to be used as identifiers in the owner.txt
+	private static final Set<Long> EXCLUDED_TEAMS = ImmutableSet.of(
+		BOOTSTRAP_PRINCIPAL.AUTHENTICATED_USERS_GROUP.getPrincipalId(),
+		BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId(),
+		BOOTSTRAP_PRINCIPAL.CERTIFIED_USERS.getPrincipalId()
+	);
+	
 	@Autowired
 	private PrincipalAliasDAO principalAliasDAO;
 
@@ -51,23 +64,9 @@ public class BucketOwnerVerifierImpl implements BucketOwnerVerifier {
 		String bucketName = storageLocation.getBucket();
 		String baseKey = storageLocation.getBaseKey();
 		String ownerKey = baseKey == null ? OWNER_MARKER : baseKey + "/" + OWNER_MARKER;
-
-		List<PrincipalAlias> ownerAliases = getBucketOwnerAliases(userInfo.getId());
-
-		String ownerContent;
-
-		try (InputStream stream = reader.openStream(bucketName, ownerKey)) {
-
-			BufferedReader content = newStreamReader(stream);
-
-			ownerContent = content.readLine();
-		} catch (IOException e) {
-			throw new IllegalArgumentException("Could not read username from key " + ownerKey + " from bucket " + bucketName + ". "
-					+ getExplanation(ownerAliases, bucketName, ownerKey));
-		} catch (Exception e) {
-			throw new IllegalArgumentException(e.getMessage() + ". " + getExplanation(ownerAliases, bucketName, ownerKey), e);
-		}
-
+		
+		Set<String> ownerAliases = getBucketOwnerAliases(userInfo);
+		List<String> ownerContent = readOwnerContent(reader, bucketName, ownerKey);
 		validateOwnerContent(ownerContent, ownerAliases, bucketName, ownerKey);
 
 	}
@@ -79,55 +78,82 @@ public class BucketOwnerVerifierImpl implements BucketOwnerVerifier {
 		}
 		return reader;
 	}
+	
+	List<String> readOwnerContent(BucketObjectReader reader, String bucketName, String ownerKey) {
+		try (InputStream stream = reader.openStream(bucketName, ownerKey)) {
 
+			BufferedReader content = newStreamReader(stream);
+			
+			return content.lines().limit(OWNER_TXT_MAX_LINES)
+					.map(this::normalizeAlias)
+					.filter( line -> !line.isEmpty())
+					.collect(Collectors.toList());
+			
+		} catch (UncheckedIOException e) {
+			throw new IllegalArgumentException("Could not read key " + ownerKey + " from bucket " + bucketName + ". "
+					+ getExplanation(bucketName, ownerKey), e);
+		} catch (Exception e) {
+			throw new IllegalArgumentException(e.getMessage() + ". " + getExplanation(bucketName, ownerKey), e);
+		}
+	}
+	
 	BufferedReader newStreamReader(InputStream stream) {
 		return new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
 	}
 
-	void validateOwnerContent(String ownerContent, List<PrincipalAlias> expectedAliases, String bucket, String key) {
-
-		if (StringUtils.isBlank(ownerContent)) {
-			throw new IllegalArgumentException(
-					"No username found under key " + key + " from bucket " + bucket + ". " + getExplanation(expectedAliases, bucket, key));
+	void validateOwnerContent(List<String> ownerContent, Set<String> validAliases, String bucket, String key) {
+		if (ownerContent.isEmpty()) {
+			throw new IllegalArgumentException("No user identifier found under key " + key + " from bucket " + bucket + ". " + getExplanation(bucket, key));
 		}
 
-		if (!checkForCorrectName(expectedAliases, ownerContent)) {
-			throw new IllegalArgumentException("The username " + ownerContent + " found under key " + key + " from bucket " + bucket
-					+ " is not what was expected. " + getExplanation(expectedAliases, bucket, key));
+		for (String line : ownerContent) {
+			if (validAliases.contains(line)) {
+				return;
+			}
 		}
+		
+		throw new IllegalArgumentException("Could not find a valid user identifier under key " + key + " from bucket " + bucket
+				+ ". " + getExplanation(bucket, key));
+		
 	}
 	
 	/**
-	 * Collects the possible aliases that can be used to verify ownership of an S3 bucket. Currently, this is a user's
-	 * username and their email addresses.
+	 * Collects the possible aliases that can be used to verify ownership of an S3 bucket.
 	 * 
-	 * @param userId
+	 * @param userInfo
 	 * @return
 	 */
-	private List<PrincipalAlias> getBucketOwnerAliases(Long userId) {
-		return principalAliasDAO.listPrincipalAliases(userId, AliasType.USER_NAME, AliasType.USER_EMAIL);
+	Set<String> getBucketOwnerAliases(UserInfo userInfo) {
+		Set<String> ownerAliases = new HashSet<>();
+		
+		// The user id is a valid alias
+		ownerAliases.add(userInfo.getId().toString());
+		
+		List<PrincipalAlias> principalAliases = principalAliasDAO.listPrincipalAliases(userInfo.getId(), AliasType.USER_NAME, AliasType.USER_EMAIL);
+		
+		// Adds the username and user emails as valid aliases
+		ownerAliases.addAll(principalAliases.stream()
+				.map(PrincipalAlias::getAlias)
+				.map(this::normalizeAlias)
+				.collect(Collectors.toList())
+		);
+		
+		// Adds the id of the teams of the user, excluding the certain boostrapped teams (e.g. public group, certified users etc)
+		ownerAliases.addAll(userInfo.getGroups().stream()
+				.filter( teamId -> !EXCLUDED_TEAMS.contains(teamId))
+				.map(Object::toString)
+				.collect(Collectors.toList())
+		);
+		
+		return ownerAliases;
+	}
+	
+	private String normalizeAlias(String inputAlias) {
+		return inputAlias.trim().toLowerCase();
 	}
 
-	private static String getExplanation(List<PrincipalAlias> aliases, String bucket, String key) {
-		String username = aliases.get(0).getAlias();
-		for (PrincipalAlias pa : aliases) {
-			if (pa.getType().equals(AliasType.USER_NAME)) {
-				username = pa.getAlias();
-				break;
-			}
-		}
-		return String.format(SECURITY_EXPLANATION, username, bucket, key, username);
-	}
-
-	private static boolean checkForCorrectName(List<PrincipalAlias> allowedNames, String actualUsername) {
-		if (allowedNames != null) {
-			for (PrincipalAlias name : allowedNames) {
-				if (name.getAlias().equalsIgnoreCase(actualUsername)) {
-					return true;
-				}
-			}
-		}
-		return false;
+	private static String getExplanation(String bucket, String key) {
+		return String.format(SECURITY_EXPLANATION, bucket, key);
 	}
 
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/storagelocation/BucketOwnerVerifierImplAutowireTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/storagelocation/BucketOwnerVerifierImplAutowireTest.java
@@ -4,9 +4,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
+import org.sagebionetworks.StackConfigurationSingleton;
+import org.sagebionetworks.aws.SynapseS3Client;
+import org.sagebionetworks.repo.manager.UserManager;
+import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
+import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.model.auth.NewUser;
 import org.sagebionetworks.repo.model.project.BucketOwnerStorageLocationSetting;
 import org.sagebionetworks.repo.model.project.ExternalGoogleCloudStorageLocationSetting;
 import org.sagebionetworks.repo.model.project.ExternalS3StorageLocationSetting;
@@ -14,12 +26,38 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.util.StringInputStream;
+import com.google.common.collect.ImmutableList;
+
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
 public class BucketOwnerVerifierImplAutowireTest {
+	
+	private static final long TEST_TEAM_ID = 123L;
 
 	@Autowired
 	private BucketOwnerVerifierImpl bucketOwnerVerifier;
+	
+	@Autowired
+	private SynapseS3Client s3Client;
+	
+	@Autowired
+	private UserManager userManager;
+	
+	private List<Long> users;
+	
+	@BeforeEach
+	public void before() {
+		users = new ArrayList<Long>();
+	}
+	
+	@AfterEach
+	public void after() {
+		UserInfo adminUserInfo = userManager.getUserInfo(BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId());
+		
+		users.forEach(userId -> userManager.deletePrincipal(adminUserInfo, userId));
+	}
 	
 	@Test
 	public void testS3StorageLocationWiring() {
@@ -44,6 +82,88 @@ public class BucketOwnerVerifierImplAutowireTest {
 			bucketOwnerVerifier.getObjectReader(storageLocation);
 		});
 		assertEquals("Unsupported storage location type: " + storageLocation.getClass().getSimpleName(), e.getMessage());
+	}
+	
+	@Test
+	public void testVerificationWithMultipleUsers() throws Exception {
+		UserInfo user1 = createUser();
+		UserInfo user2 = createUser();
+		
+		List<String> ownerList = ImmutableList.of(user1.getId().toString(), user2.getId().toString());
+		
+		BucketOwnerStorageLocationSetting storageLocation = linkBucket(ownerList);
+		
+		bucketOwnerVerifier.verifyBucketOwnership(user1, storageLocation);
+		bucketOwnerVerifier.verifyBucketOwnership(user2, storageLocation);
+	}
+	
+	@Test
+	public void testVerificationWithMultipleUsersThroughTeam() throws Exception {
+		UserInfo user1 = createUser();
+		UserInfo user2 = createUser();
+		
+		List<String> ownerList = ImmutableList.of(String.valueOf(TEST_TEAM_ID));
+		
+		BucketOwnerStorageLocationSetting storageLocation = linkBucket(ownerList);
+		
+		bucketOwnerVerifier.verifyBucketOwnership(user1, storageLocation);
+		bucketOwnerVerifier.verifyBucketOwnership(user2, storageLocation);
+	}
+	
+	
+	private BucketOwnerStorageLocationSetting linkBucket(List<String> ownersList) throws Exception {
+		
+		String baseKey = "test_externalS3MultipleUsers_" + UUID.randomUUID();
+		
+		BucketOwnerStorageLocationSetting storageLocation = new ExternalS3StorageLocationSetting();
+		
+		storageLocation.setBucket(StackConfigurationSingleton.singleton().getExternalS3TestBucketName());
+		storageLocation.setBaseKey(baseKey);
+		
+		s3Client.createBucket(storageLocation.getBucket());
+			
+		String ownerContent = String.join("\n", ownersList);
+
+		ObjectMetadata metadata = new ObjectMetadata();
+		
+		metadata.setContentLength(ownerContent.length());
+		
+		String key = baseKey + "/owner.txt";
+		
+		s3Client.putObject(storageLocation.getBucket(), key, new StringInputStream(ownerContent), metadata);
+		
+		waitForS3Object(storageLocation.getBucket(), key);
+		
+		return storageLocation;
+		
+	}
+	
+	private UserInfo createUser() {
+		NewUser user = new NewUser();
+		
+		String username = UUID.randomUUID().toString();
+		
+		user.setEmail(username + "@test.com");
+		user.setUserName(username);
+		
+		long userId = userManager.createUser(user);
+
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		
+		userInfo.getGroups().add(BOOTSTRAP_PRINCIPAL.CERTIFIED_USERS.getPrincipalId());
+		userInfo.getGroups().add(TEST_TEAM_ID);
+
+		return userInfo;
+	}
+	
+	private void waitForS3Object(String bucket, String key) throws InterruptedException {
+		long start = System.currentTimeMillis();
+		while(!s3Client.doesObjectExist(bucket, key)) {
+			if (System.currentTimeMillis() - start > 60 * 1000) {
+				throw new IllegalStateException("Timed out while waiting for S3 object: " + bucket + "/" + key);
+			}
+			Thread.sleep(1000);
+		}
 	}
 	
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/AdministrationController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/AdministrationController.java
@@ -274,9 +274,9 @@ public class AdministrationController {
 	 * Changes the verified status of the OAuth client with the provided id. Only an administrator or a member of the ACT team can perform this operation.
 	 * 
 	 * @param userId
-	 * @param clientId
-	 * @param etag
-	 * @param status
+	 * @param clientId The id of the client to verify
+	 * @param etag The etag of the client, this must match the current etag of the client
+	 * @param status The verified status to change to, default true
 	 * @return
 	 * @throws NotFoundException
 	 * @throws UnauthorizedException
@@ -286,7 +286,7 @@ public class AdministrationController {
 	public @ResponseBody OAuthClient updateOAuthClientVerifiedStatus(@RequestParam(value = AuthorizationConstants.USER_ID_PARAM) Long userId,
 			@PathVariable String clientId,
 			@RequestParam(defaultValue = "true") Boolean status,
-			@RequestParam String etag)
+			@RequestParam(required = true) String etag)
 			throws NotFoundException, UnauthorizedException {
 		return serviceProvider.getOpenIDConnectService().updateOpenIDConnectClientVerifiedStatus(userId, clientId, etag, status);
 	}


### PR DESCRIPTION
Allows the owner.txt to contain as a valid identifier:

- id of the user (new)
- id of a team the user is part of (new)
- username
- email

Note: I added the id in place of the team name since the name can be changed and reused
