### PR TITLE
Use only needed AWS modules

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -8,7 +8,6 @@
     <version>develop-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.sagebionetworks</groupId>
   <artifactId>client</artifactId>
   <packaging>pom</packaging>
   <name>Platform Clients</name>

--- a/client/sample-code/pom.xml
+++ b/client/sample-code/pom.xml
@@ -23,5 +23,9 @@
 			<groupId>org.sagebionetworks</groupId>
 			<artifactId>synapseJavaClient</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-s3</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/client/synapseJavaClient/pom.xml
+++ b/client/synapseJavaClient/pom.xml
@@ -10,7 +10,6 @@
 		<version>develop-SNAPSHOT</version>
 	</parent>
 
-	<groupId>org.sagebionetworks</groupId>
 	<artifactId>synapseJavaClient</artifactId>
 	<packaging>jar</packaging>
 	<name>synapseJavaClient</name>

--- a/lib/communicationUtilities/pom.xml
+++ b/lib/communicationUtilities/pom.xml
@@ -10,10 +10,8 @@
 		<version>develop-SNAPSHOT</version>
 	</parent>
 
-	<groupId>org.sagebionetworks</groupId>
 	<artifactId>lib-communicationUtilities</artifactId>
 	<name>lib-communicationUtilities</name>
-	<version>develop-SNAPSHOT</version>
 	<url>http://maven.apache.org</url>
 
 	<dependencies>
@@ -22,12 +20,6 @@
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>

--- a/lib/communicationUtilities/src/main/java/org/sagebionetworks/utils/ContentTypeUtil.java
+++ b/lib/communicationUtilities/src/main/java/org/sagebionetworks/utils/ContentTypeUtil.java
@@ -5,8 +5,6 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.http.entity.ContentType;
 
