### PR TITLE
STS docs changes; block access to owner.txt

### DIFF
--- a/services/repository-managers/src/main/resources/sts-policy-template.json
+++ b/services/repository-managers/src/main/resources/sts-policy-template.json
@@ -25,6 +25,12 @@
 				"arn:aws:s3:::${bucketWithFolder}",
 				"arn:aws:s3:::${bucketWithFolder}/*"
 			]
+		},
+		{
+			"Sid": "DenyOwnerTxt",
+			"Effect": "Deny",
+			"Action": ["*"],
+			"Resource": ["arn:aws:s3:::${bucketWithFolder}/owner.txt"]
 		}
 	]
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/EntityController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/EntityController.java
@@ -1523,7 +1523,7 @@ public class EntityController {
 	 * </p>
 	 *
 	 * @param id         The ID of the entity to get credentials. This must be a folder with an STS-enabled storage location.
-	 * @param permission Read-only or read-write permissions. See {@link org.sagebionetworks.repo.model.sts.StsPermission}.
+	 * @param permission Read-only or read-write permissions. See <a href="${org.sagebionetworks.repo.model.sts.StsPermission}">StsPermission</a>.
 	 */
 	@RequiredScope({ view, modify, download })
 	@ResponseStatus(HttpStatus.OK)


### PR DESCRIPTION
Changes for
* https://sagebionetworks.jira.com/browse/PLFM-6208 - API doc's for STS services need add'l descriptions
* https://sagebionetworks.jira.com/browse/PLFM-6279 - STS API should not allow write access to owner.txt

I was considering which permissions I should deny for owner.txt. Then I decided there probably wasn't really a use case for accessing owner.txt, so I just denied all permissions to owner.txt.