### PR TITLE
Apache httpclient version updated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -997,7 +997,7 @@
 		<schema-to-pojo.version>0.4.1</schema-to-pojo.version>
 		<com.amazonaws.version>1.11.751</com.amazonaws.version>
 		<findbugs-maven-plugin.version>2.5.2</findbugs-maven-plugin.version>
-		<org.apache.httpcomponents.version>4.5.7</org.apache.httpcomponents.version>
+		<org.apache.httpcomponents.version>4.5.9</org.apache.httpcomponents.version>
 		<com.sun.tools.version>1.7</com.sun.tools.version>
 		<org.apache.pivot.version>2.0.1</org.apache.pivot.version>
 		<log4j.version>2.6.1</log4j.version>


### PR DESCRIPTION
Updates the version of httpclient to avoid warnings that started showing up in the build:

NoSuchMethodException was thrown when disabling normalizeUri. This indicates you are using an old version (< 4.5.8) of Apache http client. It is recommended to use http client version >= 4.5.9 to avoid the breaking change introduced in apache client 4.5.7 and the latency in exception handling. See https://github.com/aws/aws-sdk-java/issues/1919 for more information