-import com.amazonaws.services.s3.model.S3Object;
-
 public class ContentTypeUtil {
 	public static final ContentType TEXT_PLAIN_UTF8 = ContentType.create("text/plain", StandardCharsets.UTF_8);
 	public static final ContentType TEXT_HTML_UTF8 = ContentType.create("text/html", StandardCharsets.UTF_8);
@@ -19,11 +17,6 @@ public class ContentTypeUtil {
 	public static Charset getCharsetFromContentTypeString(String contentTypeString) {
 		ContentType contentType = contentTypeString==null ? null : ContentType.parse(contentTypeString);
 		return contentType==null ? null : contentType.getCharset();
-	}
-	
-	public static Charset getCharsetFromS3Object(S3Object s3Object) {
-		String contentTypeString = s3Object.getObjectMetadata().getContentType();
-		return getCharsetFromContentTypeString(contentTypeString);
 	}
 
 }

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/wikiV2/V2DBOWikiPageDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/wikiV2/V2DBOWikiPageDaoImpl.java
@@ -519,12 +519,10 @@ public class V2DBOWikiPageDaoImpl implements V2WikiPageDao {
 		V2WikiPage wiki = get(key, version);
 		S3FileHandle markdownHandle = (S3FileHandle) fileMetadataDao.get(wiki.getMarkdownFileHandleId());
 		S3Object s3Object = s3Client.getObject(markdownHandle.getBucketName(), markdownHandle.getKey());
-		InputStream in = s3Object.getObjectContent();
-		Charset charset = ContentTypeUtil.getCharsetFromS3Object(s3Object);
-		try{
+		String contentType = s3Object.getObjectMetadata().getContentType();
+		Charset charset = ContentTypeUtil.getCharsetFromContentTypeString(contentType);
+		try (InputStream in = s3Object.getObjectContent()) {
 			return FileUtils.readStreamAsString(in, charset, /*gunzip*/true);
-		}finally{
-			in.close();
 		}
 	}
 	
@@ -841,8 +839,7 @@ public class V2DBOWikiPageDaoImpl implements V2WikiPageDao {
 			throw new IllegalArgumentException("Etag cannot be null.");
 		}
 		String wikiId = key.getWikiPageId();
-		int ra = jdbcTemplate.update(SQL_UPDATE_WIKI_ETAG, etag, wikiId);
-		return;
+		jdbcTemplate.update(SQL_UPDATE_WIKI_ETAG, etag, wikiId);
 	}
 
 	@Override

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/asynch/AsynchJobTypeTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/asynch/AsynchJobTypeTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.StringWriter;
 
-import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import org.junit.Test;
 import org.sagebionetworks.repo.model.file.BulkFileDownloadRequest;
 import org.sagebionetworks.repo.model.file.BulkFileDownloadResponse;

--- a/lib/lib-audit/pom.xml
+++ b/lib/lib-audit/pom.xml
@@ -47,11 +47,6 @@
 			<artifactId>spring-context</artifactId>
 		</dependency>		
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
 			<scope>test</scope>

--- a/lib/lib-javaclient/pom.xml
+++ b/lib/lib-javaclient/pom.xml
@@ -65,11 +65,6 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/lib/lib-search/pom.xml
+++ b/lib/lib-search/pom.xml
@@ -32,13 +32,6 @@
 			<groupId>org.sagebionetworks</groupId>
 			<artifactId>schema-to-pojo-org-json</artifactId>
 		</dependency>
-
-		<!-- All of the AWS clients -->
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>org.sagebionetworks</groupId>
 			<artifactId>simple-http-client</artifactId>

--- a/lib/lib-shared-models/pom.xml
+++ b/lib/lib-shared-models/pom.xml
@@ -6,9 +6,7 @@
 		<groupId>org.sagebionetworks</groupId>
 		<version>develop-SNAPSHOT</version>
 	</parent>
-	<groupId>org.sagebionetworks</groupId>
 	<artifactId>lib-shared-models</artifactId>
-	<version>develop-SNAPSHOT</version>
 	<name>lib-shared-models</name>
 	<description>These model objects are shared between the client and server.  Only GWT compatible models should exist in this project</description>
 

--- a/lib/lib-table-cluster/pom.xml
+++ b/lib/lib-table-cluster/pom.xml
@@ -114,11 +114,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
 			<version>20040616</version>

--- a/lib/lib-table-cluster/src/main/java/org/sagebionetworks/table/cluster/columntranslation/ColumnTranslationReferenceLookup.java
+++ b/lib/lib-table-cluster/src/main/java/org/sagebionetworks/table/cluster/columntranslation/ColumnTranslationReferenceLookup.java
@@ -6,11 +6,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.amazonaws.services.apigateway.model.Op;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 

--- a/lib/lib-test/pom.xml
+++ b/lib/lib-test/pom.xml
@@ -67,11 +67,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
 			<scope>compile</scope>

--- a/lib/lib-worker/pom.xml
+++ b/lib/lib-worker/pom.xml
@@ -46,10 +46,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-		</dependency>
 		<!-- Spring Framework dependencies -->
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/lib/logging/pom.xml
+++ b/lib/logging/pom.xml
@@ -55,11 +55,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>

--- a/lib/stackConfiguration/pom.xml
+++ b/lib/stackConfiguration/pom.xml
@@ -11,10 +11,8 @@
 		<version>develop-SNAPSHOT</version>
 	</parent>
 
-	<groupId>org.sagebionetworks</groupId>
 	<artifactId>lib-stackConfiguration</artifactId>
 	<name>stackConfiguration</name>
-	<version>develop-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<dependencies>
@@ -94,11 +92,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 			<scope>runtime</scope>
@@ -114,7 +107,56 @@
 			<artifactId>commons-collections4</artifactId>
 			<type>jar</type>
 		</dependency>
-
+		
+		<!-- Amazon AWS Dependencies -->
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-secretsmanager</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-kms</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-sns</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-sqs</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-ses</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-s3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-athena</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-cloudsearch</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-glue</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-kinesis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-cloudwatch</artifactId>
+		</dependency>		
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-sts</artifactId>
+		</dependency>
 	</dependencies>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -372,12 +372,6 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.amazonaws</groupId>
-				<artifactId>aws-java-sdk</artifactId>
-				<version>${com.amazonaws.version}</version>
-			</dependency>
-
-			<dependency>
 				<groupId>com.google.cloud</groupId>
 				<artifactId>google-cloud-storage</artifactId>
 				<version>${com.google.cloud.version}</version>
@@ -610,12 +604,12 @@
 			<dependency>
 				<groupId>org.sagebionetworks</groupId>
 				<artifactId>worker-utilities</artifactId>
-				<version>1.1.3</version>
+				<version>1.1.4</version>
 			</dependency>
 			<dependency>
 				<groupId>org.sagebionetworks</groupId>
 				<artifactId>aws-utilities</artifactId>
-				<version>1.0.11</version>
+				<version>1.0.12</version>
 			</dependency>
 			<dependency>
 				<groupId>org.sagebionetworks</groupId>
@@ -718,6 +712,15 @@
 				<artifactId>commons-dbcp2</artifactId>
 				<version>2.6.0</version>
 			</dependency>
+			
+			<!-- Import the BOM for AWS sdk dependencies -->
+			<dependency>
+		      <groupId>com.amazonaws</groupId>
+		      <artifactId>aws-java-sdk-bom</artifactId>
+		      <version>${com.amazonaws.version}</version>
+		      <type>pom</type>
+		      <scope>import</scope>
+		    </dependency>
 
 		</dependencies>
 
@@ -992,7 +995,7 @@
 		<org.aspectj.aspectjlib.version>1.6.2</org.aspectj.aspectjlib.version>
 		<org.aspectj.version>1.8.11</org.aspectj.version>
 		<schema-to-pojo.version>0.4.1</schema-to-pojo.version>
-		<com.amazonaws.version>1.11.535</com.amazonaws.version>
+		<com.amazonaws.version>1.11.751</com.amazonaws.version>
 		<findbugs-maven-plugin.version>2.5.2</findbugs-maven-plugin.version>
 		<org.apache.httpcomponents.version>4.5.7</org.apache.httpcomponents.version>
 		<com.sun.tools.version>1.7</com.sun.tools.version>

--- a/services/repository-managers/pom.xml
+++ b/services/repository-managers/pom.xml
@@ -157,11 +157,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.quartz-scheduler</groupId>
 			<artifactId>quartz</artifactId>
 		</dependency>

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/StubAmazonSimpleEmailServiceClient.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/StubAmazonSimpleEmailServiceClient.java
@@ -542,5 +542,12 @@ public class StubAmazonSimpleEmailServiceClient implements AmazonSimpleEmailServ
 		// TODO Auto-generated method stub
 		return null;
 	}
