### PR TITLE
PLFM-6413: Gets rid of profiles in worker tests

### DIFF
--- a/services/workers/src/test/java/org/sagebionetworks/dataaccess/workers/AccessApprovalExpirationWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/dataaccess/workers/AccessApprovalExpirationWorkerIntegrationTest.java
@@ -18,13 +18,11 @@ import org.sagebionetworks.repo.model.feature.Feature;
 import org.sagebionetworks.util.Pair;
 import org.sagebionetworks.util.TimeUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {"classpath:test-context.xml"})
-@ActiveProfiles("test-dataaccess-worker")
 public class AccessApprovalExpirationWorkerIntegrationTest {
 	
 	private static final long WORKER_TIMEOUT = 60 * 1000;

--- a/services/workers/src/test/java/org/sagebionetworks/dataaccess/workers/AccessApprovalRevokedNotificationWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/dataaccess/workers/AccessApprovalRevokedNotificationWorkerIntegrationTest.java
@@ -4,9 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,11 +12,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sagebionetworks.repo.manager.UserManager;
+import org.sagebionetworks.repo.manager.dataaccess.AccessApprovalNotificationManager;
 import org.sagebionetworks.repo.model.AccessApproval;
 import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.repo.model.ApprovalState;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
-import org.sagebionetworks.repo.model.MessageDAO;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.NewUser;
 import org.sagebionetworks.repo.model.dbo.dao.dataaccess.DBODataAccessNotification;
@@ -27,18 +24,15 @@ import org.sagebionetworks.repo.model.dbo.dao.dataaccess.DataAccessNotificationD
 import org.sagebionetworks.repo.model.dbo.dao.dataaccess.DataAccessNotificationType;
 import org.sagebionetworks.repo.model.dbo.feature.FeatureStatusDao;
 import org.sagebionetworks.repo.model.feature.Feature;
-import org.sagebionetworks.repo.model.message.MessageToUser;
 import org.sagebionetworks.util.Pair;
 import org.sagebionetworks.util.TimeUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {"classpath:test-context.xml"})