+
+	@Override
+	public PutConfigurationSetDeliveryOptionsResult putConfigurationSetDeliveryOptions(
+			PutConfigurationSetDeliveryOptionsRequest putConfigurationSetDeliveryOptionsRequest) {
+		// TODO Auto-generated method stub
+		return null;
+	}
 	
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/WikiModelTranslationHelper.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/WikiModelTranslationHelper.java
@@ -151,15 +151,14 @@ public class WikiModelTranslationHelper implements WikiModelTranslator {
 		S3FileHandle markdownHandle = (S3FileHandle) fileMetadataDao.get(from.getMarkdownFileHandleId());
 		// Retrieve uploaded markdown
 		S3Object s3Object = s3Client.getObject(markdownHandle.getBucketName(), markdownHandle.getKey());
-		Charset charset = ContentTypeUtil.getCharsetFromS3Object(s3Object);
-		InputStream in = s3Object.getObjectContent();
-		try{
+		String contentTypeString = s3Object.getObjectMetadata().getContentType();
+		Charset charset = ContentTypeUtil.getCharsetFromContentTypeString(contentTypeString);
+		
+		try (InputStream in = s3Object.getObjectContent()) {
 			// Read the file as a string
 			String markdownString = FileUtils.readStreamAsString(in, charset, /*gunzip*/true);
 			wiki.setMarkdown(markdownString);
 			return wiki;
-		}finally{
-			in.close();
 		}
 
 	}

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/WikiModelTranslationHelperTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/WikiModelTranslationHelperTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 import org.sagebionetworks.aws.SynapseS3Client;
 import org.sagebionetworks.downloadtools.FileUtils;
 import org.sagebionetworks.repo.manager.UserManager;
-import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.UserInfo;
@@ -31,8 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.amazonaws.services.s3.model.S3Object;
 
 public class WikiModelTranslationHelperTest extends AbstractAutowiredControllerTestBase {
-	@Autowired
-	private FileHandleManager fileHandleManager;
 	
 	@Autowired
 	private FileHandleDao fileMetadataDao;	
@@ -105,13 +102,12 @@ public class WikiModelTranslationHelperTest extends AbstractAutowiredControllerT
 		File markdownTemp = tempFileProvider.createTempFile(wiki.getId()+ "_markdown", ".tmp");
 		// Retrieve uploaded markdown
 		S3Object s3Object = s3Client.getObject(markdownHandle.getBucketName(), markdownHandle.getKey());
-		Charset charset = ContentTypeUtil.getCharsetFromS3Object(s3Object);
-		InputStream in = s3Object.getObjectContent();
+		String contentType = s3Object.getObjectMetadata().getContentType();
+		Charset charset = ContentTypeUtil.getCharsetFromContentTypeString(contentType);
 		String markdownString = null;
-		try{
+		
+		try (InputStream in = s3Object.getObjectContent()) {
 			markdownString = FileUtils.readStreamAsString(in, charset, /*gunzip*/true);
-		}finally{
-			in.close();
 		}
 		// Make sure uploaded markdown is accurate
 		assertEquals(markdownAsString, markdownString);
@@ -142,14 +138,13 @@ public class WikiModelTranslationHelperTest extends AbstractAutowiredControllerT
 		tempFileProvider.createTempFile(wiki.getId()+ "_markdown", ".tmp");
 		// Retrieve uploaded markdown
 		S3Object s3Object = s3Client.getObject(markdownHandle.getBucketName(), markdownHandle.getKey());
-		Charset charset = ContentTypeUtil.getCharsetFromS3Object(s3Object);
-		InputStream in = s3Object.getObjectContent();
+		String contentType = s3Object.getObjectMetadata().getContentType();
+		Charset charset = ContentTypeUtil.getCharsetFromContentTypeString(contentType);
 		String markdownString = null;
-		try{
+		try (InputStream in = s3Object.getObjectContent()) {
 			markdownString = FileUtils.readStreamAsString(in, charset, /*gunzip*/true);
-		}finally{
-			in.close();
 		}
+		
 		assertEquals("", markdownString);
 	}
 }

--- a/services/workers/pom.xml
+++ b/services/workers/pom.xml
@@ -42,11 +42,6 @@
 			<artifactId>lib-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-		</dependency>
 		<!-- Spring Framework dependencies -->
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/services/workers/src/test/java/org/sagebionetworks/message/workers/BroadcastMessageWorkerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/message/workers/BroadcastMessageWorkerTest.java
@@ -7,14 +7,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.mq.model.User;
 import org.apache.http.client.ClientProtocolException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.common.util.progress.ProgressCallback;
 import org.sagebionetworks.markdown.MarkdownClientException;
@@ -26,7 +24,6 @@ import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.message.ChangeMessage;
 import org.sagebionetworks.repo.model.message.ChangeType;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BroadcastMessageWorkerTest {


### PR DESCRIPTION
Instead of importing the whole AWS sdk only import what's needed (https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-project-maven.html#configuring-maven-individual-components). The AWS sdk BOM is in the root pom.xml so that dependencies can be managed. The result is that the deployed file size is reduced of about 60%.

This PR depends on two other components:

https://github.com/Sage-Bionetworks/aws-utilities/pull/16
https://github.com/Sage-Bionetworks/worker-utilities/pull/39