-@ActiveProfiles("test-dataaccess-worker")
 public class AccessApprovalRevokedNotificationWorkerIntegrationTest {
 
 	private static final long WORKER_TIMEOUT = 3 * 60 * 1000;
@@ -53,14 +47,10 @@ public class AccessApprovalRevokedNotificationWorkerIntegrationTest {
 	private DataAccessNotificationDao notificationDao;
 	
 	@Autowired
-	private MessageDAO messageDao;
-	
-	@Autowired
 	private DataAccessTestHelper testHelper;
 	
 	private UserInfo adminUser;
 	private UserInfo user;
-	private List<String> messages;
 	
 	@BeforeEach
 	public void before() {
@@ -78,7 +68,6 @@ public class AccessApprovalRevokedNotificationWorkerIntegrationTest {
 		// Enabled the features for testing, we need both the auto revocation and the notification workers running
 		featureStatusDao.setFeatureEnabled(Feature.DATA_ACCESS_AUTO_REVOCATION, true);
 		featureStatusDao.setFeatureEnabled(Feature.DATA_ACCESS_NOTIFICATIONS, true);
-		messages = new ArrayList<>();
 	}
 	
 	@AfterEach
@@ -86,7 +75,6 @@ public class AccessApprovalRevokedNotificationWorkerIntegrationTest {
 		notificationDao.clear();
 		featureStatusDao.clear();
 		testHelper.cleanUp();
-		messages.forEach(id -> messageDao.deleteMessage(id));
 		userManager.deletePrincipal(adminUser, user.getId());
 	}
 	
@@ -100,23 +88,15 @@ public class AccessApprovalRevokedNotificationWorkerIntegrationTest {
 		TimeUtils.waitFor(WORKER_TIMEOUT, 1000L, () -> {
 			Optional<DBODataAccessNotification> result = notificationDao.find(DataAccessNotificationType.REVOCATION, ap.getRequirementId(), user.getId());
 			
-			if (!result.isPresent()) { 
-				return new Pair<>(false, null); 
-			}
+			result.ifPresent(notification -> {
+				assertEquals(ar.getId(), notification.getRequirementId());
+				assertEquals(ap.getId(), notification.getAccessApprovalId());
+				assertEquals(user.getId(), notification.getRecipientId());
+				// Makes sure that it didn't actually send a message
+				assertEquals(AccessApprovalNotificationManager.NO_MESSAGE_TO_USER, notification.getMessageId());
+			});
 			
-			// Verify that the message to user was created for the user (the workers are setup to act as prod so that
-			// the message is created and processed: no email is actually delivered)
-			Long messageId = result.get().getMessageId();
-
-			MessageToUser message = messageDao.getMessage(messageId.toString());
-		
-			messages.add(message.getId());
-			
-			assertEquals(message.getCreatedBy(), BOOTSTRAP_PRINCIPAL.DATA_ACCESS_NOTFICATIONS_SENDER.getPrincipalId().toString());
-			assertEquals(message.getRecipients(), Collections.singleton(user.getId().toString()));
-			
-			// Wait till the message is processed
-			return new Pair<>(messageDao.getMessageSent(message.getId()), null);
+			return new Pair<>(result.isPresent(), null);
 		});
 		
 	}

--- a/services/workers/src/test/java/org/sagebionetworks/replication/workers/ObjectReplicationReconciliationWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/replication/workers/ObjectReplicationReconciliationWorkerIntegrationTest.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -33,7 +32,6 @@ import org.sagebionetworks.repo.model.table.ViewScope;
 import org.sagebionetworks.table.cluster.ConnectionFactory;
 import org.sagebionetworks.table.cluster.TableIndexDAO;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -41,7 +39,6 @@ import com.google.common.collect.Lists;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
-@ActiveProfiles("test-reconciliation-workers")
 public class ObjectReplicationReconciliationWorkerIntegrationTest {
 	
 	private static final int MAX_WAIT_MS = 2* 60 *1000;
@@ -94,7 +91,6 @@ public class ObjectReplicationReconciliationWorkerIntegrationTest {
 		}
 	}
 	
-	@Disabled // see PLFM-6410
 	@Test
 	public void testReconciliation() throws Exception{
 		// Add a folder to the project
@@ -123,7 +119,6 @@ public class ObjectReplicationReconciliationWorkerIntegrationTest {
 	 * 
 	 * @throws InterruptedException
 	 */
-	@Disabled // see PLFM-6410
 	@Test
 	public void testPLFM_5352() throws InterruptedException {
 		// Add a folder to the project

--- a/services/workers/src/test/java/org/sagebionetworks/replication/workers/ObjectReplicationWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/replication/workers/ObjectReplicationWorkerIntegrationTest.java
@@ -21,13 +21,11 @@ import org.sagebionetworks.repo.model.table.ViewObjectType;
 import org.sagebionetworks.table.cluster.ConnectionFactory;
 import org.sagebionetworks.table.cluster.TableIndexDAO;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
-@ActiveProfiles("test-replication-workers")
 public class ObjectReplicationWorkerIntegrationTest {
 	
 	private static final int MAX_WAIT_MS = 2* 60 *1000;

--- a/services/workers/src/test/java/org/sagebionetworks/replication/workers/SubmissionReplicationIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/replication/workers/SubmissionReplicationIntegrationTest.java
@@ -32,13 +32,11 @@ import org.sagebionetworks.repo.model.table.ObjectDataDTO;
 import org.sagebionetworks.repo.model.table.ViewObjectType;
 import org.sagebionetworks.worker.TestHelper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
-@ActiveProfiles("test-replication-workers")
 public class SubmissionReplicationIntegrationTest {
 	
 	private static final int MAX_WAIT = 2 * 60 * 1000;

--- a/services/workers/src/test/java/org/sagebionetworks/table/worker/SubmissionViewIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/table/worker/SubmissionViewIntegrationTest.java
@@ -57,7 +57,6 @@ import org.sagebionetworks.table.cluster.TableIndexDAO;
 import org.sagebionetworks.table.cluster.utils.TableModelUtils;
 import org.sagebionetworks.worker.TestHelper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -66,7 +65,6 @@ import com.google.common.collect.ImmutableMap;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
-@ActiveProfiles("test-view-workers")
 public class SubmissionViewIntegrationTest {
 
 	private static final int MAX_WAIT = 2 * 60 * 1000;

--- a/services/workers/src/test/java/org/sagebionetworks/table/worker/TableViewIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/table/worker/TableViewIntegrationTest.java
@@ -100,7 +100,6 @@ import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.table.cluster.ConnectionFactory;
 import org.sagebionetworks.table.cluster.TableIndexDAO;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -109,7 +108,6 @@ import com.google.common.collect.Sets;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
-@ActiveProfiles("test-view-workers")
 public class TableViewIntegrationTest {
 	
 	public static final int MAX_WAIT_MS = 1000 * 60 * 3;

--- a/services/workers/src/test/java/org/sagebionetworks/table/worker/ViewColumnModelRequestWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/table/worker/ViewColumnModelRequestWorkerIntegrationTest.java
@@ -32,7 +32,6 @@ import org.sagebionetworks.repo.model.table.ViewObjectType;
 import org.sagebionetworks.repo.model.table.ViewScope;
 import org.sagebionetworks.worker.TestHelper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -40,7 +39,6 @@ import com.google.common.collect.ImmutableList;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
-@ActiveProfiles("test-view-column-model-request-worker")
 public class ViewColumnModelRequestWorkerIntegrationTest {
 	
 	private static final int MAX_WAIT = 2 * 60 * 1000;

--- a/services/workers/src/test/resources/test-context.xml
+++ b/services/workers/src/test/resources/test-context.xml
@@ -35,65 +35,6 @@
 
 	<bean id="testHelper" class="org.sagebionetworks.worker.TestHelper"/>
 	
-	<!-- Profile with a subset of workers for views (Use with @ActiveProfiles("test-view-workers") -->
-	<beans profile="test-view-workers">
-		<util:list id="workerTriggersList">
-			<ref bean="tableTransactionMessageTrigger" />
-			<ref bean="tableQueryQueueMessageReveiverTrigger" />
-			<ref bean="tableQueryNextPageQueueMessageReveiverTrigger" />
-			<!-- workers publish messages too -->
-			<ref bean="messagePublisherTrigger" />
-			<ref bean="tableViewWorkerTrigger" />
-			<ref bean="objectReplicationWorkerTrigger" />
-			<ref bean="objectReplicationReconciliationWorkerTrigger" />
-			<ref bean="entityHierarchyChangeWorkerTrigger" />
-		</util:list>
-	</beans>
+	<bean id="dataAccessTestHelper" class="org.sagebionetworks.dataaccess.workers.DataAccessTestHelper"/>
 	
-	<!-- Profile with a subset of workers for replication only (Use with @ActiveProfiles("test-replication-workers") -->
-	<beans profile="test-replication-workers">
-		<util:list id="workerTriggersList">
-			<!-- workers publish messages too -->
-			<ref bean="messagePublisherTrigger" />
-			<ref bean="objectReplicationWorkerTrigger" />
-		</util:list>
-	</beans>
-	
-	<!-- Profile with a subset of workers for reconciliation only (Use with @ActiveProfiles("test-reconciliation-workers") -->
-	<beans profile="test-reconciliation-workers">
-		<util:list id="workerTriggersList">
-			<!-- workers publish messages too -->
-			<ref bean="messagePublisherTrigger" />
-			<ref bean="tableViewWorkerTrigger" />
-			<ref bean="objectReplicationWorkerTrigger" />
-			<ref bean="objectReplicationReconciliationWorkerTrigger" />
-			<ref bean="entityHierarchyChangeWorkerTrigger" />
-		</util:list>
-	</beans>
-	
-	<!-- Profile with a subset of workers for ViewColumnModelRequestWorkerTrigger only (Use with @ActiveProfiles("test-view-column-model-request-worker") -->
-	<beans profile="test-view-column-model-request-worker">
-		<util:list id="workerTriggersList">
-			<ref bean="messagePublisherTrigger" />
-			<ref bean="objectReplicationWorkerTrigger" />
-			<ref bean="viewColumnModelRequestWorkerTrigger" />
-		</util:list>
-	</beans>
-	
-	<!-- Profile with a subset of workers for data access workers only (Use with @ActiveProfiles("test-dataaccess-worker") -->
-	<beans profile="test-dataaccess-worker">
-		<util:list id="workerTriggersList">
-			<ref bean="messagePublisherTrigger" />
-			<ref bean="accessApprovalExpirationTrigger"/>
-			<ref bean="accessApprovalRevokedNotificationTrigger"/>
-			<ref bean="accessApprovalReminderNotificationWorkerTrigger"/>
-			<ref bean="messageToUserQueueMessageReceiverTrigger"/>
-		</util:list>
-		<!-- We want to simulate the email sending (no email go out) so this must be prod -->
-		<bean id="prodDetector" class="org.sagebionetworks.repo.manager.testing.StubProdDetector">
-			<constructor-arg value="true" />
-		</bean>
-		
-		<bean id="dataAccessTestHelper" class="org.sagebionetworks.dataaccess.workers.DataAccessTestHelper"/>
-	</beans>
 </beans>


### PR DESCRIPTION
Removed the profiles as I discovered that they might lead to leaks of schedulers.