### PR TITLE
Multipart manager refactoring

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/MultipartManagerV2Impl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/MultipartManagerV2Impl.java
@@ -98,7 +98,7 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 		return startOrResumeMultipartRequest(handler, user, request, forceRestart);
 	}
 	
-	private <T extends MultipartRequest> MultipartUploadStatus startOrResumeMultipartRequest(MultipartRequestHandler<T> handler, UserInfo user, T request, boolean forceRestart) {
+	<T extends MultipartRequest> MultipartUploadStatus startOrResumeMultipartRequest(MultipartRequestHandler<T> handler, UserInfo user, T request, boolean forceRestart) {
 		
 		// Common validation of the request
 		validateMultipartRequest(user, request);
@@ -214,7 +214,7 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 
 			final Long partNumber = partNumbers.get(i);
 
-			ValidateArgument.required(partNumber, "PartNumber cannot be null");
+			ValidateArgument.required(partNumber, "PartNumber");
 
 			validatePartNumber(partNumber.intValue(), numberOfParts);
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/MultipartManagerV2Impl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/MultipartManagerV2Impl.java
@@ -6,11 +6,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.sagebionetworks.ids.IdGenerator;
 import org.sagebionetworks.ids.IdType;
 import org.sagebionetworks.repo.manager.ProjectSettingsManager;
+import org.sagebionetworks.repo.manager.file.multipart.FileHandleCreateRequest;
+import org.sagebionetworks.repo.manager.file.multipart.MultipartRequestHandler;
+import org.sagebionetworks.repo.manager.file.multipart.MultipartRequestHandlerProvider;
 import org.sagebionetworks.repo.model.AuthorizationUtils;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
@@ -19,15 +21,12 @@ import org.sagebionetworks.repo.model.dbo.file.CompositeMultipartUploadStatus;
 import org.sagebionetworks.repo.model.dbo.file.CreateMultipartRequest;
 import org.sagebionetworks.repo.model.dbo.file.MultipartRequestUtils;
 import org.sagebionetworks.repo.model.dbo.file.MultipartUploadDAO;
-import org.sagebionetworks.repo.model.file.AddPartRequest;
 import org.sagebionetworks.repo.model.file.AddPartResponse;
 import org.sagebionetworks.repo.model.file.AddPartState;
 import org.sagebionetworks.repo.model.file.BatchPresignedUploadUrlRequest;
 import org.sagebionetworks.repo.model.file.BatchPresignedUploadUrlResponse;
 import org.sagebionetworks.repo.model.file.CloudProviderFileHandleInterface;
 import org.sagebionetworks.repo.model.file.CompleteMultipartRequest;
-import org.sagebionetworks.repo.model.file.FileHandle;
-import org.sagebionetworks.repo.model.file.FileHandleAssociation;
 import org.sagebionetworks.repo.model.file.GoogleCloudFileHandle;
 import org.sagebionetworks.repo.model.file.MultipartRequest;
 import org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest;
@@ -39,12 +38,10 @@ import org.sagebionetworks.repo.model.file.PartPresignedUrl;
 import org.sagebionetworks.repo.model.file.PartUtils;
 import org.sagebionetworks.repo.model.file.S3FileHandle;
 import org.sagebionetworks.repo.model.file.UploadType;
-import org.sagebionetworks.repo.model.jdo.NameValidation;
 import org.sagebionetworks.repo.model.project.StorageLocationSetting;
 import org.sagebionetworks.repo.transactions.WriteTransaction;
 import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAO;
 import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAOProvider;
-import org.sagebionetworks.upload.multipart.MultipartUploadUtils;
 import org.sagebionetworks.upload.multipart.PresignedUrl;
 import org.sagebionetworks.util.ValidateArgument;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,9 +49,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class MultipartManagerV2Impl implements MultipartManagerV2 {
-
-	@Autowired
-	private CloudServiceMultipartUploadDAOProvider cloudServiceMultipartUploadDAOProvider;
 
 	@Autowired
 	private MultipartUploadDAO multipartUploadDAO;
@@ -69,8 +63,10 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 	private IdGenerator idGenerator;
 	
 	@Autowired
-	private FileHandleAuthorizationManager authManager;
+	private CloudServiceMultipartUploadDAOProvider cloudDaoProvider;
 	
+	@Autowired
+	private MultipartRequestHandlerProvider handlerProvider;
 
 	@Override
 	@WriteTransaction
@@ -89,19 +85,26 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 	@Override
 	@WriteTransaction
 	public MultipartUploadStatus startOrResumeMultipartUpload(UserInfo user, MultipartUploadRequest request, boolean forceRestart) {
-		return startOrResumeMultipartRequest(user, request, forceRestart, this::validateMultipartUpload, this::createNewMultipartUpload);
+		MultipartRequestHandler<MultipartUploadRequest> handler = handlerProvider.getHandlerForClass(MultipartUploadRequest.class);
+		
+		return startOrResumeMultipartRequest(handler, user, request, forceRestart);
 	}
 	
 	@Override
 	@WriteTransaction
 	public MultipartUploadStatus startOrResumeMultipartUploadCopy(UserInfo user, MultipartUploadCopyRequest request, boolean forceRestart) {
-		return startOrResumeMultipartRequest(user, request, forceRestart, this::validateMultipartUploadCopy, this::createNewMultipartUploadCopy);
+		MultipartRequestHandler<MultipartUploadCopyRequest> handler = handlerProvider.getHandlerForClass(MultipartUploadCopyRequest.class);
+		
+		return startOrResumeMultipartRequest(handler, user, request, forceRestart);
 	}
 	
-	private <T extends MultipartRequest> MultipartUploadStatus startOrResumeMultipartRequest(UserInfo user, T request, boolean forceRestart, MultipartRequestValidator<T> validator, MultipartRequestInitiator<T> initiator) {
+	private <T extends MultipartRequest> MultipartUploadStatus startOrResumeMultipartRequest(MultipartRequestHandler<T> handler, UserInfo user, T request, boolean forceRestart) {
 		
-		validator.validate(user, request);
+		// Common validation of the request
+		validateMultipartRequest(user, request);
 		
+		handler.validateRequest(user, request);
+
 		// The MD5 is used to identify if this upload request already exists for this user.
 		String requestMD5Hex = MultipartRequestUtils.calculateMD5AsHex(request);
 		
@@ -116,9 +119,11 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 		if (status == null) {
 			// This storage location might be null if the request does not specify an id (the id is required for the copy, while it's not for the upload)
 			StorageLocationSetting storageLocation = projectSettingsManager.getStorageLocationSetting(request.getStorageLocationId());
-
+			
 			// Since the status for this file does not exist, create it.
-			status = initiator.initiate(user, request, requestMD5Hex, storageLocation);
+			CreateMultipartRequest createRequest = handler.initiateRequest(user, request, requestMD5Hex, storageLocation);
+			
+			status = multipartUploadDAO.createUploadStatus(createRequest);
 		}
 		
 		// Calculate the parts state for this file.
@@ -144,116 +149,6 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 		if (AuthorizationUtils.isUserAnonymous(user)) {
 			throw new UnauthorizedException("Anonymous cannot upload files.");
 		}
-	}
-	
-	private void validateMultipartUpload(UserInfo user, MultipartUploadRequest request) {
-		validateMultipartRequest(user, request);
-		
-		ValidateArgument.requiredNotEmpty(request.getFileName(), "MultipartUploadRequest.fileName");
-		ValidateArgument.required(request.getFileSizeBytes(), "MultipartUploadRequest.fileSizeBytes");
-		ValidateArgument.requiredNotEmpty(request.getContentMD5Hex(), "MultipartUploadRequest.MD5Hex");
-		PartUtils.validateFileSize(request.getFileSizeBytes());
-
-		//validate file name
-		NameValidation.validateName(request.getFileName());
-	}
-	
-	private void validateMultipartUploadCopy(UserInfo user, MultipartUploadCopyRequest request) {
-		validateMultipartRequest(user, request);
-		
-		ValidateArgument.required(request.getSourceFileHandleAssociation(), "MultipartUploadCopyRequest.sourceFileHandleAssociation");
-		ValidateArgument.required(request.getStorageLocationId(), "MultipartUploadCopyRequest.storageLocationId");
-		
-		if (!StringUtils.isBlank(request.getFileName())) {
-			//validate file name
-			NameValidation.validateName(request.getFileName());
-		}
-	}
-
-	/**
-	 * Create a new multi-part upload both in the cloud service and the database.
-	 * 
-	 * @param user
-	 * @param request
-	 * @param requestHash
-	 * @return
-	 */
-	private CompositeMultipartUploadStatus createNewMultipartUpload(UserInfo user, MultipartUploadRequest request, String requestHash, StorageLocationSetting storageLocation) {
-		UploadType uploadType = storageLocation == null ? UploadType.S3 : storageLocation.getUploadType();
-		
-		// the bucket depends on the upload location used.
-		String bucket = MultipartUtils.getBucket(storageLocation);
-		// create a new key for this file.
-		String key = MultipartUtils.createNewKey(user.getId().toString(), request.getFileName(), storageLocation);
-		
-		String uploadToken = getCloudServiceMultipartDao(uploadType).initiateMultipartUpload(bucket, key, request);
-		
-		String requestJson = MultipartRequestUtils.createRequestJSON(request);
-		// How many parts will be needed to upload this file?
-		int numberParts = PartUtils.calculateNumberOfParts(request.getFileSizeBytes(), request.getPartSizeBytes());
-		// Start the upload
-		return multipartUploadDAO
-				.createUploadStatus(new CreateMultipartRequest(user.getId(),
-						requestHash, requestJson, uploadToken, uploadType,
-						bucket, key, numberParts, request.getPartSizeBytes()));
-	}
-	
-	private CompositeMultipartUploadStatus createNewMultipartUploadCopy(UserInfo user, MultipartUploadCopyRequest request, String requestHash, StorageLocationSetting storageLocation) {
-		UploadType uploadType = storageLocation.getUploadType();
-		
-		FileHandleAssociation association = request.getSourceFileHandleAssociation();
-		
-		// Verifies that the user can download the source file
-		authManager.canDownLoadFile(user, Arrays.asList(association))
-			.stream()
-			.filter(status -> status.getStatus().isAuthorized())
-			.findFirst()
-			.orElseThrow(() -> 
-				new UnauthorizedException("The user is not authorized to access the source file.")
-			);
-		
-		// Makes sure the user owns the storage location, note that the storage location id is required in the request
-		if (!user.isAdmin() && !user.getId().equals(storageLocation.getCreatedBy())) {
-			throw new UnauthorizedException("The user does not own the destination storage location.");
-		}
-		
-		FileHandle fileHandle = fileHandleDao.get(association.getFileHandleId());
-		
-		if (fileHandle.getContentSize() == null) {
-			throw new IllegalArgumentException("The source file handle does not define its size.");
-		}
-		
-		if (fileHandle.getContentMd5() == null) {
-			throw new IllegalArgumentException("The source file handle does not define its content MD5.");
-		}
-
-		if (storageLocation.getStorageLocationId().equals(fileHandle.getStorageLocationId())) {
-			throw new IllegalArgumentException("The source file handle is already in the given destination storage location.");
-		}
-		
-		// Sets a file name as it is optional, but we save it in the request (the hash won't contain this)
-		request.setFileName(StringUtils.isBlank(request.getFileName()) ? fileHandle.getFileName() : request.getFileName());
-		
-		String requestJson = MultipartRequestUtils.createRequestJSON(request);
-		
-		// the bucket depends on the upload location used.
-		String bucket = MultipartUtils.getBucket(storageLocation);
-		// create a new key for this file.
-		String key = MultipartUtils.createNewKey(user.getId().toString(), request.getFileName(), storageLocation);
-		
-		String uploadToken = getCloudServiceMultipartDao(uploadType).initiateMultipartUploadCopy(bucket, key, request, fileHandle);
-		
-		int numberParts = PartUtils.calculateNumberOfParts(fileHandle.getContentSize(), request.getPartSizeBytes());
-		
-		// Start the copy
-		return multipartUploadDAO
-				.createUploadStatus(new CreateMultipartRequest(user.getId(),
-						requestHash, requestJson, uploadToken, uploadType,
-						bucket, key, numberParts, request.getPartSizeBytes(), fileHandle.getId()));
-	}
-	
-	private CloudServiceMultipartUploadDAO getCloudServiceMultipartDao(UploadType uploadType) {
-		return cloudServiceMultipartUploadDAOProvider.getCloudServiceMultipartUploadDao(uploadType);
 	}
 
 	/**
@@ -306,24 +201,11 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 		// validate the caller is the user that started this upload.
 		validateStartedBy(user, status);
 		
-		int numberOfParts = status.getNumberOfParts();
+		final int numberOfParts = status.getNumberOfParts();
 		
-		List<PartPresignedUrl> partUrls = new ArrayList<>(request.getPartNumbers().size());
+		final List<PartPresignedUrl> partUrls = new ArrayList<>(request.getPartNumbers().size());
 		
-		PresignedUrlProvider presignedUrlProvider;
-		
-		switch (status.getRequestType()) {
-		case UPLOAD:
-			presignedUrlProvider = this::getPresignedUrlForUpload;
-			break;
-		case COPY:
-			presignedUrlProvider = this::getPresignedUrlForUploadCopy;
-			break;
-		default:
-			throw new IllegalStateException("Unsupported request type: " + status.getRequestType());
-		}
-		
-		CloudServiceMultipartUploadDAO cloudServiceMultipartDao = getCloudServiceMultipartDao(status.getUploadType());
+		final MultipartRequestHandler<? extends MultipartRequest> handler = handlerProvider.getHandlerForType(status.getRequestType());
 		
 		final List<Long> partNumbers = request.getPartNumbers();
 		final List<String> partMd5List = request.getPartMD5Hex();
@@ -342,7 +224,7 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 				partMD5Hex = partMd5List.get(i);
 			}
 
-			PresignedUrl url = presignedUrlProvider.create(status, cloudServiceMultipartDao, partNumber, request.getContentType(), partMD5Hex);
+			PresignedUrl url = handler.getPresignedUrl(status, partNumber, request.getContentType(), partMD5Hex);
 
 			partUrls.add(map(url, partNumber));
 		}
@@ -352,16 +234,6 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 		response.setPartPresignedUrls(partUrls);
 		
 		return response;
-	}
-	
-	private PresignedUrl getPresignedUrlForUpload(CompositeMultipartUploadStatus status, CloudServiceMultipartUploadDAO cloudDao, long partNumber, String contentType, String partMD5Hex) {
-		String partKey = MultipartUploadUtils.createPartKey(status.getKey(), partNumber);
-		
-		return cloudDao.createPartUploadPreSignedUrl(status.getBucket(), partKey, contentType, partMD5Hex);
-	}
-	
-	private PresignedUrl getPresignedUrlForUploadCopy(CompositeMultipartUploadStatus status, CloudServiceMultipartUploadDAO cloudDao, long partNumber, String contentType, String partMD5Hex) {
-		return cloudDao.createPartUploadCopyPresignedUrl(status, partNumber, contentType, partMD5Hex);
 	}
 	
 	private static PartPresignedUrl map(PresignedUrl presignedUrl, Long partNumber) {
@@ -441,21 +313,11 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 		
 		response.setPartNumber(new Long(partNumber));
 		response.setUploadId(uploadId);
-
-		CloudServiceMultipartUploadDAO cloudDao = getCloudServiceMultipartDao(composite.getUploadType());
 		
+		final MultipartRequestHandler<? extends MultipartRequest> handler = handlerProvider.getHandlerForType(composite.getRequestType());
+
 		try {
-			switch (composite.getRequestType()) {
-			case UPLOAD:
-				validatePartAddedForUpload(cloudDao, composite, partNumber, partMD5Hex);
-				break;
-			case COPY:
-				validatePartAddedForUploadCopy(cloudDao, composite, partNumber, partMD5Hex);
-				break;
-			default:
-				throw new IllegalStateException("Unsupported request type: " + composite.getRequestType());
-			}
-			
+			handler.validateAddedPart(composite, partNumber, partMD5Hex);
 			// added the part successfully.
 			multipartUploadDAO.addPartToUpload(uploadId, partNumber, partMD5Hex);
 			response.setAddPartState(AddPartState.ADD_SUCCESS);
@@ -467,26 +329,10 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 		}
 		return response;
 	}
-	
-	private void validatePartAddedForUpload(CloudServiceMultipartUploadDAO cloudDao, CompositeMultipartUploadStatus status, long partNumber, String partMD5Hex) {
-		String partKey = MultipartUploadUtils.createPartKey(status.getKey(), partNumber);
-		
-		cloudDao.validateAndAddPart(
-				new AddPartRequest(status.getMultipartUploadStatus().getUploadId(), status
-						.getUploadToken(), status.getBucket(), status
-						.getKey(), partKey, partMD5Hex, partNumber, status.getNumberOfParts())
-		);
-	}
-	
-	private void validatePartAddedForUploadCopy(CloudServiceMultipartUploadDAO cloudDao, CompositeMultipartUploadStatus status, long partNumber, String partMD5Hex) {
-		cloudDao.validatePartCopy(status, partNumber, partMD5Hex);
-	}
-
 
 	@WriteTransaction
 	@Override
-	public MultipartUploadStatus completeMultipartUpload(UserInfo user,
-			String uploadId) {
+	public MultipartUploadStatus completeMultipartUpload(UserInfo user, String uploadId) {
 		ValidateArgument.required(user, "UserInfo");
 		ValidateArgument.required(uploadId, "uploadId");
 		
@@ -506,33 +352,28 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 		
 		validateParts(composite.getNumberOfParts(), addedParts);
 		
+		final CloudServiceMultipartUploadDAO cloudDao = cloudDaoProvider.getCloudServiceMultipartUploadDao(composite.getUploadType());
+		
+		final MultipartRequestHandler<? extends MultipartRequest> handler = handlerProvider.getHandlerForType(composite.getRequestType());
+		
+		final String requestJson = multipartUploadDAO.getUploadRequest(uploadId);
+		
 		// complete the upload
-		CompleteMultipartRequest request = new CompleteMultipartRequest();
+		CompleteMultipartRequest completeRequest = new CompleteMultipartRequest();
 		
-		request.setUploadId(Long.valueOf(uploadId));
-		request.setNumberOfParts(composite.getNumberOfParts().longValue());
-		request.setAddedParts(addedParts);
-		request.setBucket(composite.getBucket());
-		request.setKey(composite.getKey());
-		request.setUploadToken(composite.getUploadToken());
+		completeRequest.setUploadId(Long.valueOf(composite.getMultipartUploadStatus().getUploadId()));
+		completeRequest.setNumberOfParts(composite.getNumberOfParts().longValue());
+		completeRequest.setAddedParts(addedParts);
+		completeRequest.setBucket(composite.getBucket());
+		completeRequest.setKey(composite.getKey());
+		completeRequest.setUploadToken(composite.getUploadToken());
 		
-		long fileContentSize = getCloudServiceMultipartDao(composite.getUploadType()).completeMultipartUpload(request);
-		
-		FileHandleCreateRequest fileHandleRequest;
-		
-		switch (composite.getRequestType()) {
-		case UPLOAD:
-			fileHandleRequest = createFileHandleRequestForUpload(composite, getOriginalRequest(uploadId, MultipartUploadRequest.class));
-			break;
-		case COPY:
-			fileHandleRequest = createFileHandleRequestForUploadCopy(composite, getOriginalRequest(uploadId, MultipartUploadCopyRequest.class));
-			break;
-		default:
-			throw new IllegalStateException("Unsupported request type: " + composite.getRequestType());
-		}
+		final long fileSize = cloudDao.completeMultipartUpload(completeRequest);
+				
+		final FileHandleCreateRequest fileHandleCreateRequest = handler.getFileHandleCreateRequest(composite, requestJson);
 		
 		// create a file handle to represent this file.
-		String resultFileHandleId = createFileHandle(fileContentSize, composite, fileHandleRequest).getId();
+		String resultFileHandleId = createFileHandle(fileSize, composite, fileHandleCreateRequest).getId();
 		
 		// complete the upload.
 		composite = multipartUploadDAO.setUploadComplete(uploadId, resultFileHandleId);
@@ -540,18 +381,6 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 		return prepareCompleteStatus(composite);
 	}
 	
-	private FileHandleCreateRequest createFileHandleRequestForUpload(CompositeMultipartUploadStatus composite, MultipartUploadRequest request) {
-		return new FileHandleCreateRequest(request.getFileName(), request.getContentType(), request.getContentMD5Hex(), request.getStorageLocationId(), request.getGeneratePreview());
-	}
-
-	private FileHandleCreateRequest createFileHandleRequestForUploadCopy(CompositeMultipartUploadStatus composite, MultipartUploadCopyRequest request) {
-		FileHandle fileHandle = fileHandleDao.get(composite.getSourceFileHandleId().toString());
-		
-		// Note that the filename in the request is optional, but we do save the file handle name in the request if not supplied
-		return new FileHandleCreateRequest(request.getFileName(), fileHandle.getContentType(), fileHandle.getContentMd5(), request.getStorageLocationId(), request.getGeneratePreview());
-		
-	}
-
 	/**
 	 * Validate there is one part for the expected number of parts.
 	 * 
@@ -587,12 +416,6 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 		status.setPartsState(completePartsState);
 		return status;
 	}
-
-	<T extends MultipartRequest> T getOriginalRequest(String uploadId, Class<T> clazz) {
-		String requestJson = multipartUploadDAO.getUploadRequest(uploadId);
-		
-		return MultipartRequestUtils.getRequestFromJson(requestJson, clazz);
-	}
 	
 	/**
 	 * Create an S3FileHandle for a multi-part upload.
@@ -602,7 +425,7 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 	 * @param request
 	 * @return
 	 */
-	CloudProviderFileHandleInterface createFileHandle(long fileSize, CompositeMultipartUploadStatus composite, FileHandleCreateRequest request){
+	CloudProviderFileHandleInterface createFileHandle(long fileSize, CompositeMultipartUploadStatus composite, FileHandleCreateRequest request) {
 		// Convert all of the data to a file handle.
 		CloudProviderFileHandleInterface fileHandle;
 		if (composite.getUploadType().equals(UploadType.S3)) {
@@ -635,68 +458,6 @@ public class MultipartManagerV2Impl implements MultipartManagerV2 {
 	@Override
 	public void truncateAll() {
 		this.multipartUploadDAO.truncateAll();
-	}
-	
-	// Internal interfaces and DTOs
-	
-	@FunctionalInterface
-	private static interface MultipartRequestValidator<T extends MultipartRequest> {
-		
-		void validate(UserInfo user, T request);
-		
-	}
-	
-	@FunctionalInterface
-	private static interface MultipartRequestInitiator<T extends MultipartRequest> {
-		
-		CompositeMultipartUploadStatus initiate(UserInfo user, T request, String requestHash, StorageLocationSetting storageLocation);
-		
-	}
-	
-	@FunctionalInterface
-	private static interface PresignedUrlProvider {
-		
-		PresignedUrl create(CompositeMultipartUploadStatus status, CloudServiceMultipartUploadDAO cloudDao, long partNumber, String contentType, String partMD5Hex);
-	
-	}
-	
-	// Internal DTO for customizing the file handle data
-	static class FileHandleCreateRequest {
-		
-		private String fileName;
-		private String contentType;
-		private String contentMD5;
-		private Long storageLocationId;
-		private Boolean generatePreview;
-		
-		FileHandleCreateRequest(String fileName, String contentType, String contentMD5, Long storageLocationId, Boolean generatePreview) {
-			this.fileName = fileName;
-			this.contentType = contentType;
-			this.contentMD5 = contentMD5;
-			this.storageLocationId = storageLocationId;
-			this.generatePreview = generatePreview;
-		}
-		
-		public String getFileName() {
-			return fileName;
-		}
-		
-		public String getContentType() {
-			return contentType;
-		}
-		
-		public String getContentMD5() {
-			return contentMD5;
-		}
-		
-		public Long getStorageLocationId() {
-			return storageLocationId;
-		}
-
-		public Boolean getGeneratePreview() {
-			return generatePreview;
-		}
-		
 	}
 
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/FileHandleCreateRequest.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/FileHandleCreateRequest.java
@@ -1,0 +1,76 @@
+package org.sagebionetworks.repo.manager.file.multipart;
+
+import java.util.Objects;
+
+/**
+ * DTO to create a file handle when a multipart request is completed.
+ * 
+ * @author Marco Marasca
+ *
+ */
+public class FileHandleCreateRequest {
+	
+	private String fileName;
+	private String contentType;
+	private String contentMD5;
+	private Long storageLocationId;
+	private Boolean generatePreview;
+	
+	public FileHandleCreateRequest(String fileName, String contentType, String contentMD5, Long storageLocationId, Boolean generatePreview) {
+		this.fileName = fileName;
+		this.contentType = contentType;
+		this.contentMD5 = contentMD5;
+		this.storageLocationId = storageLocationId;
+		this.generatePreview = generatePreview;
+	}
+	
+	public String getFileName() {
+		return fileName;
+	}
+	
+	public String getContentType() {
+		return contentType;
+	}
+	
+	public String getContentMD5() {
+		return contentMD5;
+	}
+	
+	public Long getStorageLocationId() {
+		return storageLocationId;
+	}
+
+	public Boolean getGeneratePreview() {
+		return generatePreview;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(contentMD5, contentType, fileName, generatePreview, storageLocationId);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		FileHandleCreateRequest other = (FileHandleCreateRequest) obj;
+		return Objects.equals(contentMD5, other.contentMD5) && Objects.equals(contentType, other.contentType)
+				&& Objects.equals(fileName, other.fileName) && Objects.equals(generatePreview, other.generatePreview)
+				&& Objects.equals(storageLocationId, other.storageLocationId);
+	}
+
+	@Override
+	public String toString() {
+		return "FileHandleCreateRequest [fileName=" + fileName + ", contentType=" + contentType + ", contentMD5="
+				+ contentMD5 + ", storageLocationId=" + storageLocationId + ", generatePreview=" + generatePreview
+				+ "]";
+	}
+	
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/MultipartRequestHandler.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/MultipartRequestHandler.java
@@ -1,0 +1,71 @@
+package org.sagebionetworks.repo.manager.file.multipart;
+
+import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.model.dbo.file.CompositeMultipartUploadStatus;
+import org.sagebionetworks.repo.model.dbo.file.CreateMultipartRequest;
+import org.sagebionetworks.repo.model.file.MultipartRequest;
+import org.sagebionetworks.repo.model.project.StorageLocationSetting;
+import org.sagebionetworks.upload.multipart.PresignedUrl;
+
+/**
+ * Abstraction to handle different types of multipart requests.
+ * 
+ * @author Marco Marasca
+ *
+ */
+public interface MultipartRequestHandler<T extends MultipartRequest> {
+	
+	/**
+	 * @return The concrete request class
+	 */
+	Class<T> getRequestClass();
+
+	/**
+	 * Validates the given request, generic validation on the {@link MultipartRequest} is performed before invoking this method
+	 * 
+	 * @param user The user making the request
+	 * @param request The multipart request to validate
+	 */
+	void validateRequest(UserInfo user, T request);
+	
+	/**
+	 * Initiates a the multipart request
+	 * 
+	 * @param user The user initiating the request
+	 * @param request The original request
+	 * @param requestHash The hash of the request
+	 * @param storageLocation The destination storage location, might be null
+	 * @return A {@link CreateMultipartRequest} DTO that encapsulate the data about the new request
+	 */
+	CreateMultipartRequest initiateRequest(UserInfo user, T request, String requestHash, StorageLocationSetting storageLocation);
+	
+	/**
+	 * Obtains a pre-signed url for the given upload status and part number
+	 * 
+	 * @param status The upload status
+	 * @param partNumber The part number
+	 * @param contentType The optional content type
+	 * @param partMD5Hex The optional MD5 checksum
+	 * @return A pre-signed url including all the signed headers
+	 */
+	PresignedUrl getPresignedUrl(CompositeMultipartUploadStatus status, long partNumber, String contentType, String partMD5Hex);
+	
+	/**
+	 * Invoked after a part was added to the multipart
+	 * 
+	 * @param status The upload status
+	 * @param partNumber The part number
+	 * @param partMD5Hex The part MD5 checksum
+	 */
+	void validateAddedPart(CompositeMultipartUploadStatus status, long partNumber, String partMD5Hex);
+	
+	/**
+	 * Invoked after a multipart is completed in order to obtain the data for a new file handle
+	 * 
+	 * @param status The upload status
+	 * @param originalRequest The original request, serialized to json
+	 * @return The data about the new file handle to create
+	 */
+	FileHandleCreateRequest getFileHandleCreateRequest(CompositeMultipartUploadStatus status, String originalRequest);
+	
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/MultipartRequestHandlerProvider.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/MultipartRequestHandlerProvider.java
@@ -1,0 +1,18 @@
+package org.sagebionetworks.repo.manager.file.multipart;
+
+import org.sagebionetworks.repo.model.dbo.file.MultiPartRequestType;
+import org.sagebionetworks.repo.model.file.MultipartRequest;
+
+/**
+ * {@link MultipartRequestHandler} provider for a given type of request.
+ * 
+ * @author Marco Marasca
+ *
+ */
+public interface MultipartRequestHandlerProvider {
+
+	MultipartRequestHandler<? extends MultipartRequest> getHandlerForType(MultiPartRequestType requestType);
+
+	<T extends MultipartRequest> MultipartRequestHandler<T> getHandlerForClass(Class<T> requestClass);
+
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/MultipartRequestHandlerProviderImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/MultipartRequestHandlerProviderImpl.java
@@ -1,0 +1,48 @@
+package org.sagebionetworks.repo.manager.file.multipart;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.sagebionetworks.repo.model.dbo.file.MultiPartRequestType;
+import org.sagebionetworks.repo.model.file.MultipartRequest;
+import org.sagebionetworks.util.ValidateArgument;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MultipartRequestHandlerProviderImpl implements MultipartRequestHandlerProvider {
+
+	private Map<Class<? extends MultipartRequest>, MultipartRequestHandler<? extends MultipartRequest>> handlersMap;
+	
+	@Autowired
+	public MultipartRequestHandlerProviderImpl(List<MultipartRequestHandler<? extends MultipartRequest>> handlers) {
+		if (handlers == null || handlers.isEmpty()) {
+			throw new IllegalStateException("No multipart request handler found on the classpath.");
+		}
+		
+		handlersMap = handlers.stream()
+				.collect(
+					Collectors.toMap(MultipartRequestHandler::getRequestClass, Function.identity())
+				);
+	}
+	
+	@Override
+	public MultipartRequestHandler<? extends MultipartRequest> getHandlerForType(MultiPartRequestType requestType) {
+		ValidateArgument.required(requestType, "The requestType");
+		return getHandlerForClass(requestType.getRequestType());
+	}
+	
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends MultipartRequest> MultipartRequestHandler<T> getHandlerForClass(Class<T> requestClass) {
+		ValidateArgument.required(requestClass, "The requestClass");
+		MultipartRequestHandler<? extends MultipartRequest> handler = handlersMap.get(requestClass);
+		if (handler == null) {
+			throw new IllegalArgumentException("Unsupported request type: " + requestClass.getName());
+		}
+		return (MultipartRequestHandler<T>) handler;
+	}
+	
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/MultipartUploadCopyRequestHandler.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/MultipartUploadCopyRequestHandler.java
@@ -1,0 +1,159 @@
+package org.sagebionetworks.repo.manager.file.multipart;
+
+import java.util.Arrays;
+
+import org.apache.commons.lang3.StringUtils;
+import org.sagebionetworks.repo.manager.file.FileHandleAuthorizationManager;
+import org.sagebionetworks.repo.manager.file.MultipartUtils;
+import org.sagebionetworks.repo.model.UnauthorizedException;
+import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.model.dao.FileHandleDao;
+import org.sagebionetworks.repo.model.dbo.file.CompositeMultipartUploadStatus;
+import org.sagebionetworks.repo.model.dbo.file.CreateMultipartRequest;
+import org.sagebionetworks.repo.model.dbo.file.MultipartRequestUtils;
+import org.sagebionetworks.repo.model.file.FileHandle;
+import org.sagebionetworks.repo.model.file.FileHandleAssociation;
+import org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest;
+import org.sagebionetworks.repo.model.file.PartUtils;
+import org.sagebionetworks.repo.model.file.UploadType;
+import org.sagebionetworks.repo.model.jdo.NameValidation;
+import org.sagebionetworks.repo.model.project.StorageLocationSetting;
+import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAO;
+import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAOProvider;
+import org.sagebionetworks.upload.multipart.PresignedUrl;
+import org.sagebionetworks.util.ValidateArgument;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MultipartUploadCopyRequestHandler implements MultipartRequestHandler<MultipartUploadCopyRequest> {
+
+	private CloudServiceMultipartUploadDAOProvider cloudServiceDaoProvider;
+
+	private FileHandleAuthorizationManager authManager;
+	
+	private FileHandleDao fileHandleDao;
+	
+	@Autowired
+	public MultipartUploadCopyRequestHandler(
+			CloudServiceMultipartUploadDAOProvider cloudServiceDaoProvider, 
+			FileHandleAuthorizationManager authManager,
+			FileHandleDao fileHandleDao) {
+		this.cloudServiceDaoProvider = cloudServiceDaoProvider;
+		this.authManager = authManager;
+		this.fileHandleDao = fileHandleDao;
+	}
+
+	@Override
+	public Class<MultipartUploadCopyRequest> getRequestClass() {
+		return MultipartUploadCopyRequest.class;
+	}
+
+	@Override
+	public void validateRequest(UserInfo user, MultipartUploadCopyRequest request) {
+		ValidateArgument.required(request, "The request");
+		ValidateArgument.required(request.getSourceFileHandleAssociation(), "MultipartUploadCopyRequest.sourceFileHandleAssociation");
+		ValidateArgument.required(request.getStorageLocationId(), "MultipartUploadCopyRequest.storageLocationId");
+		
+		if (!StringUtils.isBlank(request.getFileName())) {
+			//validate file name
+			NameValidation.validateName(request.getFileName());
+		}
+	}
+
+	@Override
+	public CreateMultipartRequest initiateRequest(UserInfo user, MultipartUploadCopyRequest request, String requestHash,
+			StorageLocationSetting storageLocation) {
+		ValidateArgument.required(user, "The user");
+		ValidateArgument.required(request, "The request");
+		ValidateArgument.required(storageLocation, "The storageLocation");
+		
+		UploadType uploadType = storageLocation.getUploadType();
+		
+		FileHandleAssociation association = request.getSourceFileHandleAssociation();
+		
+		// Verifies that the user can download the source file
+		authManager.canDownLoadFile(user, Arrays.asList(association))
+			.stream()
+			.filter(status -> status.getStatus().isAuthorized())
+			.findFirst()
+			.orElseThrow(() -> 
+				new UnauthorizedException("The user is not authorized to access the source file.")
+			);
+		
+		// Makes sure the user owns the storage location, note that the storage location id is required in the request
+		if (!user.isAdmin() && !user.getId().equals(storageLocation.getCreatedBy())) {
+			throw new UnauthorizedException("The user does not own the destination storage location.");
+		}
+		
+		FileHandle fileHandle = fileHandleDao.get(association.getFileHandleId());
+		
+		if (fileHandle.getContentSize() == null) {
+			throw new IllegalArgumentException("The source file handle does not define its size.");
+		}
+		
+		if (fileHandle.getContentMd5() == null) {
+			throw new IllegalArgumentException("The source file handle does not define its content MD5.");
+		}
+
+		if (storageLocation.getStorageLocationId().equals(fileHandle.getStorageLocationId())) {
+			throw new IllegalArgumentException("The source file handle is already in the given destination storage location.");
+		}
+		
+		// Sets a file name as it is optional, but we save it in the request (the hash won't contain this)
+		request.setFileName(StringUtils.isBlank(request.getFileName()) ? fileHandle.getFileName() : request.getFileName());
+		
+		String requestJson = MultipartRequestUtils.createRequestJSON(request);
+		
+		// the bucket depends on the upload location used.
+		String bucket = MultipartUtils.getBucket(storageLocation);
+		// create a new key for this file.
+		String key = MultipartUtils.createNewKey(user.getId().toString(), request.getFileName(), storageLocation);
+		
+		final CloudServiceMultipartUploadDAO cloudDao = cloudServiceDaoProvider.getCloudServiceMultipartUploadDao(uploadType);
+		
+		String uploadToken = cloudDao.initiateMultipartUploadCopy(bucket, key, request, fileHandle);
+		
+		int numberParts = PartUtils.calculateNumberOfParts(fileHandle.getContentSize(), request.getPartSizeBytes());
+		
+		// Creates the copy request
+		return new CreateMultipartRequest(user.getId(),
+						requestHash, requestJson, uploadToken, uploadType,
+						bucket, key, numberParts, request.getPartSizeBytes(), fileHandle.getId());
+	}
+
+	@Override
+	public PresignedUrl getPresignedUrl(CompositeMultipartUploadStatus status, long partNumber, String contentType,
+			String partMD5Hex) {
+		ValidateArgument.required(status, "The upload status");
+		
+		final CloudServiceMultipartUploadDAO cloudDao = cloudServiceDaoProvider.getCloudServiceMultipartUploadDao(status.getUploadType());
+		
+		return cloudDao.createPartUploadCopyPresignedUrl(status, partNumber, contentType, partMD5Hex);
+	}
+
+	@Override
+	public void validateAddedPart(CompositeMultipartUploadStatus status, long partNumber, String partMD5Hex) {
+		ValidateArgument.required(status, "The upload status");
+		ValidateArgument.required(partMD5Hex, "The part MD5");
+		
+		final CloudServiceMultipartUploadDAO cloudDao = cloudServiceDaoProvider.getCloudServiceMultipartUploadDao(status.getUploadType());
+		
+		cloudDao.validatePartCopy(status, partNumber, partMD5Hex);
+	}
+
+	@Override
+	public FileHandleCreateRequest getFileHandleCreateRequest(CompositeMultipartUploadStatus status, String originalRequest) {
+		ValidateArgument.required(status, "The upload status");
+		ValidateArgument.required(originalRequest, "The original request");
+		
+		MultipartUploadCopyRequest request = MultipartRequestUtils.getRequestFromJson(originalRequest, MultipartUploadCopyRequest.class);
+		
+		FileHandle fileHandle = fileHandleDao.get(status.getSourceFileHandleId().toString());
+
+		// Note that the filename in the request is optional, but we do save the file handle name in the request if not supplied
+		return new FileHandleCreateRequest(request.getFileName(), fileHandle.getContentType(), fileHandle.getContentMd5(), request.getStorageLocationId(), request.getGeneratePreview());
+	
+	}
+
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/MultipartUploadRequestHandler.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/multipart/MultipartUploadRequestHandler.java
@@ -1,0 +1,115 @@
+package org.sagebionetworks.repo.manager.file.multipart;
+
+import org.sagebionetworks.repo.manager.file.MultipartUtils;
+import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.model.dbo.file.CompositeMultipartUploadStatus;
+import org.sagebionetworks.repo.model.dbo.file.CreateMultipartRequest;
+import org.sagebionetworks.repo.model.dbo.file.MultipartRequestUtils;
+import org.sagebionetworks.repo.model.file.AddPartRequest;
+import org.sagebionetworks.repo.model.file.MultipartUploadRequest;
+import org.sagebionetworks.repo.model.file.PartUtils;
+import org.sagebionetworks.repo.model.file.UploadType;
+import org.sagebionetworks.repo.model.jdo.NameValidation;
+import org.sagebionetworks.repo.model.project.StorageLocationSetting;
+import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAO;
+import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAOProvider;
+import org.sagebionetworks.upload.multipart.MultipartUploadUtils;
+import org.sagebionetworks.upload.multipart.PresignedUrl;
+import org.sagebionetworks.util.ValidateArgument;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MultipartUploadRequestHandler implements MultipartRequestHandler<MultipartUploadRequest> {
+
+	private CloudServiceMultipartUploadDAOProvider cloudServiceDaoProvider;
+
+	@Autowired
+	public MultipartUploadRequestHandler(CloudServiceMultipartUploadDAOProvider cloudServiceDaoProvider) {
+		this.cloudServiceDaoProvider = cloudServiceDaoProvider;
+	}
+
+	@Override
+	public Class<MultipartUploadRequest> getRequestClass() {
+		return MultipartUploadRequest.class;
+	}
+
+	@Override
+	public void validateRequest(UserInfo user, MultipartUploadRequest request) {
+		ValidateArgument.required(user, "The user");
+		ValidateArgument.required(request, "The request");
+		
+		ValidateArgument.requiredNotEmpty(request.getFileName(), "MultipartUploadRequest.fileName");
+		//validate file name
+		NameValidation.validateName(request.getFileName());		
+		ValidateArgument.required(request.getFileSizeBytes(), "MultipartUploadRequest.fileSizeBytes");
+		ValidateArgument.requiredNotEmpty(request.getContentMD5Hex(), "MultipartUploadRequest.contentMD5Hex");
+		
+		PartUtils.validateFileSize(request.getFileSizeBytes());
+
+	}
+
+	@Override
+	public CreateMultipartRequest initiateRequest(UserInfo user, MultipartUploadRequest request, String requestHash, StorageLocationSetting storageLocation) {
+		ValidateArgument.required(user, "The user");
+		ValidateArgument.required(request, "The request");
+		
+		UploadType uploadType = storageLocation == null ? UploadType.S3 : storageLocation.getUploadType();
+		
+		// the bucket depends on the upload location used.
+		String bucket = MultipartUtils.getBucket(storageLocation);
+		// create a new key for this file.
+		String key = MultipartUtils.createNewKey(user.getId().toString(), request.getFileName(), storageLocation);
+		
+		CloudServiceMultipartUploadDAO cloudDao = cloudServiceDaoProvider.getCloudServiceMultipartUploadDao(uploadType);
+		
+		String uploadToken = cloudDao.initiateMultipartUpload(bucket, key, request);
+		
+		String requestJson = MultipartRequestUtils.createRequestJSON(request);
+		// How many parts will be needed to upload this file?
+		int numberParts = PartUtils.calculateNumberOfParts(request.getFileSizeBytes(), request.getPartSizeBytes());
+		// Create the upload request
+		return new CreateMultipartRequest(user.getId(),
+						requestHash, requestJson, uploadToken, uploadType,
+						bucket, key, numberParts, request.getPartSizeBytes());
+	}
+
+	@Override
+	public PresignedUrl getPresignedUrl(CompositeMultipartUploadStatus status, long partNumber, String contentType, String partMD5Hex) {
+		ValidateArgument.required(status, "The upload status");
+		
+		String partKey = MultipartUploadUtils.createPartKey(status.getKey(), partNumber);
+		
+		CloudServiceMultipartUploadDAO cloudDao = cloudServiceDaoProvider.getCloudServiceMultipartUploadDao(status.getUploadType());
+		
+		return cloudDao.createPartUploadPreSignedUrl(status.getBucket(), partKey, contentType, partMD5Hex);
+	}
+
+	@Override
+	public void validateAddedPart(CompositeMultipartUploadStatus status, long partNumber, String partMD5Hex) {
+		ValidateArgument.required(status, "The upload status");
+		ValidateArgument.required(partMD5Hex, "The part MD5");
+		
+		final String partKey = MultipartUploadUtils.createPartKey(status.getKey(), partNumber);
+		
+		final CloudServiceMultipartUploadDAO cloudDao = cloudServiceDaoProvider.getCloudServiceMultipartUploadDao(status.getUploadType());
+		
+		cloudDao.validateAndAddPart(
+				new AddPartRequest(status.getMultipartUploadStatus().getUploadId(), status
+						.getUploadToken(), status.getBucket(), status
+						.getKey(), partKey, partMD5Hex, partNumber, status.getNumberOfParts())
+		);
+
+	}
+
+	@Override
+	public FileHandleCreateRequest getFileHandleCreateRequest(CompositeMultipartUploadStatus status, String originalRequest) {
+		ValidateArgument.required(status, "The upload status");
+		ValidateArgument.required(originalRequest, "The original request");
+		
+		MultipartUploadRequest request = MultipartRequestUtils.getRequestFromJson(originalRequest, MultipartUploadRequest.class);
+		
+		return new FileHandleCreateRequest(request.getFileName(), request.getContentType(), request.getContentMD5Hex(), request.getStorageLocationId(), request.getGeneratePreview());
+		
+	}
+}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/MultipartManagerV2ImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/MultipartManagerV2ImplTest.java
@@ -6,13 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.endsWith;
-import static org.mockito.ArgumentMatchers.startsWith;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -24,1383 +22,1300 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-import org.mockito.stubbing.Answer;
-import org.sagebionetworks.StackConfigurationSingleton;
 import org.sagebionetworks.ids.IdGenerator;
 import org.sagebionetworks.ids.IdType;
 import org.sagebionetworks.repo.manager.ProjectSettingsManager;
-import org.sagebionetworks.repo.manager.file.MultipartManagerV2Impl.FileHandleCreateRequest;
+import org.sagebionetworks.repo.manager.file.multipart.FileHandleCreateRequest;
+import org.sagebionetworks.repo.manager.file.multipart.MultipartRequestHandler;
+import org.sagebionetworks.repo.manager.file.multipart.MultipartRequestHandlerProvider;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
-import org.sagebionetworks.repo.model.auth.AuthorizationStatus;
 import org.sagebionetworks.repo.model.dao.FileHandleDao;
 import org.sagebionetworks.repo.model.dbo.file.CompositeMultipartUploadStatus;
 import org.sagebionetworks.repo.model.dbo.file.CreateMultipartRequest;
-import org.sagebionetworks.repo.model.dbo.file.MultiPartRequestType;
 import org.sagebionetworks.repo.model.dbo.file.MultipartRequestUtils;
 import org.sagebionetworks.repo.model.dbo.file.MultipartUploadDAO;
-import org.sagebionetworks.repo.model.file.AddPartRequest;
 import org.sagebionetworks.repo.model.file.AddPartResponse;
 import org.sagebionetworks.repo.model.file.AddPartState;
 import org.sagebionetworks.repo.model.file.BatchPresignedUploadUrlRequest;
 import org.sagebionetworks.repo.model.file.BatchPresignedUploadUrlResponse;
+import org.sagebionetworks.repo.model.file.CloudProviderFileHandleInterface;
 import org.sagebionetworks.repo.model.file.CompleteMultipartRequest;
-import org.sagebionetworks.repo.model.file.FileHandleAssociateType;
-import org.sagebionetworks.repo.model.file.FileHandleAssociation;
 import org.sagebionetworks.repo.model.file.GoogleCloudFileHandle;
+import org.sagebionetworks.repo.model.file.MultipartRequest;
 import org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest;
 import org.sagebionetworks.repo.model.file.MultipartUploadRequest;
 import org.sagebionetworks.repo.model.file.MultipartUploadState;
 import org.sagebionetworks.repo.model.file.MultipartUploadStatus;
 import org.sagebionetworks.repo.model.file.PartMD5;
 import org.sagebionetworks.repo.model.file.PartPresignedUrl;
+import org.sagebionetworks.repo.model.file.PartUtils;
 import org.sagebionetworks.repo.model.file.S3FileHandle;
 import org.sagebionetworks.repo.model.file.UploadType;
-import org.sagebionetworks.repo.model.project.S3StorageLocationSetting;
+import org.sagebionetworks.repo.model.project.StorageLocationSetting;
+import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAO;
 import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAOProvider;
-import org.sagebionetworks.upload.multipart.MultipartUploadUtils;
 import org.sagebionetworks.upload.multipart.PresignedUrl;
-import org.sagebionetworks.upload.multipart.S3MultipartUploadDAOImpl;
-
-import com.google.common.collect.Lists;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 public class MultipartManagerV2ImplTest {
-	
+
 	@Mock
-	UserInfo userInfo;
+	private MultipartUploadDAO mockMultipartUploadDAO;
+
 	@Mock
-	MultipartUploadDAO mockMultiparUploadDAO;
+	private FileHandleDao mockFileHandleDao;
+
 	@Mock
-	ProjectSettingsManager mockProjectSettingsManager;
+	private ProjectSettingsManager mockProjectSettingsManager;
+
 	@Mock
-	S3MultipartUploadDAOImpl mockS3multipartUploadDAO;
+	private IdGenerator mockIdGenerator;
+
 	@Mock
-	CloudServiceMultipartUploadDAOProvider mockUploadDAOProvider;
+	private CloudServiceMultipartUploadDAOProvider mockCloudDaoProvider;
+
 	@Mock
-	FileHandleDao mockFileHandleDao;
+	private CloudServiceMultipartUploadDAO mockCloudDao;
+
 	@Mock
-	IdGenerator mockIdGenerator;
+	private MultipartRequestHandlerProvider mockHandlerProvider;
+
 	@Mock
-	FileHandleAuthorizationManager mockAuthManager;
+	private MultipartRequestHandler<MultipartRequest> mockHandler;
 
 	@InjectMocks
-	MultipartManagerV2Impl manager;
+	private MultipartManagerV2Impl manager;
 
-	MultipartUploadRequest request;	
-	String requestJson;
-	String requestHash;
-
-	boolean forceRestart;
-	
-	String uploadId;
-	String uploadToken;
-	CompositeMultipartUploadStatus composite;
-	CompositeMultipartUploadStatus completeComposite;
-	S3FileHandle fileHandle;
-	GoogleCloudFileHandle googleCloudFileHandle;
-	List<PartMD5> addedParts;
-	String synapseBucket;
-	
 	@Mock
-	private S3StorageLocationSetting mockStorageLocation;
-	
+	private MultipartUploadStatus mockStatus;
+
+	@Mock
+	private CompositeMultipartUploadStatus mockCompositeStatus;
+
+	@Mock
+	private MultipartRequest mockRequest;
+
+	@Mock
+	private StorageLocationSetting mockStorageSettings;
+
+	@Mock
+	private CreateMultipartRequest mockCreateMultipartRequest;
+
+	@Mock
+	private CloudProviderFileHandleInterface mockFileHandle;
+
+	private UserInfo user;
+
 	@BeforeEach
-	public void before(){
-		when(userInfo.getId()).thenReturn(456L);
-		
-		request = new MultipartUploadRequest();
-		request.setFileName("foo.txt");
-		request.setFileSizeBytes((long) (1024*1024*100+15));
-		request.setContentMD5Hex("someMD5Hex");
-		request.setPartSizeBytes((long) (1024*1024*5));
-		request.setStorageLocationId(789L);
-		request.setContentType("plain/text");
-		
-		requestJson = MultipartRequestUtils.createRequestJSON(request);
-		requestHash = MultipartRequestUtils.calculateMD5AsHex(request);
-		
-		uploadId = "123456";
-		uploadToken = "someUploadToken";
-		
-		MultipartUploadStatus status = new MultipartUploadStatus();
-		status.setUploadId(uploadId);
-		status.setStartedBy(""+userInfo.getId());
-		composite = new CompositeMultipartUploadStatus();
-		composite.setMultipartUploadStatus(status);
-		composite.setNumberOfParts(2);
-		composite.setBucket("someBucket");
-		composite.setKey("someKey");
-		composite.setUploadToken(uploadToken);
-		composite.setUploadType(UploadType.S3);
-		composite.setRequestType(MultiPartRequestType.UPLOAD);
-		
-		fileHandle = new S3FileHandle();
-		fileHandle.setId("9999");
-		when(mockIdGenerator.generateNewId(IdType.FILE_IDS)).thenReturn(9999L);
-		when(mockFileHandleDao.createFile(any(S3FileHandle.class))).thenReturn(fileHandle);
-
-		googleCloudFileHandle = new GoogleCloudFileHandle();
-		googleCloudFileHandle.setId("9999");
-		when(mockFileHandleDao.createFile(any(GoogleCloudFileHandle.class))).thenReturn(googleCloudFileHandle);
-
-		// setup a completed upload.
-		MultipartUploadStatus completeStatus = new MultipartUploadStatus();
-		completeStatus.setUploadId(status.getUploadId());
-		completeStatus.setStartedBy(""+userInfo.getId());
-		completeStatus.setResultFileHandleId(fileHandle.getId());
-		completeStatus.setStartedBy(""+userInfo.getId());
-		completeStatus.setState(MultipartUploadState.COMPLETED);
-		completeStatus.setStartedOn(new Date());
-		completeComposite = new CompositeMultipartUploadStatus();
-		completeComposite.setMultipartUploadStatus(completeStatus);
-		completeComposite.setBucket(composite.getBucket());
-		completeComposite.setKey(composite.getKey());
-		completeComposite.setUploadToken(uploadToken);
-		completeComposite.setNumberOfParts(composite.getNumberOfParts());
-		
-		addedParts = Lists.newArrayList(new PartMD5(2, "partMD5HexTwo"), new PartMD5(1, "partMD5HexOne"));
-		when(mockMultiparUploadDAO.getAddedPartMD5s(uploadId)).thenReturn(addedParts);
-		when(mockMultiparUploadDAO.getUploadRequest(uploadId)).thenReturn(requestJson);
-		when(mockMultiparUploadDAO.getUploadStatus(uploadId)).thenReturn(composite);
-		when(mockMultiparUploadDAO.setUploadComplete(uploadId, fileHandle.getId())).thenReturn(completeComposite);
-		
-		// capture all data from a created
-		doAnswer(new Answer<CompositeMultipartUploadStatus>(){
-			@Override
-			public CompositeMultipartUploadStatus answer(
-					InvocationOnMock invocation) throws Throwable {
-				CreateMultipartRequest cmr = (CreateMultipartRequest) invocation.getArguments()[0];
-
-				MultipartUploadStatus status = new MultipartUploadStatus();
-				status.setStartedBy(""+cmr.getUserId());
-				status.setStartedOn(new Date());
-				status.setState(MultipartUploadState.UPLOADING);
-				status.setUploadId("123456");
-				status.setUpdatedOn(status.getStartedOn());
-				CompositeMultipartUploadStatus composite = new CompositeMultipartUploadStatus();
-				composite.setMultipartUploadStatus(status);
-				composite.setBucket(cmr.getBucket());
-				composite.setKey(cmr.getKey());
-				composite.setNumberOfParts(cmr.getNumberOfParts());
-				composite.setUploadToken("anUploadToken");
-				return composite;
-			}}).when(mockMultiparUploadDAO).createUploadStatus(any(CreateMultipartRequest.class));
-
-		when(mockUploadDAOProvider.getCloudServiceMultipartUploadDao(UploadType.S3)).thenReturn(mockS3multipartUploadDAO);
-		when(mockS3multipartUploadDAO.initiateMultipartUpload(anyString(), anyString(), any(MultipartUploadRequest.class))).thenReturn(uploadToken);
-		
-		// Simulate the number of parts
-		doAnswer(new Answer<String>(){
-			@Override
-			public String answer(InvocationOnMock invocation) throws Throwable {
-				String uploadId = (String) invocation.getArguments()[0];
-				int numberOfParts = (Integer) invocation.getArguments()[1];
-				char[] chars = new char[numberOfParts];
-				Arrays.fill(chars, '0');
-				return new String(chars);
-			}}).when(mockMultiparUploadDAO).getPartsState(anyString(), anyInt());
-					
-		// simulate a presigned url.
-		doAnswer(new Answer<PresignedUrl>() {
-			@Override
-			public PresignedUrl answer(InvocationOnMock invocation) throws Throwable {
-				String bucket = (String) invocation.getArguments()[0];
-				String key = (String) invocation.getArguments()[1];
-				return new PresignedUrl().withUrl(new URL("http", "amazon.com", bucket+"/"+key));
-			}
-		}).when(mockS3multipartUploadDAO).createPartUploadPreSignedUrl(anyString(), anyString(), any(), any());
-		
-		forceRestart = false;
-		synapseBucket = StackConfigurationSingleton.singleton().getS3Bucket();
+	public void before() {
+		user = new UserInfo(false);
+		user.setId(123L);
 	}
-	
+
 	@Test
-	public void testStartOrResumeMultipartUploadAnonymous(){
+	public void testStartOrResumeMultipartOperationWithUpload() {
+
+		MultipartUploadRequest request = new MultipartUploadRequest();
+
+		boolean forceRestart = false;
+
+		// We just want to verify that the right method is invoked
+		MultipartManagerV2Impl managerSpy = Mockito.spy(manager);
+
+		doReturn(mockStatus).when(managerSpy).startOrResumeMultipartUpload(any(), any(), anyBoolean());
+
+		// Call under test
+		managerSpy.startOrResumeMultipartOperation(user, request, forceRestart);
+
+		verify(managerSpy).startOrResumeMultipartUpload(user, request, forceRestart);
+	}
+
+	@Test
+	public void testStartOrResumeMultipartOperationWithCopy() {
+
+		MultipartUploadCopyRequest request = new MultipartUploadCopyRequest();
+
+		boolean forceRestart = false;
+
+		// We just want to verify that the right method is invoked
+		MultipartManagerV2Impl managerSpy = Mockito.spy(manager);
+
+		doReturn(mockStatus).when(managerSpy).startOrResumeMultipartUploadCopy(any(), any(), anyBoolean());
+
+		// Call under test
+		managerSpy.startOrResumeMultipartOperation(user, request, forceRestart);
+
+		verify(managerSpy).startOrResumeMultipartUploadCopy(user, request, forceRestart);
+	}
+
+	@Test
+	public void testStartOrResumeMultipartOperationWithUnsupported() {
+
+		MultipartRequest request = Mockito.mock(MultipartRequest.class);
+
+		boolean forceRestart = false;
+
+		String errorMessage = assertThrows(UnsupportedOperationException.class, () -> {
+			// Call under test
+			manager.startOrResumeMultipartOperation(user, request, forceRestart);
+		}).getMessage();
+
+		assertTrue(errorMessage.startsWith("Request type unsupported: MultipartRequest"));
+	}
+
+	@Test
+	public void testStartOrResumeMultipartUpload() {
+		MultipartUploadRequest request = new MultipartUploadRequest();
+
+		boolean forceRestart = false;
+
+		// We just want to verify that the right method is invoked
+		MultipartManagerV2Impl managerSpy = Mockito.spy(manager);
+
+		when(mockHandlerProvider.getHandlerForClass(any())).thenReturn(mockHandler);
+
+		doReturn(mockStatus).when(managerSpy).startOrResumeMultipartRequest(any(), any(), any(), anyBoolean());
+
+		// Call under test
+		managerSpy.startOrResumeMultipartUpload(user, request, forceRestart);
+
+		verify(mockHandlerProvider).getHandlerForClass(MultipartUploadRequest.class);
+		verify(managerSpy).startOrResumeMultipartRequest(mockHandler, user, request, forceRestart);
+	}
+
+	@Test
+	public void testStartOrResumeMultipartUploadCopy() {
+		MultipartUploadCopyRequest request = new MultipartUploadCopyRequest();
+
+		boolean forceRestart = false;
+
+		// We just want to verify that the right method is invoked
+		MultipartManagerV2Impl managerSpy = Mockito.spy(manager);
+
+		when(mockHandlerProvider.getHandlerForClass(any())).thenReturn(mockHandler);
+
+		doReturn(mockStatus).when(managerSpy).startOrResumeMultipartRequest(any(), any(), any(), anyBoolean());
+
+		// Call under test
+		managerSpy.startOrResumeMultipartUploadCopy(user, request, forceRestart);
+
+		verify(mockHandlerProvider).getHandlerForClass(MultipartUploadCopyRequest.class);
+		verify(managerSpy).startOrResumeMultipartRequest(mockHandler, user, request, forceRestart);
+	}
+
+	@Test
+	public void testStartOrResumeMultipartRequestWithForceRestartTrue() {
+		Long partSize = PartUtils.MIN_PART_SIZE_BYTES;
+		String requestHash = MultipartRequestUtils.calculateMD5AsHex(mockRequest);
+		int numberOfParts = 4;
+
+		boolean forceRestart = true;
+
+		when(mockRequest.getPartSizeBytes()).thenReturn(partSize);
+		doNothing().when(mockHandler).validateRequest(any(), any());
+		doNothing().when(mockMultipartUploadDAO).deleteUploadStatus(anyLong(), any());
+
+		// Mimic a new upload
+		when(mockMultipartUploadDAO.getUploadStatus(any(), any())).thenReturn(null);
+		when(mockProjectSettingsManager.getStorageLocationSetting(any())).thenReturn(mockStorageSettings);
+		when(mockHandler.initiateRequest(any(), any(), any(), any())).thenReturn(mockCreateMultipartRequest);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.UPLOADING);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockMultipartUploadDAO.createUploadStatus(any())).thenReturn(mockCompositeStatus);
+		when(mockMultipartUploadDAO.getPartsState(any(), anyInt())).thenReturn("0000");
+
+		// Call under test
+		MultipartUploadStatus result = manager.startOrResumeMultipartRequest(mockHandler, user, mockRequest,
+				forceRestart);
+
+		assertEquals(mockStatus, result);
+
+		verify(mockHandler).validateRequest(user, mockRequest);
+		verify(mockMultipartUploadDAO).deleteUploadStatus(user.getId(), requestHash);
+		verify(mockMultipartUploadDAO).getUploadStatus(user.getId(), requestHash);
+		verify(mockHandler).initiateRequest(user, mockRequest, requestHash, mockStorageSettings);
+		verify(mockMultipartUploadDAO).createUploadStatus(mockCreateMultipartRequest);
+		verify(mockStatus).setPartsState("0000");
+	}
+
+	@Test
+	public void testStartOrResumeMultipartRequestWithNoForceRestartFalse() {
+		Long partSize = PartUtils.MIN_PART_SIZE_BYTES;
+		String requestHash = MultipartRequestUtils.calculateMD5AsHex(mockRequest);
+		int numberOfParts = 4;
+
+		boolean forceRestart = false;
+
+		when(mockRequest.getPartSizeBytes()).thenReturn(partSize);
+		doNothing().when(mockHandler).validateRequest(any(), any());
+
+		// Mimic a new upload
+		when(mockMultipartUploadDAO.getUploadStatus(any(), any())).thenReturn(null);
+		when(mockProjectSettingsManager.getStorageLocationSetting(any())).thenReturn(mockStorageSettings);
+		when(mockHandler.initiateRequest(any(), any(), any(), any())).thenReturn(mockCreateMultipartRequest);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.UPLOADING);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockMultipartUploadDAO.createUploadStatus(any())).thenReturn(mockCompositeStatus);
+		when(mockMultipartUploadDAO.getPartsState(any(), anyInt())).thenReturn("0000");
+
+		// Call under test
+		MultipartUploadStatus result = manager.startOrResumeMultipartRequest(mockHandler, user, mockRequest,
+				forceRestart);
+
+		assertEquals(mockStatus, result);
+
+		verify(mockHandler).validateRequest(user, mockRequest);
+		verify(mockMultipartUploadDAO, never()).deleteUploadStatus(anyLong(), any());
+		verify(mockMultipartUploadDAO).getUploadStatus(user.getId(), requestHash);
+		verify(mockHandler).initiateRequest(user, mockRequest, requestHash, mockStorageSettings);
+		verify(mockMultipartUploadDAO).createUploadStatus(mockCreateMultipartRequest);
+		verify(mockStatus).setPartsState("0000");
+
+	}
+
+	@Test
+	public void testStartOrResumeMultipartRequestWithAlreadyStarted() {
+		Long partSize = PartUtils.MIN_PART_SIZE_BYTES;
+		String requestHash = MultipartRequestUtils.calculateMD5AsHex(mockRequest);
+		int numberOfParts = 4;
+
+		boolean forceRestart = false;
+
+		when(mockRequest.getPartSizeBytes()).thenReturn(partSize);
+		doNothing().when(mockHandler).validateRequest(any(), any());
+
+		// Mimic a new upload
+		when(mockMultipartUploadDAO.getUploadStatus(any(), any())).thenReturn(mockCompositeStatus);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.UPLOADING);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockMultipartUploadDAO.getPartsState(any(), anyInt())).thenReturn("0000");
+
+		// Call under test
+		MultipartUploadStatus result = manager.startOrResumeMultipartRequest(mockHandler, user, mockRequest,
+				forceRestart);
+
+		assertEquals(mockStatus, result);
+
+		verify(mockHandler).validateRequest(user, mockRequest);
+		verify(mockMultipartUploadDAO, never()).deleteUploadStatus(anyLong(), any());
+		verify(mockMultipartUploadDAO).getUploadStatus(user.getId(), requestHash);
+		verify(mockStatus).setPartsState("0000");
+		verify(mockHandler, never()).initiateRequest(any(), any(), any(), any());
+		verify(mockMultipartUploadDAO, never()).createUploadStatus(any());
+	}
+
+	@Test
+	public void testStartOrResumeMultipartRequestWithCompleted() {
+		Long partSize = PartUtils.MIN_PART_SIZE_BYTES;
+		String requestHash = MultipartRequestUtils.calculateMD5AsHex(mockRequest);
+		int numberOfParts = 4;
+
+		boolean forceRestart = false;
+
+		when(mockRequest.getPartSizeBytes()).thenReturn(partSize);
+		doNothing().when(mockHandler).validateRequest(any(), any());
+
+		// Mimic a new upload
+		when(mockMultipartUploadDAO.getUploadStatus(any(), any())).thenReturn(mockCompositeStatus);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.COMPLETED);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+
+		// Call under test
+		MultipartUploadStatus result = manager.startOrResumeMultipartRequest(mockHandler, user, mockRequest,
+				forceRestart);
+
+		assertEquals(mockStatus, result);
+
+		verify(mockHandler).validateRequest(user, mockRequest);
+		verify(mockMultipartUploadDAO, never()).deleteUploadStatus(anyLong(), any());
+		verify(mockMultipartUploadDAO).getUploadStatus(user.getId(), requestHash);
+		verify(mockStatus).setPartsState("1111");
+		verify(mockHandler, never()).initiateRequest(any(), any(), any(), any());
+		verify(mockMultipartUploadDAO, never()).createUploadStatus(any());
+		verify(mockMultipartUploadDAO, never()).getPartsState(any(), anyInt());
+	}
+
+	@Test
+	public void testStartOrResumeMultipartRequestWithAnonymous() {
+
+		Long partSize = PartUtils.MIN_PART_SIZE_BYTES;
+		boolean forceRestart = false;
+
 		// set the user to anonymous
-		when(userInfo.getId()).thenReturn(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId());
-		//call under test
-		assertThrows(UnauthorizedException.class, () -> manager.startOrResumeMultipartUpload(userInfo, request, forceRestart));
+		user.setId(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId());
+
+		when(mockRequest.getPartSizeBytes()).thenReturn(partSize);
+
+		String errorMessage = assertThrows(UnauthorizedException.class, () -> {
+			// Call under test
+			manager.startOrResumeMultipartRequest(mockHandler, user, mockRequest, forceRestart);
+		}).getMessage();
+
+		assertEquals("Anonymous cannot upload files.", errorMessage);
 	}
 
 	@Test
-	public void testStartOrResumeMultipartUpload_EmptyFileName(){
-		request.setFileName("");
+	public void testGetBatchPresignedUploadUrls() throws MalformedURLException {
+		String uploadId = "upload";
+		int numberOfParts = 2;
 
-		//call under test
-		assertThrows(IllegalArgumentException.class, () -> manager.startOrResumeMultipartUpload(userInfo, request, forceRestart));
-	}
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
 
-	@Test
-	public void testStartOrResumeMultipartUpload_EmptyMD5(){
-		request.setContentMD5Hex("");
+		doReturn(mockHandler).when(mockHandlerProvider).getHandlerForType(any());
 
-		//call under test
-		assertThrows(IllegalArgumentException.class, () -> manager.startOrResumeMultipartUpload(userInfo, request, forceRestart));
-	}
+		URL url1 = new URL("http://amazon.comsomeBucket/someKey/1");
+		URL url2 = new URL("http://amazon.comsomeBucket/someKey/1");
 
-	@Test
-	public void testStartOrResumeMultipartUpload_Non_ascii(){
-		request.setFileName("文件.txt");
+		when(mockHandler.getPresignedUrl(any(), anyLong(), any(), any())).thenReturn(new PresignedUrl().withUrl(url1),
+				new PresignedUrl().withUrl(url2));
 
-		//call under test
-		assertThrows(IllegalArgumentException.class, () -> manager.startOrResumeMultipartUpload(userInfo, request, forceRestart));
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadNotStarted(){
-		
-		when(mockStorageLocation.getUploadType()).thenReturn(UploadType.S3);
-		when(mockProjectSettingsManager.getStorageLocationSetting(any())).thenReturn(mockStorageLocation);
-		
-		// setup the case where the status does not exist
-		when(mockMultiparUploadDAO.getUploadStatus(anyLong(), anyString())).thenReturn(null);
-		// call under test
-		MultipartUploadStatus status = manager.startOrResumeMultipartUpload(userInfo, request, forceRestart);
-		assertNotNull(status);
-		assertEquals(MultipartUploadState.UPLOADING, status.getState());
-		assertEquals("000000000000000000000", status.getPartsState());
-		assertEquals("123456", status.getUploadId());
+		PartPresignedUrl part1 = new PartPresignedUrl();
+		part1.setPartNumber(1L);
+		part1.setUploadPresignedUrl(url1.toString());
 
-		// the status should not be reset.
-		verify(mockMultiparUploadDAO, never()).deleteUploadStatus(anyLong(), anyString());
-		
-		// since the upload does not exist it should get created.
-		ArgumentCaptor<CreateMultipartRequest> requestCapture = ArgumentCaptor.forClass(CreateMultipartRequest.class);
-		verify(mockMultiparUploadDAO).createUploadStatus(requestCapture.capture());
-		assertEquals(uploadToken, requestCapture.getValue().getUploadToken());
-		assertEquals(synapseBucket, requestCapture.getValue().getBucket());
-		assertNotNull(requestCapture.getValue().getKey());
-		assertEquals(requestJson, requestCapture.getValue().getRequestBody());
-		assertEquals(userInfo.getId(), requestCapture.getValue().getUserId());
-		assertEquals(requestHash, requestCapture.getValue().getHash());
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadAlreadyStarted(){
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(anyLong(), anyString())).thenReturn(composite);
-		// call under test
-		MultipartUploadStatus status = manager.startOrResumeMultipartUpload(userInfo, request, forceRestart);
-		assertEquals("00", status.getPartsState());
-		assertNotNull(status);
-		// the status should not be reset.
-		verify(mockMultiparUploadDAO, never()).deleteUploadStatus(anyLong(), anyString());
-		verify(mockMultiparUploadDAO, never()).createUploadStatus(any(CreateMultipartRequest.class));
-		verify(mockMultiparUploadDAO).getPartsState(anyString(), anyInt());
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadAlreadyStartedCompleted(){
-		// setup the case where the status already exists and it is complete
-		composite.getMultipartUploadStatus().setState(MultipartUploadState.COMPLETED);
-		composite.getMultipartUploadStatus().setResultFileHandleId("9876");
-		when(mockMultiparUploadDAO.getUploadStatus(anyLong(), anyString())).thenReturn(composite);
-		// call under test
-		MultipartUploadStatus status = manager.startOrResumeMultipartUpload(userInfo, request, forceRestart);
-		assertNotNull(status);
-		assertEquals(MultipartUploadState.COMPLETED, status.getState());
-		assertEquals("11", status.getPartsState());
-		assertEquals("9876", status.getResultFileHandleId());
+		PartPresignedUrl part2 = new PartPresignedUrl();
+		part2.setPartNumber(2L);
+		part2.setUploadPresignedUrl(url2.toString());
 
-		// the status should not be reset.
-		verify(mockMultiparUploadDAO, never()).deleteUploadStatus(anyLong(), anyString());
-		verify(mockMultiparUploadDAO, never()).createUploadStatus(any(CreateMultipartRequest.class));
-		// When the file is completed, the database should not be used to get the partsState.
-		verify(mockMultiparUploadDAO, never()).getPartsState(anyString(), anyInt());
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadForceRestartFalse() {
+		List<PartPresignedUrl> expectedUrls = Arrays.asList(part1, part2);
 
-		when(mockStorageLocation.getUploadType()).thenReturn(UploadType.S3);
-		when(mockProjectSettingsManager.getStorageLocationSetting(any())).thenReturn(mockStorageLocation);
-		
-		forceRestart = false;
-		// call under test
-		MultipartUploadStatus status = manager.startOrResumeMultipartUpload(userInfo, request, forceRestart);
-		assertNotNull(status);
-		verify(mockMultiparUploadDAO, never()).deleteUploadStatus(anyLong(), anyString());
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadForceRestartTrue(){
-
-		when(mockStorageLocation.getUploadType()).thenReturn(UploadType.S3);
-		when(mockProjectSettingsManager.getStorageLocationSetting(any())).thenReturn(mockStorageLocation);
-		
-		forceRestart = true;
-		// call under test
-		MultipartUploadStatus status = manager.startOrResumeMultipartUpload(userInfo, request, forceRestart);
-		assertNotNull(status);
-		verify(mockMultiparUploadDAO).deleteUploadStatus(anyLong(), anyString());
-	}
-	
-	@Test
-	public void testGetCompletePartStateString(){
-		assertEquals("1111", MultipartManagerV2Impl.getCompletePartStateString(4));
-	}
-	
-	@Test
-	public void testGetBatchPresignedUploadUrlsUnauthorized(){
-//		String uplaodId = composite.getMultipartUploadStatus().getUploadId();
-		// set this upload started by another user.
-		composite.getMultipartUploadStatus().setStartedBy(""+(userInfo.getId()+1));
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(uploadId)).thenReturn(composite);
-		
-		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
-		request.setUploadId(uploadId);
-		request.setPartNumbers(Lists.newArrayList(1L, 2L));
-		// call under test
-		assertThrows(UnauthorizedException.class, () -> manager.getBatchPresignedUploadUrls(userInfo, request));
-	}
-	
-	@Test
-	public void testGetBatchPresignedUploadUrls(){
-		String uplaodId = composite.getMultipartUploadStatus().getUploadId();
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(uplaodId)).thenReturn(composite);
-		
-		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
-		request.setUploadId(uplaodId);
-		request.setPartNumbers(Lists.newArrayList(1L, 2L));
-		request.setContentType("plain/text");
-		// call under test
-		BatchPresignedUploadUrlResponse response = manager.getBatchPresignedUploadUrls(userInfo, request);
-		assertNotNull(response);
-		assertNotNull(response.getPartPresignedUrls());
-		assertEquals(2, response.getPartPresignedUrls().size());
-		PartPresignedUrl partUrl = response.getPartPresignedUrls().get(0);
-		assertEquals(new Long(1), partUrl.getPartNumber());
-		assertEquals("http://amazon.comsomeBucket/someKey/1", partUrl.getUploadPresignedUrl());
-		partUrl = response.getPartPresignedUrls().get(1);
-		assertEquals(new Long(2), partUrl.getPartNumber());
-		assertEquals("http://amazon.comsomeBucket/someKey/2", partUrl.getUploadPresignedUrl());
-	}
-	
-	@Test
-	public void testGetBatchPresignedUploadUrlsNull(){
-		String uplaodId = composite.getMultipartUploadStatus().getUploadId();
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(uplaodId)).thenReturn(composite);
-		
-		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
-		request.setUploadId(uplaodId);
-		request.setPartNumbers(null);
-		// call under test
-		assertThrows(IllegalArgumentException.class, () -> manager.getBatchPresignedUploadUrls(userInfo, request));
-	}
-	
-	@Test
-	public void testGetBatchPresignedUploadUrlsEmptyl(){
-		String uplaodId = composite.getMultipartUploadStatus().getUploadId();
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(uplaodId)).thenReturn(composite);
-		
-		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
-		request.setUploadId(uplaodId);
-		request.setPartNumbers(new LinkedList<Long>());
-		// call under test
-		assertThrows(IllegalArgumentException.class, () -> manager.getBatchPresignedUploadUrls(userInfo, request));
-	}
-	
-	@Test
-	public void testGetBatchPresignedUploadUrlsZeroPart(){
-		String uplaodId = composite.getMultipartUploadStatus().getUploadId();
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(uplaodId)).thenReturn(composite);
-		
-		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
-		request.setUploadId(uplaodId);
-		request.setPartNumbers(Lists.newArrayList(0L));
-		// call under test
-		assertThrows(IllegalArgumentException.class, () -> manager.getBatchPresignedUploadUrls(userInfo, request));
-	}
-	
-	@Test
-	public void testGetBatchPresignedUploadUrlsPartTooBig(){
-		String uplaodId = composite.getMultipartUploadStatus().getUploadId();
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(uplaodId)).thenReturn(composite);
-		
-		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
-		request.setUploadId(uplaodId);
-		request.setPartNumbers(Lists.newArrayList(new Long(composite.getNumberOfParts()+1)));
-		// call under test
-		assertThrows(IllegalArgumentException.class, () -> manager.getBatchPresignedUploadUrls(userInfo, request));
-	}
-	
-	@Test
-	public void testGetBatchPresignedUploadUrlsForCopyRequest() throws MalformedURLException{
-		String uploadId = composite.getMultipartUploadStatus().getUploadId();
-		
-		Long contentSize = 5242880 * 10L;
-		
-		composite.setRequestType(MultiPartRequestType.COPY);
-		composite.setSourceFileHandleId(Long.valueOf(fileHandle.getId()));
-		composite.setFileSize(contentSize);
-		
-		PresignedUrl presignedUrl = new PresignedUrl();
-		
-		presignedUrl.withUrl(new URL("http", "amazon.com", "bucket/key"));
-		presignedUrl.withSignedHeader("some", "header");
-		
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(any())).thenReturn(composite);
-		when(mockS3multipartUploadDAO.createPartUploadCopyPresignedUrl(any(), anyLong(), any(), any())).thenReturn(presignedUrl);
-		
-		long partNumber = 1;
-		
-		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
-		request.setUploadId(uploadId);
-		request.setPartNumbers(Arrays.asList(partNumber));
-		request.setContentType("plain/text");
-		
-		PartPresignedUrl partUrl = new PartPresignedUrl();
-		
-		partUrl.setPartNumber(partNumber);
-		partUrl.setUploadPresignedUrl(presignedUrl.getUrl().toString());
-		partUrl.setSignedHeaders(presignedUrl.getSignedHeaders());
-		
 		BatchPresignedUploadUrlResponse expected = new BatchPresignedUploadUrlResponse();
-		expected.setPartPresignedUrls(Arrays.asList(partUrl));
-		
-		// call under test
-		BatchPresignedUploadUrlResponse response = manager.getBatchPresignedUploadUrls(userInfo, request);
-		
-		assertEquals(expected, response);
-		
-		verify(mockMultiparUploadDAO).getUploadStatus(uploadId);
-		verify(mockS3multipartUploadDAO).createPartUploadCopyPresignedUrl(composite, partNumber, "plain/text", null);
-	
-	}
-	
-	@Test
-	public void testGetBatchPresignedUploadUrlsForCopyRequestWithContentMD5Hex() throws MalformedURLException{
-		String uploadId = composite.getMultipartUploadStatus().getUploadId();
-		
-		Long contentSize = 5242880 * 10L;
-		
-		composite.setRequestType(MultiPartRequestType.COPY);
-		composite.setSourceFileHandleId(Long.valueOf(fileHandle.getId()));
-		composite.setFileSize(contentSize);
-		
-		PresignedUrl presignedUrl = new PresignedUrl();
-		
-		presignedUrl.withUrl(new URL("http", "amazon.com", "bucket/key"));
-		presignedUrl.withSignedHeader("some", "header");
-		
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(any())).thenReturn(composite);
-		when(mockS3multipartUploadDAO.createPartUploadCopyPresignedUrl(any(), anyLong(), any(), any())).thenReturn(presignedUrl);
-		
-		long partNumber = 1;
-		
+		expected.setPartPresignedUrls(expectedUrls);
+
 		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
+
 		request.setUploadId(uploadId);
-		request.setPartNumbers(Arrays.asList(partNumber));
-		request.setPartMD5Hex(Arrays.asList("md5"));
+		request.setPartNumbers(Arrays.asList(1L, 2L));
 		request.setContentType("plain/text");
-		
-		PartPresignedUrl partUrl = new PartPresignedUrl();
-		
-		partUrl.setPartNumber(partNumber);
-		partUrl.setUploadPresignedUrl(presignedUrl.getUrl().toString());
-		partUrl.setSignedHeaders(presignedUrl.getSignedHeaders());
-		
+
+		// Call under test
+		BatchPresignedUploadUrlResponse result = manager.getBatchPresignedUploadUrls(user, request);
+
+		assertEquals(expected, result);
+
+		verify(mockMultipartUploadDAO).getUploadStatus(uploadId);
+
+		verify(mockHandler).getPresignedUrl(mockCompositeStatus, 1L, "plain/text", null);
+		verify(mockHandler).getPresignedUrl(mockCompositeStatus, 2L, "plain/text", null);
+	}
+
+	@Test
+	public void testGetBatchPresignedUploadUrlsWithMd5CheckSums() throws MalformedURLException {
+		String uploadId = "upload";
+		int numberOfParts = 2;
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		doReturn(mockHandler).when(mockHandlerProvider).getHandlerForType(any());
+
+		URL url1 = new URL("http://amazon.comsomeBucket/someKey/1");
+		URL url2 = new URL("http://amazon.comsomeBucket/someKey/1");
+
+		when(mockHandler.getPresignedUrl(any(), anyLong(), any(), any())).thenReturn(new PresignedUrl().withUrl(url1),
+				new PresignedUrl().withUrl(url2));
+
+		PartPresignedUrl part1 = new PartPresignedUrl();
+		part1.setPartNumber(1L);
+		part1.setUploadPresignedUrl(url1.toString());
+
+		PartPresignedUrl part2 = new PartPresignedUrl();
+		part2.setPartNumber(2L);
+		part2.setUploadPresignedUrl(url2.toString());
+
+		List<PartPresignedUrl> expectedUrls = Arrays.asList(part1, part2);
+
 		BatchPresignedUploadUrlResponse expected = new BatchPresignedUploadUrlResponse();
-		expected.setPartPresignedUrls(Arrays.asList(partUrl));
-		
-		// call under test
-		BatchPresignedUploadUrlResponse response = manager.getBatchPresignedUploadUrls(userInfo, request);
-		
-		assertEquals(expected, response);
-		
-		verify(mockMultiparUploadDAO).getUploadStatus(uploadId);
-		verify(mockS3multipartUploadDAO).createPartUploadCopyPresignedUrl(composite, partNumber, "plain/text", "md5");
-	
+		expected.setPartPresignedUrls(expectedUrls);
+
+		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
+
+		request.setUploadId(uploadId);
+		request.setPartNumbers(Arrays.asList(1L, 2L));
+		request.setPartMD5Hex(Arrays.asList("md51", "md52"));
+		request.setContentType("plain/text");
+
+		// Call under test
+		BatchPresignedUploadUrlResponse result = manager.getBatchPresignedUploadUrls(user, request);
+
+		assertEquals(expected, result);
+
+		verify(mockMultipartUploadDAO).getUploadStatus(uploadId);
+
+		verify(mockHandler).getPresignedUrl(mockCompositeStatus, 1L, "plain/text", "md51");
+		verify(mockHandler).getPresignedUrl(mockCompositeStatus, 2L, "plain/text", "md52");
 	}
 	
 	@Test
-	public void testValidatePartNumberPartZero(){
+	public void testGetBatchPresignedUploadUrlsWithEmptyMd5CheckSums() throws MalformedURLException {
+		String uploadId = "upload";
+		int numberOfParts = 2;
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		doReturn(mockHandler).when(mockHandlerProvider).getHandlerForType(any());
+
+		URL url1 = new URL("http://amazon.comsomeBucket/someKey/1");
+		URL url2 = new URL("http://amazon.comsomeBucket/someKey/1");
+
+		when(mockHandler.getPresignedUrl(any(), anyLong(), any(), any())).thenReturn(new PresignedUrl().withUrl(url1),
+				new PresignedUrl().withUrl(url2));
+
+		PartPresignedUrl part1 = new PartPresignedUrl();
+		part1.setPartNumber(1L);
+		part1.setUploadPresignedUrl(url1.toString());
+
+		PartPresignedUrl part2 = new PartPresignedUrl();
+		part2.setPartNumber(2L);
+		part2.setUploadPresignedUrl(url2.toString());
+
+		List<PartPresignedUrl> expectedUrls = Arrays.asList(part1, part2);
+
+		BatchPresignedUploadUrlResponse expected = new BatchPresignedUploadUrlResponse();
+		expected.setPartPresignedUrls(expectedUrls);
+
+		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
+
+		request.setUploadId(uploadId);
+		request.setPartNumbers(Arrays.asList(1L, 2L));
+		request.setPartMD5Hex(Collections.emptyList());
+		request.setContentType("plain/text");
+
+		// Call under test
+		BatchPresignedUploadUrlResponse result = manager.getBatchPresignedUploadUrls(user, request);
+
+		assertEquals(expected, result);
+
+		verify(mockMultipartUploadDAO).getUploadStatus(uploadId);
+
+		verify(mockHandler).getPresignedUrl(mockCompositeStatus, 1L, "plain/text", null);
+		verify(mockHandler).getPresignedUrl(mockCompositeStatus, 2L, "plain/text", null);
+	}
+
+	@Test
+	public void testGetBatchPresignedUploadUrlsWithWrongMd5CheckSums() throws MalformedURLException {
+		String uploadId = "upload";
+
+		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
+
+		request.setUploadId(uploadId);
+		request.setPartNumbers(Arrays.asList(1L, 2L));
+		request.setPartMD5Hex(Arrays.asList("md51", "md52", "md53"));
+		request.setContentType("plain/text");
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			manager.getBatchPresignedUploadUrls(user, request);
+		}).getMessage();
+
+		assertEquals("The number of MD5 checksums must match the number of parts.", errorMessage);
+
+		verifyZeroInteractions(mockMultipartUploadDAO);
+		verifyZeroInteractions(mockHandler);
+	}
+
+	@Test
+	public void testGetBatchPresignedUploadUrlsWithNullPart() throws MalformedURLException {
+		String uploadId = "upload";
+		int numberOfParts = 2;
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		doReturn(mockHandler).when(mockHandlerProvider).getHandlerForType(any());
+
+		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
+
+		request.setUploadId(uploadId);
+		request.setPartNumbers(Arrays.asList(null, 2L));
+		request.setContentType("plain/text");
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			manager.getBatchPresignedUploadUrls(user, request);
+		}).getMessage();
+
+		assertEquals("PartNumber is required.", errorMessage);
+
+		verifyZeroInteractions(mockHandler);
+	}
+
+	@Test
+	public void testGetBatchPresignedUploadUrlsWithZeroPart() throws MalformedURLException {
+		String uploadId = "upload";
+		int numberOfParts = 2;
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		doReturn(mockHandler).when(mockHandlerProvider).getHandlerForType(any());
+
+		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
+
+		request.setUploadId(uploadId);
+		request.setPartNumbers(Arrays.asList(0L, 1L));
+		request.setContentType("plain/text");
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			manager.getBatchPresignedUploadUrls(user, request);
+		}).getMessage();
+
+		assertEquals("Part numbers cannot be less than one.", errorMessage);
+
+		verifyZeroInteractions(mockHandler);
+	}
+
+	@Test
+	public void testGetBatchPresignedUploadUrlsWithPartNumberTooBig() throws MalformedURLException {
+		String uploadId = "upload";
+		int numberOfParts = 2;
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		doReturn(mockHandler).when(mockHandlerProvider).getHandlerForType(any());
+
+		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
+
+		request.setUploadId(uploadId);
+		request.setPartNumbers(Arrays.asList(numberOfParts + 1L));
+		request.setContentType("plain/text");
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			manager.getBatchPresignedUploadUrls(user, request);
+		}).getMessage();
+
+		assertEquals("Part number cannot be larger than number of parts. Number of parts: 2, provided part number: 3",
+				errorMessage);
+
+		verifyZeroInteractions(mockHandler);
+	}
+
+	@Test
+	public void testGetBatchPresignedUploadUrlsWithEmptyList() throws MalformedURLException {
+		String uploadId = "upload";
+
+		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
+
+		request.setUploadId(uploadId);
+		request.setPartNumbers(Collections.emptyList());
+		request.setContentType("plain/text");
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			manager.getBatchPresignedUploadUrls(user, request);
+		}).getMessage();
+
+		assertEquals("BatchPresignedUploadUrlRequest.partNumbers must contain at least one value", errorMessage);
+
+	}
+
+	@Test
+	public void testGetBatchPresignedUploadUrlsWithUnauthorizedUser() throws MalformedURLException {
+		String uploadId = "upload";
+
+		// Started by another user
+		when(mockStatus.getStartedBy()).thenReturn("789");
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		BatchPresignedUploadUrlRequest request = new BatchPresignedUploadUrlRequest();
+
+		request.setUploadId(uploadId);
+		request.setPartNumbers(Arrays.asList(0L, 1L));
+		request.setContentType("plain/text");
+
+		String errorMessage = assertThrows(UnauthorizedException.class, () -> {
+			// Call under test
+			manager.getBatchPresignedUploadUrls(user, request);
+		}).getMessage();
+
+		assertEquals(
+				"Only the user that started a multipart upload can get part upload pre-signed URLs for that file upload.",
+				errorMessage);
+
+		verifyZeroInteractions(mockHandler);
+
+	}
+
+	@Test
+	public void testAddMultipartPart() {
+		String uploadId = "upload";
+		Integer partNumber = 2;
+		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
+		Integer numberOfParts = 4;
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.UPLOADING);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		doReturn(mockHandler).when(mockHandlerProvider).getHandlerForType(any());
+
+		AddPartResponse expected = new AddPartResponse();
+
+		expected.setPartNumber(Long.valueOf(partNumber));
+		expected.setUploadId(uploadId);
+		expected.setAddPartState(AddPartState.ADD_SUCCESS);
+
+		// Call under test
+		AddPartResponse result = manager.addMultipartPart(user, uploadId, partNumber, partMD5Hex);
+
+		assertEquals(expected, result);
+
+		verify(mockMultipartUploadDAO).getUploadStatus(uploadId);
+		verify(mockHandler).validateAddedPart(mockCompositeStatus, partNumber, partMD5Hex);
+		verify(mockMultipartUploadDAO).addPartToUpload(uploadId, partNumber, partMD5Hex);
+
+	}
+
+	@Test
+	public void testAddMultipartPartCompleted() {
+		String uploadId = "upload";
+		Integer partNumber = 2;
+		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
+
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.COMPLETED);
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			manager.addMultipartPart(user, uploadId, partNumber, partMD5Hex);
+		}).getMessage();
+
+		assertEquals("Cannot add parts to completed file upload.", errorMessage);
+
+		verifyNoMoreInteractions(mockMultipartUploadDAO);
+		verifyZeroInteractions(mockHandler);
+
+	}
+
+	@Test
+	public void testAddMultipartPartFailed() {
+		String uploadId = "upload";
+		Integer partNumber = 2;
+		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
+		Integer numberOfParts = 4;
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.UPLOADING);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		doReturn(mockHandler).when(mockHandlerProvider).getHandlerForType(any());
+
+		Exception error = new RuntimeException("Something went wrong");
+
+		doThrow(error).when(mockHandler).validateAddedPart(any(), anyLong(), any());
+
+		AddPartResponse expected = new AddPartResponse();
+
+		expected.setPartNumber(Long.valueOf(partNumber));
+		expected.setUploadId(uploadId);
+		expected.setAddPartState(AddPartState.ADD_FAILED);
+		expected.setErrorMessage(error.getMessage());
+
+		// Call under test
+		AddPartResponse result = manager.addMultipartPart(user, uploadId, partNumber, partMD5Hex);
+
+		assertEquals(expected, result);
+
+		verify(mockMultipartUploadDAO).getUploadStatus(uploadId);
+		verify(mockHandler).validateAddedPart(mockCompositeStatus, partNumber, partMD5Hex);
+		verify(mockMultipartUploadDAO, never()).addPartToUpload(uploadId, partNumber, partMD5Hex);
+		verify(mockMultipartUploadDAO).setPartToFailed(uploadId, partNumber, ExceptionUtils.getStackTrace(error));
+
+	}
+
+	@Test
+	public void testAddMultipartPartWithUnauthorizedUser() {
+		String uploadId = "upload";
+		Integer partNumber = 2;
+		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
+		Integer numberOfParts = 4;
+
+		// Started by a different user
+		when(mockStatus.getStartedBy()).thenReturn("8796");
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.UPLOADING);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		String errorMessage = assertThrows(UnauthorizedException.class, () -> {
+			// Call under test
+			manager.addMultipartPart(user, uploadId, partNumber, partMD5Hex);
+		}).getMessage();
+
+		assertEquals(
+				"Only the user that started a multipart upload can get part upload pre-signed URLs for that file upload.",
+				errorMessage);
+	}
+
+	@Test
+	public void testAddMultipartPartBadPartNumber() {
+		String uploadId = "upload";
+		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
+		Integer numberOfParts = 4;
+		Integer partNumber = numberOfParts + 1;
+
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.UPLOADING);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			manager.addMultipartPart(user, uploadId, partNumber, partMD5Hex);
+		}).getMessage();
+
+		assertEquals("Part number cannot be larger than number of parts. Number of parts: 4, provided part number: 5",
+				errorMessage);
+	}
+
+	@Test
+	public void testAddMultipartPartPartNumberLessThanOne() {
+		String uploadId = "upload";
+		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
+		Integer numberOfParts = 4;
+		Integer partNumber = 0;
+
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.UPLOADING);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			manager.addMultipartPart(user, uploadId, partNumber, partMD5Hex);
+		}).getMessage();
+
+		assertEquals("Part numbers cannot be less than one.", errorMessage);
+	}
+
+	@Test
+	public void testCompleteMultipartUpload() {
+		String uploadId = "1234";
+		String token = "token";
+		Integer numberOfParts = 2;
+		String bucket = "bucket";
+		String key = "key";
+		Long fileSize = PartUtils.MAX_PART_SIZE_BYTES;
+		String fileHandleId = "12345";
+		String originalRequest = "{}";
+
+		List<PartMD5> addedParts = Arrays.asList(new PartMD5(2, "partMD5HexTwo"), new PartMD5(1, "partMD5HexOne"));
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		// The status is initially uploading, then it will be changed to completed
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.UPLOADING, MultipartUploadState.COMPLETED);
+		when(mockStatus.getUploadId()).thenReturn(uploadId);
+		when(mockStatus.getResultFileHandleId()).thenReturn(fileHandleId);
+
+		when(mockCompositeStatus.getUploadToken()).thenReturn(token);
+		when(mockCompositeStatus.getBucket()).thenReturn(bucket);
+		when(mockCompositeStatus.getKey()).thenReturn(key);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockCompositeStatus.getUploadType()).thenReturn(UploadType.S3);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+		when(mockMultipartUploadDAO.getAddedPartMD5s(any())).thenReturn(addedParts);
+		when(mockMultipartUploadDAO.getUploadRequest(any())).thenReturn(originalRequest);
+		when(mockCloudDaoProvider.getCloudServiceMultipartUploadDao(any())).thenReturn(mockCloudDao);
+		when(mockCloudDao.completeMultipartUpload(any())).thenReturn(fileSize);
+		when(mockFileHandleDao.createFile(any())).thenReturn(mockFileHandle);
+		when(mockFileHandle.getId()).thenReturn(fileHandleId);
+		when(mockMultipartUploadDAO.setUploadComplete(any(), any())).thenReturn(mockCompositeStatus);
+
+		doReturn(mockHandler).when(mockHandlerProvider).getHandlerForType(any());
+
+		FileHandleCreateRequest handleCreateRequest = new FileHandleCreateRequest("fileName", "contentType", "md5",
+				123L, true);
+
+		when(mockHandler.getFileHandleCreateRequest(any(), any())).thenReturn(handleCreateRequest);
+
+		CompleteMultipartRequest completeRequest = new CompleteMultipartRequest();
+
+		completeRequest.setUploadId(Long.valueOf(uploadId));
+		completeRequest.setNumberOfParts(numberOfParts.longValue());
+		completeRequest.setAddedParts(addedParts);
+		completeRequest.setBucket(bucket);
+		completeRequest.setKey(key);
+		completeRequest.setUploadToken(token);
+
+		// Call under test
+		MultipartUploadStatus result = manager.completeMultipartUpload(user, uploadId);
+
+		assertEquals(mockStatus, result);
+
+		verify(mockStatus).setPartsState("11");
+		verify(mockCloudDao).completeMultipartUpload(completeRequest);
+		verify(mockHandler).getFileHandleCreateRequest(mockCompositeStatus, originalRequest);
+		verify(mockFileHandleDao).createFile(any());
+		verify(mockMultipartUploadDAO).setUploadComplete(uploadId, fileHandleId);
+	}
+
+	@Test
+	public void testCompleteMultipartUploadNotReady() {
+		String uploadId = "1234";
+		Integer numberOfParts = 2;
+
+		List<PartMD5> addedParts = Arrays.asList(new PartMD5(2, "partMD5HexTwo"));
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.UPLOADING);
+
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+		when(mockMultipartUploadDAO.getAddedPartMD5s(any())).thenReturn(addedParts);
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			manager.completeMultipartUpload(user, uploadId);
+		}).getMessage();
+
+		assertEquals("Missing 1 part(s).  All parts must be successfully added before a file upload can be completed.",
+				errorMessage);
+
+		verifyNoMoreInteractions(mockMultipartUploadDAO);
+		verifyZeroInteractions(mockCloudDao);
+		verifyZeroInteractions(mockHandler);
+		verifyZeroInteractions(mockFileHandleDao);
+	}
+
+	@Test
+	public void testCompleteMultipartUploadAlreadyCompleted() {
+		String uploadId = "1234";
+		Integer numberOfParts = 2;
+		String fileHandleId = "12345";
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.COMPLETED);
+		when(mockStatus.getResultFileHandleId()).thenReturn(fileHandleId);
+
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(numberOfParts);
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		// Call under test
+		MultipartUploadStatus result = manager.completeMultipartUpload(user, uploadId);
+
+		assertEquals(mockStatus, result);
+
+		verify(mockStatus).setPartsState("11");
+
+		verifyNoMoreInteractions(mockMultipartUploadDAO);
+		verifyZeroInteractions(mockCloudDao);
+		verifyZeroInteractions(mockHandler);
+		verifyZeroInteractions(mockFileHandleDao);
+	}
+
+	@Test
+	public void testCompleteMultipartUploadWithUnauthorizedUser() {
+		String uploadId = "1234";
+
+		// Started by a different user
+		when(mockStatus.getStartedBy()).thenReturn("456788");
+
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockMultipartUploadDAO.getUploadStatus(any())).thenReturn(mockCompositeStatus);
+
+		String errorMessage = assertThrows(UnauthorizedException.class, () -> {
+			// Call under test
+			manager.completeMultipartUpload(user, uploadId);
+		}).getMessage();
+
+		assertEquals(
+				"Only the user that started a multipart upload can get part upload pre-signed URLs for that file upload.",
+				errorMessage);
+
+		verifyNoMoreInteractions(mockMultipartUploadDAO);
+		verifyZeroInteractions(mockCloudDao);
+		verifyZeroInteractions(mockHandler);
+		verifyZeroInteractions(mockFileHandleDao);
+	}
+
+	@Test
+	public void testValidatePartNumberPartZero() {
 		int partNumber = 0;
 		int numberOfParts = 1;
-		//call under test.
-		assertThrows(IllegalArgumentException.class, () -> MultipartManagerV2Impl.validatePartNumber(partNumber, numberOfParts));
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			MultipartManagerV2Impl.validatePartNumber(partNumber, numberOfParts);
+		}).getMessage();
+
+		assertEquals("Part numbers cannot be less than one.", errorMessage);
 	}
-	
+
 	@Test
-	public void testValidatePartNumberNumberPartsZero(){
+	public void testValidatePartNumberNumberPartsZero() {
 		int partNumber = 1;
 		int numberOfParts = 0;
-		//call under test.
-		assertThrows(IllegalArgumentException.class, () -> MultipartManagerV2Impl.validatePartNumber(partNumber, numberOfParts));
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			MultipartManagerV2Impl.validatePartNumber(partNumber, numberOfParts);
+		}).getMessage();
+
+		assertEquals("Number of parts cannot be less than one.", errorMessage);
 	}
 
 	@Test
-	public void testValidatePartNumberTooLarge(){
+	public void testValidatePartNumberTooLarge() {
 		int partNumber = 2;
 		int numberOfParts = 1;
-		//call under test.
-		assertThrows(IllegalArgumentException.class, () -> MultipartManagerV2Impl.validatePartNumber(partNumber, numberOfParts));
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			MultipartManagerV2Impl.validatePartNumber(partNumber, numberOfParts);
+		}).getMessage();
+
+		assertEquals("Part number cannot be larger than number of parts. Number of parts: 1, provided part number: 2",
+				errorMessage);
 	}
 
 	@Test
-	public void testValidatePartNumberHappy(){
+	public void testValidatePartNumberHappy() {
 		int partNumber = 1;
 		int numberOfParts = 1;
-		//call under test.
+		// Call under test
 		MultipartManagerV2Impl.validatePartNumber(partNumber, numberOfParts);
 	}
 
 	@Test
-	public void testValidateStartedByHappy(){
-		MultipartManagerV2Impl.validateStartedBy(userInfo, composite);
+	public void testValidateStartedByHappy() {
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+
+		MultipartManagerV2Impl.validateStartedBy(user, mockCompositeStatus);
 	}
 
 	@Test
-	public void testValidateStartedByUserNull(){
-		userInfo = null;
-		assertThrows(IllegalArgumentException.class, () -> MultipartManagerV2Impl.validateStartedBy(userInfo, composite));
+	public void testValidateStartedByUserNull() {
+
+		user = null;
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			MultipartManagerV2Impl.validateStartedBy(user, mockCompositeStatus);
+		}).getMessage();
+
+		assertEquals("UserInfo is required.", errorMessage);
 	}
 
 	@Test
-	public void testValidateStartedByCompositeNull(){
-		composite = null;
-		assertThrows(IllegalArgumentException.class, () -> MultipartManagerV2Impl.validateStartedBy(userInfo, composite));
+	public void testValidateStartedByCompositeNull() {
+		mockCompositeStatus = null;
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			MultipartManagerV2Impl.validateStartedBy(user, mockCompositeStatus);
+		}).getMessage();
+
+		assertEquals("CompositeMultipartUploadStatus is required.", errorMessage);
 	}
 
 	@Test
-	public void testValidateStartedByAnotherUser(){
+	public void testValidateStartedByAnotherUser() {
+
 		// started by another user.
-		composite.getMultipartUploadStatus().setStartedBy(""+userInfo.getId()+1);;
-		assertThrows(UnauthorizedException.class, () -> MultipartManagerV2Impl.validateStartedBy(userInfo, composite));
+		when(mockStatus.getStartedBy()).thenReturn("4566");
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+
+		String errorMessage = assertThrows(UnauthorizedException.class, () -> {
+			MultipartManagerV2Impl.validateStartedBy(user, mockCompositeStatus);
+		}).getMessage();
+
+		assertEquals(
+				"Only the user that started a multipart upload can get part upload pre-signed URLs for that file upload.",
+				errorMessage);
 	}
 
 	@Test
-	public void testAddMultipartPartUnauthorizedException(){
-		String uplaodId = composite.getMultipartUploadStatus().getUploadId();
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(uplaodId)).thenReturn(composite);
-		// set the startedBy to be another user.
-		composite.getMultipartUploadStatus().setStartedBy(""+userInfo.getId()+1);
-		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
-		assertThrows(UnauthorizedException.class, () -> manager.addMultipartPart(userInfo, uplaodId, 1, partMD5Hex));
-	}
+	public void testPrepareCompleteStatusHappy() {
 
-	@Test
-	public void testAddMultipartPartBadPartNumber(){
-		int partNumber = composite.getNumberOfParts()+1;
-		String uplaodId = composite.getMultipartUploadStatus().getUploadId();
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(uplaodId)).thenReturn(composite);
-		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
-
-		assertThrows(IllegalArgumentException.class, () -> manager.addMultipartPart(userInfo, uplaodId, partNumber, partMD5Hex));
-	}
-
-	@Test
-	public void testAddMultipartPartPartNumberLessThanOne(){
-		int partNumber = 0;
-		String uplaodId = composite.getMultipartUploadStatus().getUploadId();
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(uplaodId)).thenReturn(composite);
-		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
-
-		assertThrows(IllegalArgumentException.class, () -> manager.addMultipartPart(userInfo, uplaodId, partNumber, partMD5Hex));
-	}
-
-	@Test
-	public void testAddMultipartPartHappy(){
-		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
-		int partNumber = 2;
-		String partKey = MultipartUploadUtils.createPartKey(composite.getKey(), partNumber);
-
-		AddPartResponse response = manager.addMultipartPart(userInfo, uploadId, partNumber, partMD5Hex);
-		assertNotNull(response);
-		assertEquals(uploadId, response.getUploadId());
-		assertNotNull(response.getPartNumber());
-		assertEquals(partNumber, response.getPartNumber().intValue());
-		assertEquals(AddPartState.ADD_SUCCESS, response.getAddPartState());
-
-		ArgumentCaptor<AddPartRequest> capture = ArgumentCaptor.forClass(AddPartRequest.class);
-		verify(mockS3multipartUploadDAO).validateAndAddPart(capture.capture());
-		assertEquals(composite.getBucket(), capture.getValue().getBucket());
-		assertEquals(composite.getKey(), capture.getValue().getKey());
-		assertEquals(partKey, capture.getValue().getPartKey());
-		assertEquals(partMD5Hex, capture.getValue().getPartMD5Hex());
-		assertEquals(composite.getUploadToken(), capture.getValue().getUploadToken());
-
-		// the part state should be saved
-		verify(mockMultiparUploadDAO).addPartToUpload(uploadId, partNumber, partMD5Hex);
-	}
-
-	@Test
-	public void testAddMultipartPartComplete(){
-		// setup a complete state
-		composite.getMultipartUploadStatus().setState(MultipartUploadState.COMPLETED);
-		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
-		int partNumber = 2;
-		// call under test
-		assertThrows(IllegalArgumentException.class, () -> manager.addMultipartPart(userInfo, uploadId, partNumber, partMD5Hex));
-	}
-	
-	@Test
-	public void testAddMultipartPartFailed(){
-		String uploadId = composite.getMultipartUploadStatus().getUploadId();
-		
-		//setup an error on add.
-		Exception error = new RuntimeException("Something went wrong");
-		doThrow(error).when(mockS3multipartUploadDAO).validateAndAddPart(any(AddPartRequest.class));
-		
-		// setup the case where the status already exists
-		when(mockMultiparUploadDAO.getUploadStatus(uploadId)).thenReturn(composite);
-		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
-		int partNumber = 2;
-		String partKey = MultipartUploadUtils.createPartKey(composite.getKey(), partNumber);
-		
-		AddPartResponse response = manager.addMultipartPart(userInfo, uploadId, partNumber, partMD5Hex);
-		assertNotNull(response);
-		assertEquals(uploadId, response.getUploadId());
-		assertNotNull(response.getPartNumber());
-		assertEquals(partNumber, response.getPartNumber().intValue());
-		assertEquals(AddPartState.ADD_FAILED, response.getAddPartState());
-		assertEquals(error.getMessage(), response.getErrorMessage());
-		
-		ArgumentCaptor<AddPartRequest> capture = ArgumentCaptor.forClass(AddPartRequest.class);
-		verify(mockS3multipartUploadDAO).validateAndAddPart(capture.capture());
-		assertEquals(composite.getBucket(), capture.getValue().getBucket());
-		assertEquals(composite.getKey(), capture.getValue().getKey());
-		assertEquals(partKey, capture.getValue().getPartKey());
-		assertEquals(partMD5Hex, capture.getValue().getPartMD5Hex());
-		assertEquals(composite.getUploadToken(), capture.getValue().getUploadToken());
-		
-		// the part state should be saved
-		verify(mockMultiparUploadDAO).setPartToFailed(eq(uploadId), eq(partNumber), startsWith("java.lang.RuntimeException: Something went wrong"));
-	}
-	
-	@Test
-	public void testAddMultipartPartWithCopyRequest() {
-		
-		composite.setRequestType(MultiPartRequestType.COPY);
-		
-		String partMD5Hex = "8356accbaa8bfc6ddc6c612224c6c9b3";
-		int partNumber = 2;
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(3);
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.COMPLETED);
+		when(mockStatus.getResultFileHandleId()).thenReturn("12345");
 
 		// Call under test
-		AddPartResponse response = manager.addMultipartPart(userInfo, uploadId, partNumber, partMD5Hex);
-		
-		assertNotNull(response);
-		assertEquals(uploadId, response.getUploadId());
-		assertNotNull(response.getPartNumber());
-		assertEquals(partNumber, response.getPartNumber().intValue());
-		assertEquals(AddPartState.ADD_SUCCESS, response.getAddPartState());
+		MultipartUploadStatus status = MultipartManagerV2Impl.prepareCompleteStatus(mockCompositeStatus);
 
-		verify(mockS3multipartUploadDAO).validatePartCopy(composite, partNumber, partMD5Hex);
-		// the part state should be saved
-		verify(mockMultiparUploadDAO).addPartToUpload(uploadId, partNumber, partMD5Hex);
-	}
-	
-	@Test
-	public void testValidatePartsHappy(){
-		List<PartMD5> addedParts = Lists.newArrayList(new PartMD5(2, "partMD5HexTwo"), new PartMD5(1, "partMD5HexOne"));
-		int numberOfParts = 2;
-		MultipartManagerV2Impl.validateParts(numberOfParts, addedParts);
-	}
-	
-	@Test
-	public void testValidatePartsMissing(){
-		List<PartMD5> addedParts = Lists.newArrayList(new PartMD5(2, "partMD5HexTwo"), new PartMD5(1, "partMD5HexOne"));
-		int numberOfParts = 3;
-		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> MultipartManagerV2Impl.validateParts(numberOfParts, addedParts));
-		assertTrue(e.getMessage().contains("Missing 1 part(s)"));
-	}
-	
-	@Test
-	public void testPrepareCompleteStatusHappy(){
-		composite.getMultipartUploadStatus().setState(MultipartUploadState.COMPLETED);
-		composite.getMultipartUploadStatus().setResultFileHandleId("12345");
-		composite.setNumberOfParts(3);
-		//call under test
-		MultipartUploadStatus status = MultipartManagerV2Impl.prepareCompleteStatus(composite);
 		assertNotNull(status);
 		assertEquals(MultipartUploadState.COMPLETED, status.getState());
 		assertEquals("12345", status.getResultFileHandleId());
-		assertEquals("111", status.getPartsState());
+		verify(mockStatus).setPartsState("111");
 	}
-	
+
 	@Test
-	public void testPrepareCompleteStatusNotComplete(){
-		composite.getMultipartUploadStatus().setState(MultipartUploadState.UPLOADING);
-		composite.getMultipartUploadStatus().setResultFileHandleId("12345");
-		composite.setNumberOfParts(3);
-		//call under test.
-		assertThrows(IllegalArgumentException.class, () -> MultipartManagerV2Impl.prepareCompleteStatus(composite));
+	public void testPrepareCompleteStatusNotComplete() {
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(3);
+		when(mockStatus.getState()).thenReturn(MultipartUploadState.UPLOADING);
+		when(mockStatus.getResultFileHandleId()).thenReturn("12345");
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			MultipartManagerV2Impl.prepareCompleteStatus(mockCompositeStatus);
+		}).getMessage();
+
+		assertEquals("Expected a COMPLETED state", errorMessage);
 	}
-	
+
 	@Test
-	public void testPrepareCompleteStatusMissingFileHandle(){
-		composite.getMultipartUploadStatus().setState(MultipartUploadState.COMPLETED);
-		composite.getMultipartUploadStatus().setResultFileHandleId(null);
-		composite.setNumberOfParts(3);
-		//call under test.
-		assertThrows(IllegalArgumentException.class, () -> MultipartManagerV2Impl.prepareCompleteStatus(composite));
+	public void testPrepareCompleteStatusMissingFileHandle() {
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockStatus.getResultFileHandleId()).thenReturn(null);
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			MultipartManagerV2Impl.prepareCompleteStatus(mockCompositeStatus);
+		}).getMessage();
+
+		assertEquals("ResultFileHandleId is required.", errorMessage);
 	}
-	
+
 	@Test
-	public void testPrepareCompleteStatusMissingNumberOfParts(){
-		composite.getMultipartUploadStatus().setState(MultipartUploadState.COMPLETED);
-		composite.getMultipartUploadStatus().setResultFileHandleId("12345");
-		composite.setNumberOfParts(null);
-		//call under test.
-		assertThrows(IllegalArgumentException.class, () -> MultipartManagerV2Impl.prepareCompleteStatus(composite));
+	public void testPrepareCompleteStatusMissingNumberOfParts() {
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockCompositeStatus.getNumberOfParts()).thenReturn(null);
+		when(mockStatus.getResultFileHandleId()).thenReturn("12345");
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			MultipartManagerV2Impl.prepareCompleteStatus(mockCompositeStatus);
+		}).getMessage();
+
+		assertEquals("NumberOfParts is required.", errorMessage);
 	}
-	
+
 	@Test
-	public void testGetOriginalRequest(){
-		String uploadId = composite.getMultipartUploadStatus().getUploadId();
-		when(mockMultiparUploadDAO.getUploadRequest(uploadId)).thenReturn(requestJson);
-		// call under test
-		MultipartUploadRequest returnedRequest = manager.getOriginalRequest(uploadId, MultipartUploadRequest.class);
-		assertEquals(request, returnedRequest);
+	public void testValidatePartsHappy() {
+		List<PartMD5> addedParts = Arrays.asList(new PartMD5(2, "partMD5HexTwo"), new PartMD5(1, "partMD5HexOne"));
+		int numberOfParts = 2;
+
+		// Call under test
+		MultipartManagerV2Impl.validateParts(numberOfParts, addedParts);
 	}
-	
+
+	@Test
+	public void testValidatePartsMissing() {
+		List<PartMD5> addedParts = Arrays.asList(new PartMD5(2, "partMD5HexTwo"), new PartMD5(1, "partMD5HexOne"));
+		int numberOfParts = 3;
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			MultipartManagerV2Impl.validateParts(numberOfParts, addedParts);
+		}).getMessage();
+
+		assertEquals("Missing 1 part(s).  All parts must be successfully added before a file upload can be completed.",
+				errorMessage);
+	}
+
 	@Test
 	public void testCreateFileHandle() {
 
 		FileHandleCreateRequest request = new FileHandleCreateRequest("fileName", "contentType", "md5", 123L, true);
-		
+
+		String bucket = "bucket";
+		String key = "key";
 		long fileSize = 123;
-		// call under test
-		S3FileHandle result = (S3FileHandle) manager.createFileHandle(fileSize, composite, request);
-		assertEquals(fileHandle, result);
-		
+		Long fileHandleId = 123456L;
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockCompositeStatus.getBucket()).thenReturn(bucket);
+		when(mockCompositeStatus.getKey()).thenReturn(key);
+		when(mockCompositeStatus.getUploadType()).thenReturn(UploadType.S3);
+		when(mockIdGenerator.generateNewId(any())).thenReturn(fileHandleId);
+		when(mockFileHandleDao.createFile(any())).thenReturn(mockFileHandle);
+
+		// Call under test
+		CloudProviderFileHandleInterface result = manager.createFileHandle(fileSize, mockCompositeStatus, request);
+
+		assertEquals(mockFileHandle, result);
+
 		ArgumentCaptor<S3FileHandle> capture = ArgumentCaptor.forClass(S3FileHandle.class);
+
+		verify(mockIdGenerator).generateNewId(IdType.FILE_IDS);
 		verify(mockFileHandleDao).createFile(capture.capture());
-		
+
 		S3FileHandle capturedFileHandle = capture.getValue();
-		assertEquals(composite.getBucket(), capturedFileHandle.getBucketName());
-		assertEquals(composite.getKey(), capturedFileHandle.getKey());
+
+		assertEquals(fileHandleId.toString(), capturedFileHandle.getId());
+		assertEquals(bucket, capturedFileHandle.getBucketName());
+		assertEquals(key, capturedFileHandle.getKey());
 		assertEquals(request.getContentMD5(), capturedFileHandle.getContentMd5());
 		assertEquals(request.getContentType(), capturedFileHandle.getContentType());
 		assertEquals(123L, capturedFileHandle.getStorageLocationId());
-		assertEquals(new Long(fileSize), capturedFileHandle.getContentSize());
-		assertEquals(""+userInfo.getId(), capturedFileHandle.getCreatedBy());
+		assertEquals(fileSize, capturedFileHandle.getContentSize());
+		assertEquals(user.getId().toString(), capturedFileHandle.getCreatedBy());
 		assertNotNull(capturedFileHandle.getCreatedOn());
 		assertNotNull(capturedFileHandle.getEtag());
 		assertEquals(request.getFileName(), capturedFileHandle.getFileName());
 		assertNull(capturedFileHandle.getPreviewId());
 	}
-	
+
 	@Test
-	public void testcreateFileHandleNoPreview() {
-		long fileSize = 123;
-		
+	public void testCreateFileHandleNoPreview() {
 		FileHandleCreateRequest request = new FileHandleCreateRequest("fileName", "contentType", "md5", 123L, false);
-		
-		// call under test
-		S3FileHandle result = (S3FileHandle) manager.createFileHandle(fileSize, composite, request);
-		assertEquals(fileHandle, result);
-		
-		ArgumentCaptor<S3FileHandle> capture = ArgumentCaptor.forClass(S3FileHandle.class);
-		verify(mockFileHandleDao).createFile(capture.capture());
-		
-		// preview should not be generated
-		assertEquals(capture.getValue().getPreviewId(), result.getId());
-	}
-	
-	@Test
-	public void testcreateFileHandleNullPreview() {
+
+		String bucket = "bucket";
+		String key = "key";
 		long fileSize = 123;
-		
+		Long fileHandleId = 123456L;
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockCompositeStatus.getBucket()).thenReturn(bucket);
+		when(mockCompositeStatus.getKey()).thenReturn(key);
+		when(mockCompositeStatus.getUploadType()).thenReturn(UploadType.S3);
+		when(mockIdGenerator.generateNewId(any())).thenReturn(fileHandleId);
+		when(mockFileHandleDao.createFile(any())).thenReturn(mockFileHandle);
+
+		// Call under test
+		CloudProviderFileHandleInterface result = manager.createFileHandle(fileSize, mockCompositeStatus, request);
+
+		assertEquals(mockFileHandle, result);
+
+		ArgumentCaptor<S3FileHandle> capture = ArgumentCaptor.forClass(S3FileHandle.class);
+
+		verify(mockFileHandleDao).createFile(capture.capture());
+
+		// preview should not be generated
+		assertEquals(capture.getValue().getPreviewId(), fileHandleId.toString());
+	}
+
+	@Test
+	public void testCreateFileHandleNullPreview() {
 		FileHandleCreateRequest request = new FileHandleCreateRequest("fileName", "contentType", "md5", 123L, null);
-		
-		// call under test
-		S3FileHandle result = (S3FileHandle) manager.createFileHandle(fileSize, composite, request);
-		assertEquals(fileHandle, result);
-		
+
+		String bucket = "bucket";
+		String key = "key";
+		long fileSize = 123;
+		Long fileHandleId = 123456L;
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockCompositeStatus.getBucket()).thenReturn(bucket);
+		when(mockCompositeStatus.getKey()).thenReturn(key);
+		when(mockCompositeStatus.getUploadType()).thenReturn(UploadType.S3);
+		when(mockIdGenerator.generateNewId(any())).thenReturn(fileHandleId);
+		when(mockFileHandleDao.createFile(any())).thenReturn(mockFileHandle);
+
+		// Call under test
+		CloudProviderFileHandleInterface result = manager.createFileHandle(fileSize, mockCompositeStatus, request);
+		assertEquals(mockFileHandle, result);
+
 		ArgumentCaptor<S3FileHandle> capture = ArgumentCaptor.forClass(S3FileHandle.class);
 		verify(mockFileHandleDao).createFile(capture.capture());
-		
+
 		// preview should be generated
 		assertNull(capture.getValue().getPreviewId());
 	}
-	
+
 	@Test
 	public void testCreateFileHandleGoogleCloud() {
 
 		FileHandleCreateRequest request = new FileHandleCreateRequest("fileName", "contentType", "md5", 123L, true);
-		
+
+		String bucket = "bucket";
+		String key = "key";
 		long fileSize = 123;
-		composite.setUploadType(UploadType.GOOGLECLOUDSTORAGE);
-		// call under test
-		GoogleCloudFileHandle result = (GoogleCloudFileHandle) manager.createFileHandle(fileSize, composite, request);
-		assertEquals(googleCloudFileHandle, result);
+		Long fileHandleId = 123456L;
+
+		when(mockStatus.getStartedBy()).thenReturn(user.getId().toString());
+		when(mockCompositeStatus.getMultipartUploadStatus()).thenReturn(mockStatus);
+		when(mockCompositeStatus.getBucket()).thenReturn(bucket);
+		when(mockCompositeStatus.getKey()).thenReturn(key);
+		when(mockCompositeStatus.getUploadType()).thenReturn(UploadType.GOOGLECLOUDSTORAGE);
+		when(mockIdGenerator.generateNewId(any())).thenReturn(fileHandleId);
+		when(mockFileHandleDao.createFile(any())).thenReturn(mockFileHandle);
+
+		// Call under test
+		CloudProviderFileHandleInterface result = manager.createFileHandle(fileSize, mockCompositeStatus, request);
+
+		assertEquals(mockFileHandle, result);
 
 		ArgumentCaptor<GoogleCloudFileHandle> capture = ArgumentCaptor.forClass(GoogleCloudFileHandle.class);
+
+		verify(mockIdGenerator).generateNewId(IdType.FILE_IDS);
 		verify(mockFileHandleDao).createFile(capture.capture());
 
 		GoogleCloudFileHandle capturedFileHandle = capture.getValue();
-		assertEquals(composite.getBucket(), capturedFileHandle.getBucketName());
-		assertEquals(composite.getKey(), capturedFileHandle.getKey());
+
+		assertEquals(fileHandleId.toString(), capturedFileHandle.getId());
+		assertEquals(bucket, capturedFileHandle.getBucketName());
+		assertEquals(key, capturedFileHandle.getKey());
 		assertEquals(request.getContentMD5(), capturedFileHandle.getContentMd5());
 		assertEquals(request.getContentType(), capturedFileHandle.getContentType());
-		assertEquals(new Long(fileSize), capturedFileHandle.getContentSize());
-		assertEquals(""+userInfo.getId(), capturedFileHandle.getCreatedBy());
+		assertEquals(123L, capturedFileHandle.getStorageLocationId());
+		assertEquals(fileSize, capturedFileHandle.getContentSize());
+		assertEquals(user.getId().toString(), capturedFileHandle.getCreatedBy());
 		assertNotNull(capturedFileHandle.getCreatedOn());
 		assertNotNull(capturedFileHandle.getEtag());
 		assertEquals(request.getFileName(), capturedFileHandle.getFileName());
 		assertNull(capturedFileHandle.getPreviewId());
+
 	}
-	
+
 	@Test
-	public void testCompleteMultipartUploadHappy(){		
-		//call under test
-		MultipartUploadStatus status = manager.completeMultipartUpload(userInfo, uploadId);
-		assertNotNull(status);
-		assertEquals(MultipartUploadState.COMPLETED, status.getState());
-		assertEquals("11", status.getPartsState());
-		assertEquals(fileHandle.getId(), status.getResultFileHandleId());
-		
-		verify(mockMultiparUploadDAO).getUploadStatus(uploadId);
-		verify(mockMultiparUploadDAO).getAddedPartMD5s(uploadId);
-		verify(mockFileHandleDao).createFile(any(S3FileHandle.class));
-		
-		ArgumentCaptor<CompleteMultipartRequest> completeCpature = ArgumentCaptor.forClass(CompleteMultipartRequest.class);
-		verify(mockS3multipartUploadDAO).completeMultipartUpload(completeCpature.capture());
-		assertEquals(composite.getBucket(), completeCpature.getValue().getBucket());
-		assertEquals(composite.getKey(), completeCpature.getValue().getKey());
-		assertEquals(uploadToken, completeCpature.getValue().getUploadToken());
-		assertEquals(addedParts, completeCpature.getValue().getAddedParts());
-		
-		verify(mockMultiparUploadDAO).setUploadComplete(uploadId, fileHandle.getId());
-	}
-	
-	@Test
-	public void testCompleteMultipartUploadUnAuthorized(){
-		// started by another.
-		composite.getMultipartUploadStatus().setStartedBy(""+(userInfo.getId()+1));
-	
-		//call under test
-		assertThrows(UnauthorizedException.class, () -> manager.completeMultipartUpload(userInfo, uploadId));
-	}
-	
-	@Test
-	public void testCompleteMultipartUploadAlreadyComplete(){
-		// the upload is already complete.s
-		composite.getMultipartUploadStatus().setState(MultipartUploadState.COMPLETED);
-		composite.getMultipartUploadStatus().setResultFileHandleId(fileHandle.getId());
-		//call under test
-		MultipartUploadStatus status = manager.completeMultipartUpload(userInfo, uploadId);
-		assertNotNull(status);
-		assertEquals(MultipartUploadState.COMPLETED, status.getState());
-		assertEquals("11", status.getPartsState());
-		assertEquals(fileHandle.getId(), status.getResultFileHandleId());
-		
-		verify(mockMultiparUploadDAO).getUploadStatus(uploadId);
-		verify(mockMultiparUploadDAO, never()).getAddedPartMD5s(uploadId);
-		verify(mockFileHandleDao, never()).createFile(any(S3FileHandle.class));
-		verify(mockS3multipartUploadDAO, never()).completeMultipartUpload(any(CompleteMultipartRequest.class));
-		verify(mockMultiparUploadDAO, never()).setUploadComplete(uploadId, fileHandle.getId());		
-	}
-	
-	@Test
-	public void testCompleteMultipartUploadNotReady(){
-		// the upload is missing a file.
-		addedParts.remove(1);
-		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> manager.completeMultipartUpload(userInfo, uploadId));
-		assertTrue(e.getMessage().contains("Missing 1 part(s"));
-		verify(mockMultiparUploadDAO).getUploadStatus(uploadId);
-		verify(mockMultiparUploadDAO).getAddedPartMD5s(uploadId);
-		verify(mockFileHandleDao, never()).createFile(any(S3FileHandle.class));
-		verify(mockS3multipartUploadDAO, never()).completeMultipartUpload(any(CompleteMultipartRequest.class));
-		verify(mockMultiparUploadDAO, never()).setUploadComplete(uploadId, fileHandle.getId());		
-	}
-	
-	@Test
-	public void testCompleteMultipartUploadWithCopyRequest() {
-		composite.setRequestType(MultiPartRequestType.COPY);
-		composite.setSourceFileHandleId(Long.valueOf(fileHandle.getId()));
-		
-		when(mockFileHandleDao.get(any())).thenReturn(fileHandle);
-		
-		//call under test
-		MultipartUploadStatus status = manager.completeMultipartUpload(userInfo, uploadId);
-		
-		assertNotNull(status);
-		assertEquals(MultipartUploadState.COMPLETED, status.getState());
-		assertEquals("11", status.getPartsState());
-		assertEquals(fileHandle.getId(), status.getResultFileHandleId());
-		
-		verify(mockMultiparUploadDAO).getUploadStatus(uploadId);
-		verify(mockMultiparUploadDAO).getAddedPartMD5s(uploadId);
-		verify(mockFileHandleDao).get(fileHandle.getId());
-		verify(mockFileHandleDao).createFile(any(S3FileHandle.class));
-		
-		ArgumentCaptor<CompleteMultipartRequest> completeCpature = ArgumentCaptor.forClass(CompleteMultipartRequest.class);
-		verify(mockS3multipartUploadDAO).completeMultipartUpload(completeCpature.capture());
-		assertEquals(composite.getBucket(), completeCpature.getValue().getBucket());
-		assertEquals(composite.getKey(), completeCpature.getValue().getKey());
-		assertEquals(uploadToken, completeCpature.getValue().getUploadToken());
-		assertEquals(addedParts, completeCpature.getValue().getAddedParts());
-		
-		verify(mockMultiparUploadDAO).setUploadComplete(uploadId, fileHandle.getId());
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadCopy() {
-		
-		Long userId = 123456L;
-		Long contentSize = 5242880 * 10L;
-		String contentMd5 = "md5";
-		
-		fileHandle.setFileName("fileName");
-		fileHandle.setContentSize(contentSize);
-		fileHandle.setContentMd5(contentMd5);
-		
-		String fileEntityId = "456";
-		Long storageLocationId = 789L;
-		
-		FileHandleAssociation association = new FileHandleAssociation();
-		
-		association.setAssociateObjectType(FileHandleAssociateType.FileEntity);
-		association.setAssociateObjectId(fileEntityId);
-		association.setFileHandleId(fileHandle.getId());
-		
-		MultipartUploadCopyRequest request = new MultipartUploadCopyRequest();
-		
-		request.setFileName("targetFileName");
-		request.setSourceFileHandleAssociation(association);
-		request.setPartSizeBytes(5242880L);
-		request.setStorageLocationId(storageLocationId);
-		
-		String requestHash = MultipartRequestUtils.calculateMD5AsHex(request);
-		String requestJson = MultipartRequestUtils.createRequestJSON(request);
-		boolean forceRestart = false;
-		
-		MultipartUploadStatus status = new MultipartUploadStatus();
-		
-		status.setStartedBy(String.valueOf(userInfo.getId()));
-		status.setState(MultipartUploadState.UPLOADING);
-		status.setUploadId(uploadId);
-		status.setPartsState("00000");
-		
-		CompositeMultipartUploadStatus compositeStatus = new CompositeMultipartUploadStatus();
-		
-		compositeStatus.setMultipartUploadStatus(status);
-		compositeStatus.setUploadToken(uploadToken);
-		compositeStatus.setNumberOfParts(10);
-		
-		when(userInfo.getId()).thenReturn(userId);
-		when(mockMultiparUploadDAO.getUploadStatus(any(), any())).thenReturn(null);
-		when(mockStorageLocation.getCreatedBy()).thenReturn(userId);
-		when(mockStorageLocation.getUploadType()).thenReturn(UploadType.S3);
-		when(mockProjectSettingsManager.getStorageLocationSetting(any())).thenReturn(mockStorageLocation);
-		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(Collections.singletonList(new FileHandleAssociationAuthorizationStatus(association, AuthorizationStatus.authorized())));
-		when(mockFileHandleDao.get(any())).thenReturn(fileHandle);
-		when(mockUploadDAOProvider.getCloudServiceMultipartUploadDao(UploadType.S3)).thenReturn(mockS3multipartUploadDAO);
-		when(mockS3multipartUploadDAO.initiateMultipartUploadCopy(any(), any(), any(), any())).thenReturn(uploadToken);
-		when(mockMultiparUploadDAO.createUploadStatus(any())).thenReturn(compositeStatus);
-		when(mockMultiparUploadDAO.getPartsState(any(), anyInt())).thenReturn(status.getPartsState());
-		
-		// Call under test
-		MultipartUploadStatus result = manager.startOrResumeMultipartUploadCopy(userInfo, request, forceRestart);
-		
-		assertEquals(status, result);
-		
-		verify(mockMultiparUploadDAO).getUploadStatus(userId, requestHash);
-		verify(mockProjectSettingsManager).getStorageLocationSetting(storageLocationId);
-		verify(mockAuthManager).canDownLoadFile(userInfo, Collections.singletonList(association));
-		verify(mockFileHandleDao).get(fileHandle.getId());
-		verify(mockS3multipartUploadDAO).initiateMultipartUploadCopy(eq(synapseBucket), endsWith(request.getFileName()), eq(request), eq(fileHandle));
-		
-		ArgumentCaptor<CreateMultipartRequest> captor = ArgumentCaptor.forClass(CreateMultipartRequest.class);
-		
-		verify(mockMultiparUploadDAO).createUploadStatus(captor.capture());
-		
-		CreateMultipartRequest capturedRequest = captor.getValue();
-		
-		assertEquals(userId, capturedRequest.getUserId());
-		assertEquals(synapseBucket, capturedRequest.getBucket());
-		assertEquals(request.getPartSizeBytes(), capturedRequest.getPartSize());
-		assertEquals(requestHash, capturedRequest.getHash());
-		assertEquals(compositeStatus.getNumberOfParts(), capturedRequest.getNumberOfParts());
-		assertEquals(uploadToken, capturedRequest.getUploadToken());
-		assertEquals(UploadType.S3, capturedRequest.getUploadType());
-		assertEquals(requestJson, capturedRequest.getRequestBody());
-		assertEquals(fileHandle.getId(), capturedRequest.getSourceFileHandleId());
-		
-		verify(mockMultiparUploadDAO).getPartsState(uploadId, compositeStatus.getNumberOfParts());
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadCopyAndNotAuthorized() {
-		
-		Long userId = 123456L;
-		Long contentSize = 5242880 * 10L;
-		String contentMd5 = "md5";
-		
-		fileHandle.setFileName("fileName");
-		fileHandle.setContentSize(contentSize);
-		fileHandle.setContentMd5(contentMd5);
-		
-		String fileEntityId = "456";
-		Long storageLocationId = 789L;
-		
-		FileHandleAssociation association = new FileHandleAssociation();
-		
-		association.setAssociateObjectType(FileHandleAssociateType.FileEntity);
-		association.setAssociateObjectId(fileEntityId);
-		association.setFileHandleId(fileHandle.getId());
-		
-		MultipartUploadCopyRequest request = new MultipartUploadCopyRequest();
-		
-		request.setFileName("targetFileName");
-		request.setSourceFileHandleAssociation(association);
-		request.setPartSizeBytes(5242880L);
-		request.setStorageLocationId(storageLocationId);
-		
-		String requestHash = MultipartRequestUtils.calculateMD5AsHex(request);
-		boolean forceRestart = false;
-		
-		when(userInfo.getId()).thenReturn(userId);
-		when(mockMultiparUploadDAO.getUploadStatus(any(), any())).thenReturn(null);
-		when(mockStorageLocation.getCreatedBy()).thenReturn(userId);
-		when(mockStorageLocation.getUploadType()).thenReturn(UploadType.S3);
-		when(mockProjectSettingsManager.getStorageLocationSetting(any())).thenReturn(mockStorageLocation);
-		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(Collections.singletonList(new FileHandleAssociationAuthorizationStatus(association, AuthorizationStatus.accessDenied("Denied"))));
-		
-		String errorMessage = assertThrows(UnauthorizedException.class, () -> {			
+	public void testCreateFileHandleWithUnsupportedType() {
+
+		FileHandleCreateRequest request = new FileHandleCreateRequest("fileName", "contentType", "md5", 123L, true);
+
+		long fileSize = 123;
+
+		when(mockCompositeStatus.getUploadType()).thenReturn(UploadType.HTTPS);
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
 			// Call under test
-			manager.startOrResumeMultipartUploadCopy(userInfo, request, forceRestart);
-		}).getMessage();
-		
-		assertEquals("The user is not authorized to access the source file.", errorMessage);
-		verify(mockMultiparUploadDAO).getUploadStatus(userId, requestHash);
-		verify(mockProjectSettingsManager).getStorageLocationSetting(storageLocationId);
-		verify(mockAuthManager).canDownLoadFile(userInfo, Collections.singletonList(association));
-		verifyNoMoreInteractions(mockMultiparUploadDAO);
-		verifyNoMoreInteractions(mockFileHandleDao);
-		verifyNoMoreInteractions(mockS3multipartUploadDAO);
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadCopyAndNotStorageLocationOwner() {
-		
-		Long userId = 123456L;
-		Long contentSize = 5242880 * 10L;
-		String contentMd5 = "md5";
-		
-		fileHandle.setFileName("fileName");
-		fileHandle.setContentSize(contentSize);
-		fileHandle.setContentMd5(contentMd5);
-		
-		String fileEntityId = "456";
-		Long storageLocationId = 789L;
-		
-		FileHandleAssociation association = new FileHandleAssociation();
-		
-		association.setAssociateObjectType(FileHandleAssociateType.FileEntity);
-		association.setAssociateObjectId(fileEntityId);
-		association.setFileHandleId(fileHandle.getId());
-		
-		MultipartUploadCopyRequest request = new MultipartUploadCopyRequest();
-		
-		request.setFileName("targetFileName");
-		request.setSourceFileHandleAssociation(association);
-		request.setPartSizeBytes(5242880L);
-		request.setStorageLocationId(storageLocationId);
-		
-		String requestHash = MultipartRequestUtils.calculateMD5AsHex(request);
-		boolean forceRestart = false;
-		
-		when(userInfo.getId()).thenReturn(userId);
-		when(mockMultiparUploadDAO.getUploadStatus(any(), any())).thenReturn(null);
-		when(mockStorageLocation.getCreatedBy()).thenReturn(userId + 1);
-		when(mockStorageLocation.getUploadType()).thenReturn(UploadType.S3);
-		when(mockProjectSettingsManager.getStorageLocationSetting(any())).thenReturn(mockStorageLocation);
-		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(Collections.singletonList(new FileHandleAssociationAuthorizationStatus(association, AuthorizationStatus.authorized())));
-		
-		String errorMessage = assertThrows(UnauthorizedException.class, () -> {			
-			// Call under test
-			manager.startOrResumeMultipartUploadCopy(userInfo, request, forceRestart);
-		}).getMessage();
-		
-		assertEquals("The user does not own the destination storage location.", errorMessage);
-		
-		verify(mockMultiparUploadDAO).getUploadStatus(userId, requestHash);
-		verify(mockProjectSettingsManager).getStorageLocationSetting(storageLocationId);
-		verify(mockAuthManager).canDownLoadFile(userInfo, Collections.singletonList(association));
-		verifyNoMoreInteractions(mockMultiparUploadDAO);
-		verifyNoMoreInteractions(mockFileHandleDao);
-		verifyNoMoreInteractions(mockS3multipartUploadDAO);
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadCopyAndFileWithNoContentSize() {
-		
-		Long userId = 123456L;
-		Long contentSize = null;
-		String contentMd5 = "md5";
-		
-		fileHandle.setFileName("fileName");
-		fileHandle.setContentSize(contentSize);
-		fileHandle.setContentMd5(contentMd5);
-		
-		String fileEntityId = "456";
-		Long storageLocationId = 789L;
-		
-		FileHandleAssociation association = new FileHandleAssociation();
-		
-		association.setAssociateObjectType(FileHandleAssociateType.FileEntity);
-		association.setAssociateObjectId(fileEntityId);
-		association.setFileHandleId(fileHandle.getId());
-		
-		MultipartUploadCopyRequest request = new MultipartUploadCopyRequest();
-		
-		request.setFileName("targetFileName");
-		request.setSourceFileHandleAssociation(association);
-		request.setPartSizeBytes(5242880L);
-		request.setStorageLocationId(storageLocationId);
-		
-		String requestHash = MultipartRequestUtils.calculateMD5AsHex(request);
-		
-		boolean forceRestart = false;
-		
-		when(userInfo.getId()).thenReturn(userId);
-		when(mockMultiparUploadDAO.getUploadStatus(any(), any())).thenReturn(null);
-		when(mockStorageLocation.getCreatedBy()).thenReturn(userId);
-		when(mockStorageLocation.getUploadType()).thenReturn(UploadType.S3);
-		when(mockProjectSettingsManager.getStorageLocationSetting(any())).thenReturn(mockStorageLocation);
-		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(Collections.singletonList(new FileHandleAssociationAuthorizationStatus(association, AuthorizationStatus.authorized())));
-		when(mockFileHandleDao.get(any())).thenReturn(fileHandle);
-		
-		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
-			// Call under test
-			manager.startOrResumeMultipartUploadCopy(userInfo, request, forceRestart);
+			manager.createFileHandle(fileSize, mockCompositeStatus, request);
 		}).getMessage();
 
-		assertEquals("The source file handle does not define its size.", errorMessage);
-		verify(mockMultiparUploadDAO).getUploadStatus(userId, requestHash);
-		verify(mockProjectSettingsManager).getStorageLocationSetting(storageLocationId);
-		verify(mockAuthManager).canDownLoadFile(userInfo, Collections.singletonList(association));
-		verify(mockFileHandleDao).get(fileHandle.getId());
-		verifyNoMoreInteractions(mockMultiparUploadDAO);
-		verifyNoMoreInteractions(mockFileHandleDao);
-		verifyNoMoreInteractions(mockS3multipartUploadDAO);
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadCopyAndFileWithNoMD5() {
-		
-		Long userId = 123456L;
-		Long contentSize = 5242880 * 10L;
-		String contentMd5 = null;
-		
-		fileHandle.setFileName("fileName");
-		fileHandle.setContentSize(contentSize);
-		fileHandle.setContentMd5(contentMd5);
-		
-		String fileEntityId = "456";
-		Long storageLocationId = 789L;
-		
-		FileHandleAssociation association = new FileHandleAssociation();
-		
-		association.setAssociateObjectType(FileHandleAssociateType.FileEntity);
-		association.setAssociateObjectId(fileEntityId);
-		association.setFileHandleId(fileHandle.getId());
-		
-		MultipartUploadCopyRequest request = new MultipartUploadCopyRequest();
-		
-		request.setFileName("targetFileName");
-		request.setSourceFileHandleAssociation(association);
-		request.setPartSizeBytes(5242880L);
-		request.setStorageLocationId(storageLocationId);
-		
-		String requestHash = MultipartRequestUtils.calculateMD5AsHex(request);
-		
-		boolean forceRestart = false;
-		
-		when(userInfo.getId()).thenReturn(userId);
-		when(mockMultiparUploadDAO.getUploadStatus(any(), any())).thenReturn(null);
-		when(mockStorageLocation.getCreatedBy()).thenReturn(userId);
-		when(mockStorageLocation.getUploadType()).thenReturn(UploadType.S3);
-		when(mockProjectSettingsManager.getStorageLocationSetting(any())).thenReturn(mockStorageLocation);
-		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(Collections.singletonList(new FileHandleAssociationAuthorizationStatus(association, AuthorizationStatus.authorized())));
-		when(mockFileHandleDao.get(any())).thenReturn(fileHandle);
-		
-		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
-			// Call under test
-			manager.startOrResumeMultipartUploadCopy(userInfo, request, forceRestart);
-		}).getMessage();
+		assertEquals("Cannot create a FileHandle from a multipart upload with upload type HTTPS", errorMessage);
 
-		assertEquals("The source file handle does not define its content MD5.", errorMessage);
-		verify(mockMultiparUploadDAO).getUploadStatus(userId, requestHash);
-		verify(mockProjectSettingsManager).getStorageLocationSetting(storageLocationId);
-		verify(mockAuthManager).canDownLoadFile(userInfo, Collections.singletonList(association));
-		verify(mockFileHandleDao).get(fileHandle.getId());
-		verifyNoMoreInteractions(mockMultiparUploadDAO);
-		verifyNoMoreInteractions(mockFileHandleDao);
-		verifyNoMoreInteractions(mockS3multipartUploadDAO);
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadCopyWithNoAssociation() {
-		
-		Long userId = 123456L;
-		Long contentSize = 5242880 * 10L;
-		String contentMd5 = "md5";
-		
-		fileHandle.setFileName("fileName");
-		fileHandle.setContentSize(contentSize);
-		fileHandle.setContentMd5(contentMd5);
-		
-		Long storageLocationId = 789L;
-		
-		FileHandleAssociation association = null;
-		
-		MultipartUploadCopyRequest request = new MultipartUploadCopyRequest();
-		
-		request.setFileName("targetFileName");
-		request.setSourceFileHandleAssociation(association);
-		request.setPartSizeBytes(5242880L);
-		request.setStorageLocationId(storageLocationId);
-		
-		boolean forceRestart = false;
-		
-		when(userInfo.getId()).thenReturn(userId);
-		
-		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
-			// Call under test
-			manager.startOrResumeMultipartUploadCopy(userInfo, request, forceRestart);
-		}).getMessage();
-		
-		assertEquals("MultipartUploadCopyRequest.sourceFileHandleAssociation is required.", errorMessage);
-		
-		verifyZeroInteractions(mockMultiparUploadDAO);
-		verifyZeroInteractions(mockProjectSettingsManager);
-		verifyZeroInteractions(mockAuthManager);
+		verifyZeroInteractions(mockIdGenerator);
 		verifyZeroInteractions(mockFileHandleDao);
-		verifyZeroInteractions(mockUploadDAOProvider);
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadCopyWithNoStorageLocation() {
-		
-		Long userId = 123456L;
-		Long contentSize = 5242880 * 10L;
-		String contentMd5 = "md5";
-		
-		fileHandle.setFileName("fileName");
-		fileHandle.setContentSize(contentSize);
-		fileHandle.setContentMd5(contentMd5);
-		
-		Long storageLocationId = null;
-		
-		String fileEntityId = "456";
-		
-		FileHandleAssociation association = new FileHandleAssociation();
-		
-		association.setAssociateObjectType(FileHandleAssociateType.FileEntity);
-		association.setAssociateObjectId(fileEntityId);
-		association.setFileHandleId(fileHandle.getId());
-		
-		MultipartUploadCopyRequest request = new MultipartUploadCopyRequest();
-		
-		request.setFileName("targetFileName");
-		request.setSourceFileHandleAssociation(association);
-		request.setPartSizeBytes(5242880L);
-		request.setStorageLocationId(storageLocationId);
-		
-		boolean forceRestart = false;
-		
-		when(userInfo.getId()).thenReturn(userId);
-		
-		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
-			// Call under test
-			manager.startOrResumeMultipartUploadCopy(userInfo, request, forceRestart);
-		}).getMessage();
-		
-		assertEquals("MultipartUploadCopyRequest.storageLocationId is required.", errorMessage);
-		
-		verifyZeroInteractions(mockMultiparUploadDAO);
-		verifyZeroInteractions(mockProjectSettingsManager);
-		verifyZeroInteractions(mockAuthManager);
-		verifyZeroInteractions(mockFileHandleDao);
-		verifyZeroInteractions(mockUploadDAOProvider);
-	}
-	
-	@Test
-	public void testStartOrResumeMultipartUploadCopyAndSameStorageLocation() {
-		
-		Long userId = 123456L;
-		Long contentSize = 5242880 * 10L;
-		String contentMd5 = "md5";
-		
-		String fileEntityId = "456";
-		Long storageLocationId = 789L;
 
-		fileHandle.setFileName("fileName");
-		fileHandle.setContentSize(contentSize);
-		fileHandle.setContentMd5(contentMd5);
-		fileHandle.setStorageLocationId(storageLocationId);
-		
-		FileHandleAssociation association = new FileHandleAssociation();
-		
-		association.setAssociateObjectType(FileHandleAssociateType.FileEntity);
-		association.setAssociateObjectId(fileEntityId);
-		association.setFileHandleId(fileHandle.getId());
-		
-		MultipartUploadCopyRequest request = new MultipartUploadCopyRequest();
-		
-		request.setFileName("targetFileName");
-		request.setSourceFileHandleAssociation(association);
-		request.setPartSizeBytes(5242880L);
-		request.setStorageLocationId(storageLocationId);
-		
-		String requestHash = MultipartRequestUtils.calculateMD5AsHex(request);
-		
-		boolean forceRestart = false;
-		
-		when(userInfo.getId()).thenReturn(userId);
-		when(mockMultiparUploadDAO.getUploadStatus(any(), any())).thenReturn(null);
-		// Same storage location as the source file handle
-		when(mockStorageLocation.getStorageLocationId()).thenReturn(storageLocationId);
-		when(mockStorageLocation.getCreatedBy()).thenReturn(userId);
-		when(mockStorageLocation.getUploadType()).thenReturn(UploadType.S3);
-		when(mockProjectSettingsManager.getStorageLocationSetting(any())).thenReturn(mockStorageLocation);
-		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(Collections.singletonList(new FileHandleAssociationAuthorizationStatus(association, AuthorizationStatus.authorized())));
-		when(mockFileHandleDao.get(any())).thenReturn(fileHandle);
-		
-		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
-			// Call under test
-			manager.startOrResumeMultipartUploadCopy(userInfo, request, forceRestart);
-		}).getMessage();
-
-		assertEquals("The source file handle is already in the given destination storage location.", errorMessage);
-		verify(mockMultiparUploadDAO).getUploadStatus(userId, requestHash);
-		verify(mockProjectSettingsManager).getStorageLocationSetting(storageLocationId);
-		verify(mockAuthManager).canDownLoadFile(userInfo, Collections.singletonList(association));
-		verify(mockFileHandleDao).get(fileHandle.getId());
-		verifyNoMoreInteractions(mockMultiparUploadDAO);
-		verifyNoMoreInteractions(mockFileHandleDao);
-		verifyNoMoreInteractions(mockS3multipartUploadDAO);
 	}
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/multipart/MultipartRequestHandlerProviderIntegrationTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/multipart/MultipartRequestHandlerProviderIntegrationTest.java
@@ -1,0 +1,38 @@
+package org.sagebionetworks.repo.manager.file.multipart;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.sagebionetworks.repo.model.dbo.file.MultiPartRequestType;
+import org.sagebionetworks.repo.model.file.MultipartRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(locations = { "classpath:test-context.xml" })
+public class MultipartRequestHandlerProviderIntegrationTest {
+
+	@Autowired
+	private MultipartRequestHandlerProvider provider;
+	
+	@Test
+	public void testHandlerForEachType() {
+		for (MultiPartRequestType type : MultiPartRequestType.values()) {
+			// Call under test
+			MultipartRequestHandler<? extends MultipartRequest> handler = provider.getHandlerForType(type);
+			assertNotNull(handler);
+		}
+	}
+	
+	@Test
+	public void testHandlerForEachTypeClass() {
+		for (MultiPartRequestType type : MultiPartRequestType.values()) {
+			// Call under test
+			MultipartRequestHandler<? extends MultipartRequest> handler = provider.getHandlerForClass(type.getRequestType());
+			assertNotNull(handler);
+		}
+	}
+	
+}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/multipart/MultipartRequestHandlerProviderTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/multipart/MultipartRequestHandlerProviderTest.java
@@ -1,0 +1,134 @@
+package org.sagebionetworks.repo.manager.file.multipart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sagebionetworks.repo.model.dbo.file.MultiPartRequestType;
+import org.sagebionetworks.repo.model.file.MultipartRequest;
+import org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest;
+import org.sagebionetworks.repo.model.file.MultipartUploadRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class MultipartRequestHandlerProviderTest {
+	
+	@Mock
+	private MultipartRequestHandler<MultipartUploadRequest> mockRequestHandler;
+
+	private MultipartRequestHandlerProviderImpl provider;
+	
+	@BeforeEach
+	public void before() {
+		when(mockRequestHandler.getRequestClass()).thenReturn(MultipartUploadRequest.class);
+	
+		provider = new MultipartRequestHandlerProviderImpl(Arrays.asList(mockRequestHandler));
+	}
+	
+	@Test
+	public void testProviderInitializationWithNullHandlers() {
+		List<MultipartRequestHandler<? extends MultipartRequest>> handlers = null;
+		
+		String errorMessage = assertThrows(IllegalStateException.class, () -> {
+			// Call under test
+			provider = new MultipartRequestHandlerProviderImpl(handlers);
+		}).getMessage();
+		
+		assertEquals("No multipart request handler found on the classpath.", errorMessage);
+	}
+	
+	@Test
+	public void testProviderInitializationWithNoHandlers() {
+		List<MultipartRequestHandler<? extends MultipartRequest>> handlers = Collections.emptyList();
+		
+		String errorMessage = assertThrows(IllegalStateException.class, () -> {
+			// Call under test
+			provider = new MultipartRequestHandlerProviderImpl(handlers);
+		}).getMessage();
+		
+		assertEquals("No multipart request handler found on the classpath.", errorMessage);
+	}
+	
+	@Test
+	public void testProviderInitialization() {
+		List<MultipartRequestHandler<? extends MultipartRequest>> handlers = Arrays.asList(mockRequestHandler);
+		
+		// Call under test
+		provider = new MultipartRequestHandlerProviderImpl(handlers);
+	}
+	
+	@Test
+	public void testGetHandlerForType() {
+		
+		// Call under test
+		MultipartRequestHandler<? extends MultipartRequest> handler = provider.getHandlerForType(MultiPartRequestType.UPLOAD);
+		
+		assertEquals(mockRequestHandler, handler);
+		
+	}
+	
+	@Test
+	public void testGetHandlerForTypeWithUnregistered() {
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			// Call under test, note that for the test only the UPLOAD is registered
+			provider.getHandlerForType(MultiPartRequestType.COPY);
+		}).getMessage();
+		
+		assertEquals("Unsupported request type: org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest", errorMessage);
+		
+	}
+	
+	@Test
+	public void testGetHandlerForTypeWithNull() {
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			
+			// Call under test
+			provider.getHandlerForType(null);
+		}).getMessage();
+	
+		assertEquals("The requestType is required.", errorMessage);
+	}
+	
+	@Test
+	public void testGetHandlerForClass() {
+		// Call under test
+		MultipartRequestHandler<? extends MultipartRequest> handler = provider.getHandlerForClass(MultipartUploadRequest.class);
+		
+		assertEquals(mockRequestHandler, handler);
+	}
+	
+	@Test
+	public void testGetHandlerForClassWithUnregistered() {
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			// Call under test, note that for the test only the UPLOAD is registered
+			provider.getHandlerForClass(MultipartUploadCopyRequest.class);
+		}).getMessage();
+		
+		assertEquals("Unsupported request type: org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest", errorMessage);
+		
+	}
+	
+	@Test
+	public void testGetHandlerForClassWithNull() {
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			
+			// Call under test
+			provider.getHandlerForClass(null);
+		}).getMessage();
+	
+		assertEquals("The requestClass is required.", errorMessage);
+	}
+	
+}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/multipart/MultipartUploadCopyRequestHandlerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/multipart/MultipartUploadCopyRequestHandlerTest.java
@@ -1,0 +1,421 @@
+package org.sagebionetworks.repo.manager.file.multipart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sagebionetworks.repo.manager.file.FileHandleAssociationAuthorizationStatus;
+import org.sagebionetworks.repo.manager.file.FileHandleAuthorizationManager;
+import org.sagebionetworks.repo.model.UnauthorizedException;
+import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.model.auth.AuthorizationStatus;
+import org.sagebionetworks.repo.model.dao.FileHandleDao;
+import org.sagebionetworks.repo.model.dbo.file.CompositeMultipartUploadStatus;
+import org.sagebionetworks.repo.model.dbo.file.CreateMultipartRequest;
+import org.sagebionetworks.repo.model.dbo.file.MultipartRequestUtils;
+import org.sagebionetworks.repo.model.file.FileHandleAssociateType;
+import org.sagebionetworks.repo.model.file.FileHandleAssociation;
+import org.sagebionetworks.repo.model.file.MultipartUploadCopyRequest;
+import org.sagebionetworks.repo.model.file.PartUtils;
+import org.sagebionetworks.repo.model.file.S3FileHandle;
+import org.sagebionetworks.repo.model.file.UploadType;
+import org.sagebionetworks.repo.model.project.BucketOwnerStorageLocationSetting;
+import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAO;
+import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAOProvider;
+import org.sagebionetworks.upload.multipart.PresignedUrl;
+
+@ExtendWith(MockitoExtension.class)
+public class MultipartUploadCopyRequestHandlerTest {
+	
+	@Mock
+	private CloudServiceMultipartUploadDAO mockCloudDao;
+	
+	@Mock
+	private CloudServiceMultipartUploadDAOProvider mockCloudDaoProvider;
+	
+	@Mock
+	private FileHandleAuthorizationManager mockAuthManager;
+	
+	@Mock
+	private FileHandleDao mockFileHandleDao;
+
+	@InjectMocks
+	private MultipartUploadCopyRequestHandler handler;
+	
+	@Mock
+	private UserInfo mockUser;
+	
+	@Mock
+	private MultipartUploadCopyRequest mockRequest;
+	
+	@Mock
+	private BucketOwnerStorageLocationSetting mockStorageLocation;
+	
+	@Mock
+	private CompositeMultipartUploadStatus mockStatus;
+	
+	private S3FileHandle sourceFileHandle;
+	private String sourceFileEntityId;
+	private FileHandleAssociation fileHandleAssociation;
+	
+	@BeforeEach
+	public void before() {
+		sourceFileEntityId = "456";
+		sourceFileHandle = new S3FileHandle();
+		sourceFileHandle.setId("123");
+		sourceFileHandle.setFileName("filename");
+		sourceFileHandle.setContentMd5("contentMd5");
+		sourceFileHandle.setContentSize(1024L);
+		sourceFileHandle.setConcreteType("plain/text");
+		fileHandleAssociation = new FileHandleAssociation();
+		fileHandleAssociation.setAssociateObjectType(FileHandleAssociateType.FileEntity);
+		fileHandleAssociation.setAssociateObjectId(sourceFileEntityId);
+		fileHandleAssociation.setFileHandleId(sourceFileHandle.getId());
+	}
+	
+	@Test
+	public void testGetRequestClass() {
+		// Call under test
+		assertEquals(MultipartUploadCopyRequest.class, handler.getRequestClass());
+	}
+	
+	@Test
+	public void testValidateRequest() {
+		String fileName = "fileName";
+		Long storageLocationId = 678L;
+		
+		when(mockRequest.getFileName()).thenReturn(fileName);
+		when(mockRequest.getSourceFileHandleAssociation()).thenReturn(fileHandleAssociation);
+		when(mockRequest.getStorageLocationId()).thenReturn(storageLocationId);
+
+		// Call under test
+		handler.validateRequest(mockUser, mockRequest);
+	}
+	
+	@Test
+	public void testValidateRequestWithNoFileName() {
+		String fileName = null;
+		Long storageLocationId = 678L;
+		
+		when(mockRequest.getFileName()).thenReturn(fileName);
+		when(mockRequest.getSourceFileHandleAssociation()).thenReturn(fileHandleAssociation);
+		when(mockRequest.getStorageLocationId()).thenReturn(storageLocationId);
+
+		// Call under test
+		handler.validateRequest(mockUser, mockRequest);
+	}
+	
+	@Test
+	public void testValidateRequestWithInvalidFileName() {
+		Long storageLocationId = 123L;
+		String fileName = "文件.txt";
+		
+		when(mockRequest.getSourceFileHandleAssociation()).thenReturn(fileHandleAssociation);
+		when(mockRequest.getStorageLocationId()).thenReturn(storageLocationId);
+		when(mockRequest.getFileName()).thenReturn(fileName);
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			// Call under test
+			handler.validateRequest(mockUser, mockRequest);
+		}).getMessage();
+		
+		assertEquals("Invalid Name: '文件.txt'. Names may only contain: letters, numbers, spaces, underscores, hyphens, periods, plus signs, apostrophes, and parentheses", errorMessage);
+	}
+	
+	@Test
+	public void testValidateRequestWithNoStorageLocation() {
+		Long storageLocationId = null;
+		
+		when(mockRequest.getSourceFileHandleAssociation()).thenReturn(fileHandleAssociation);
+		when(mockRequest.getStorageLocationId()).thenReturn(storageLocationId);
+
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			// Call under test
+			handler.validateRequest(mockUser, mockRequest);
+		}).getMessage();
+		
+		assertEquals("MultipartUploadCopyRequest.storageLocationId is required.", errorMessage);
+	}
+	
+	@Test
+	public void testValidateRequestWithNoFileAssociation() {
+		fileHandleAssociation = null;
+		
+		when(mockRequest.getSourceFileHandleAssociation()).thenReturn(fileHandleAssociation);
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			// Call under test
+			handler.validateRequest(mockUser, mockRequest);
+		}).getMessage();
+		
+		assertEquals("MultipartUploadCopyRequest.sourceFileHandleAssociation is required.", errorMessage);
+	}
+	
+	
+	@Test
+	public void testInitiateRequest() {
+		Long partSize = PartUtils.MIN_PART_SIZE_BYTES;
+		Long storageLocationId = 456L;
+		Long userId = 123456L;
+		String requestHash = "hash";
+		String uploadToken = "token";
+		UploadType uploadType = UploadType.S3;
+		
+		when(mockRequest.getSourceFileHandleAssociation()).thenReturn(fileHandleAssociation);
+		when(mockRequest.getPartSizeBytes()).thenReturn(partSize);
+		when(mockUser.getId()).thenReturn(userId);
+		when(mockStorageLocation.getStorageLocationId()).thenReturn(storageLocationId);
+		when(mockStorageLocation.getCreatedBy()).thenReturn(userId);
+		when(mockStorageLocation.getUploadType()).thenReturn(uploadType);
+		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(Collections.singletonList(new FileHandleAssociationAuthorizationStatus(fileHandleAssociation, AuthorizationStatus.authorized())));
+		when(mockFileHandleDao.get(any())).thenReturn(sourceFileHandle);
+		when(mockCloudDaoProvider.getCloudServiceMultipartUploadDao(any())).thenReturn(mockCloudDao);
+		when(mockCloudDao.initiateMultipartUploadCopy(any(), any(), any(), any())).thenReturn(uploadToken);
+		
+		String requestBody = MultipartRequestUtils.createRequestJSON(mockRequest);
+		
+		CreateMultipartRequest expected = new CreateMultipartRequest(userId,
+				requestHash, requestBody, uploadToken, uploadType,
+				null, null, 1, partSize, sourceFileHandle.getId());
+		
+		// Call under test
+		CreateMultipartRequest result = handler.initiateRequest(mockUser, mockRequest, requestHash, mockStorageLocation);
+		
+		expected.setBucket(result.getBucket());
+		expected.setKey(result.getKey());
+		
+		assertEquals(expected, result);
+		
+		verify(mockAuthManager).canDownLoadFile(mockUser, Collections.singletonList(fileHandleAssociation));
+		verify(mockFileHandleDao).get(sourceFileHandle.getId());
+		verify(mockCloudDaoProvider).getCloudServiceMultipartUploadDao(uploadType);
+		verify(mockCloudDao).initiateMultipartUploadCopy(result.getBucket(), result.getKey(), mockRequest, sourceFileHandle);		
+	}
+	
+	@Test
+	public void testInitiateRequestAndFileWithNoContentMD5() {
+		sourceFileHandle.setContentMd5(null);
+		
+		Long userId = 123456L;
+		String requestHash = "hash";
+		UploadType uploadType = UploadType.S3;
+		
+		when(mockRequest.getSourceFileHandleAssociation()).thenReturn(fileHandleAssociation);
+		when(mockUser.getId()).thenReturn(userId);
+		when(mockStorageLocation.getCreatedBy()).thenReturn(userId);
+		when(mockStorageLocation.getUploadType()).thenReturn(uploadType);
+		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(Collections.singletonList(new FileHandleAssociationAuthorizationStatus(fileHandleAssociation, AuthorizationStatus.authorized())));
+		when(mockFileHandleDao.get(any())).thenReturn(sourceFileHandle);
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			// Call under test
+			handler.initiateRequest(mockUser, mockRequest, requestHash, mockStorageLocation);
+		}).getMessage();
+		
+		assertEquals("The source file handle does not define its content MD5.", errorMessage);
+		
+		verify(mockAuthManager).canDownLoadFile(mockUser, Collections.singletonList(fileHandleAssociation));
+		verify(mockFileHandleDao).get(sourceFileHandle.getId());
+		verifyZeroInteractions(mockCloudDaoProvider);
+		verifyZeroInteractions(mockCloudDao);
+	}
+	
+	@Test
+	public void testInitiateRequestAndFileWithNoContentSize() {
+		sourceFileHandle.setContentSize(null);
+		
+		Long userId = 123456L;
+		String requestHash = "hash";
+		UploadType uploadType = UploadType.S3;
+		
+		when(mockRequest.getSourceFileHandleAssociation()).thenReturn(fileHandleAssociation);
+		when(mockUser.getId()).thenReturn(userId);
+		when(mockStorageLocation.getCreatedBy()).thenReturn(userId);
+		when(mockStorageLocation.getUploadType()).thenReturn(uploadType);
+		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(Collections.singletonList(new FileHandleAssociationAuthorizationStatus(fileHandleAssociation, AuthorizationStatus.authorized())));
+		when(mockFileHandleDao.get(any())).thenReturn(sourceFileHandle);
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			// Call under test
+			handler.initiateRequest(mockUser, mockRequest, requestHash, mockStorageLocation);
+		}).getMessage();
+		
+		assertEquals("The source file handle does not define its size.", errorMessage);
+		
+		verify(mockAuthManager).canDownLoadFile(mockUser, Collections.singletonList(fileHandleAssociation));
+		verify(mockFileHandleDao).get(sourceFileHandle.getId());
+		verifyZeroInteractions(mockCloudDaoProvider);
+		verifyZeroInteractions(mockCloudDao);
+	}
+	
+	@Test
+	public void testInitiateRequestAndSameStorageLocation() {
+		Long storageLocationId = 456L;
+
+		sourceFileHandle.setStorageLocationId(storageLocationId);
+		
+		Long userId = 123456L;
+		String requestHash = "hash";
+		UploadType uploadType = UploadType.S3;
+		
+		when(mockRequest.getSourceFileHandleAssociation()).thenReturn(fileHandleAssociation);
+		when(mockUser.getId()).thenReturn(userId);
+		when(mockStorageLocation.getStorageLocationId()).thenReturn(storageLocationId);
+		when(mockStorageLocation.getCreatedBy()).thenReturn(userId);
+		when(mockStorageLocation.getUploadType()).thenReturn(uploadType);
+		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(Collections.singletonList(new FileHandleAssociationAuthorizationStatus(fileHandleAssociation, AuthorizationStatus.authorized())));
+		when(mockFileHandleDao.get(any())).thenReturn(sourceFileHandle);
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			handler.initiateRequest(mockUser, mockRequest, requestHash, mockStorageLocation);			
+		}).getMessage();
+		
+		assertEquals("The source file handle is already in the given destination storage location.", errorMessage);
+		
+		verify(mockAuthManager).canDownLoadFile(mockUser, Collections.singletonList(fileHandleAssociation));
+		verify(mockFileHandleDao).get(sourceFileHandle.getId());
+		verifyZeroInteractions(mockCloudDaoProvider);
+		verifyZeroInteractions(mockCloudDao);
+	}
+	
+	@Test
+	public void testInitiateRequestAndUserIsNotStorageLocationOwner() {
+		Long storageLocationId = 456L;
+
+		sourceFileHandle.setStorageLocationId(storageLocationId);
+		
+		Long userId = 123456L;
+		Long anotherUser = 789L;
+		String requestHash = "hash";
+		UploadType uploadType = UploadType.S3;
+		
+		when(mockRequest.getSourceFileHandleAssociation()).thenReturn(fileHandleAssociation);
+		when(mockUser.getId()).thenReturn(userId);
+		when(mockStorageLocation.getCreatedBy()).thenReturn(anotherUser);
+		when(mockStorageLocation.getUploadType()).thenReturn(uploadType);
+		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(Collections.singletonList(new FileHandleAssociationAuthorizationStatus(fileHandleAssociation, AuthorizationStatus.authorized())));
+		
+		String errorMessage = assertThrows(UnauthorizedException.class, () -> {
+			// Call under test
+			handler.initiateRequest(mockUser, mockRequest, requestHash, mockStorageLocation);			
+		}).getMessage();
+		
+		assertEquals("The user does not own the destination storage location.", errorMessage);
+		
+		verify(mockAuthManager).canDownLoadFile(mockUser, Collections.singletonList(fileHandleAssociation));
+		verifyZeroInteractions(mockFileHandleDao);
+		verifyZeroInteractions(mockCloudDaoProvider);
+		verifyZeroInteractions(mockCloudDao);
+	}
+	
+	@Test
+	public void testInitiateRequestAndUserIsNotAuthorized() {
+		Long storageLocationId = 456L;
+
+		sourceFileHandle.setStorageLocationId(storageLocationId);
+		
+		String requestHash = "hash";
+		UploadType uploadType = UploadType.S3;
+		
+		when(mockRequest.getSourceFileHandleAssociation()).thenReturn(fileHandleAssociation);
+		when(mockStorageLocation.getUploadType()).thenReturn(uploadType);
+		when(mockAuthManager.canDownLoadFile(any(), any())).thenReturn(
+				Collections.singletonList(
+						new FileHandleAssociationAuthorizationStatus(fileHandleAssociation, 
+								AuthorizationStatus.accessDenied("denied"))));
+		
+		String errorMessage = assertThrows(UnauthorizedException.class, () -> {
+			// Call under test
+			handler.initiateRequest(mockUser, mockRequest, requestHash, mockStorageLocation);			
+		}).getMessage();
+		
+		assertEquals("The user is not authorized to access the source file.", errorMessage);
+		
+		verify(mockAuthManager).canDownLoadFile(mockUser, Collections.singletonList(fileHandleAssociation));
+		verifyZeroInteractions(mockFileHandleDao);
+		verifyZeroInteractions(mockCloudDaoProvider);
+		verifyZeroInteractions(mockCloudDao);
+	}
+	
+	@Test
+	public void testGetPresignedUrl() throws MalformedURLException {
+		String contentType = "plain/text";
+		String partMD5Hex = "md5";
+		UploadType uploadType = UploadType.S3;
+		Long partNumber = 1L;
+		
+		PresignedUrl url = new PresignedUrl().withUrl(new URL("https://some.url"));
+		
+		when(mockStatus.getUploadType()).thenReturn(uploadType);
+		when(mockCloudDaoProvider.getCloudServiceMultipartUploadDao(any())).thenReturn(mockCloudDao);
+		when(mockCloudDao.createPartUploadCopyPresignedUrl(mockStatus, partNumber, contentType, partMD5Hex)).thenReturn(url);
+		
+		// Call under test
+		PresignedUrl result = handler.getPresignedUrl(mockStatus, 1, contentType, partMD5Hex);
+	
+		assertEquals(url, result);
+		
+		verify(mockCloudDaoProvider).getCloudServiceMultipartUploadDao(uploadType);
+		verify(mockCloudDao).createPartUploadCopyPresignedUrl(mockStatus, partNumber, contentType, partMD5Hex);
+		
+	}
+	
+	@Test
+	public void testValidateAddedPart() {
+		String partMD5Hex = "md5";
+		UploadType uploadType = UploadType.S3;
+		Long partNumber = 1L;
+		
+		when(mockStatus.getUploadType()).thenReturn(uploadType);
+		when(mockCloudDaoProvider.getCloudServiceMultipartUploadDao(any())).thenReturn(mockCloudDao);
+		
+		// Call under test
+		handler.validateAddedPart(mockStatus, partNumber, partMD5Hex);
+		
+		verify(mockCloudDaoProvider).getCloudServiceMultipartUploadDao(uploadType);
+		verify(mockCloudDao).validatePartCopy(mockStatus, partNumber, partMD5Hex);
+	}
+	
+	@Test
+	public void testGetFileHandleCreateRequest() {
+		String fileName = "fileName";
+		Long partSize = PartUtils.MIN_PART_SIZE_BYTES;
+		Long storageLocationId = 1L;
+		Boolean generatePreview = true;
+		
+		when(mockFileHandleDao.get(any())).thenReturn(sourceFileHandle);
+		
+		MultipartUploadCopyRequest request = new MultipartUploadCopyRequest();
+		
+		request.setFileName(fileName);
+		request.setPartSizeBytes(partSize);
+		request.setSourceFileHandleAssociation(fileHandleAssociation);
+		request.setStorageLocationId(storageLocationId);
+		request.setGeneratePreview(generatePreview);
+		
+		String originalRequest = MultipartRequestUtils.createRequestJSON(request);
+		
+		FileHandleCreateRequest expected = new FileHandleCreateRequest(fileName, sourceFileHandle.getContentType(), sourceFileHandle.getContentMd5(), storageLocationId, generatePreview);
+		
+		// Call under test
+		FileHandleCreateRequest result = handler.getFileHandleCreateRequest(mockStatus, originalRequest);
+		
+		assertEquals(expected, result);
+	}
+	
+}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/multipart/MultipartUploadRequestHandlerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/multipart/MultipartUploadRequestHandlerTest.java
@@ -1,0 +1,267 @@
+package org.sagebionetworks.repo.manager.file.multipart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.model.dbo.file.CompositeMultipartUploadStatus;
+import org.sagebionetworks.repo.model.dbo.file.CreateMultipartRequest;
+import org.sagebionetworks.repo.model.dbo.file.MultipartRequestUtils;
+import org.sagebionetworks.repo.model.file.AddPartRequest;
+import org.sagebionetworks.repo.model.file.MultipartUploadRequest;
+import org.sagebionetworks.repo.model.file.MultipartUploadStatus;
+import org.sagebionetworks.repo.model.file.PartUtils;
+import org.sagebionetworks.repo.model.file.UploadType;
+import org.sagebionetworks.repo.model.project.BucketOwnerStorageLocationSetting;
+import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAO;
+import org.sagebionetworks.upload.multipart.CloudServiceMultipartUploadDAOProvider;
+import org.sagebionetworks.upload.multipart.MultipartUploadUtils;
+import org.sagebionetworks.upload.multipart.PresignedUrl;
+
+@ExtendWith(MockitoExtension.class)
+public class MultipartUploadRequestHandlerTest {
+	
+	@Mock
+	private CloudServiceMultipartUploadDAO mockCloudDao;
+	
+	@Mock
+	private CloudServiceMultipartUploadDAOProvider mockCloudDaoProvider;
+
+	@InjectMocks
+	private MultipartUploadRequestHandler handler;
+	
+	@Mock
+	private UserInfo mockUser;
+	
+	@Mock
+	private MultipartUploadRequest mockRequest;
+	
+	@Mock
+	private BucketOwnerStorageLocationSetting mockStorageLocation;
+	
+	@Mock
+	private CompositeMultipartUploadStatus mockStatus;
+	
+	@Test
+	public void testGetRequestClass() {
+		// Call under test
+		assertEquals(MultipartUploadRequest.class, handler.getRequestClass());
+	}
+	
+	@Test
+	public void testValidateRequest() {
+		String fileName = "fileName";
+		Long fileSize = 1024L;
+		String md5 = "md5";
+		
+		when(mockRequest.getFileName()).thenReturn(fileName);
+		when(mockRequest.getFileSizeBytes()).thenReturn(fileSize);
+		when(mockRequest.getContentMD5Hex()).thenReturn(md5);
+		
+		// Call under test
+		handler.validateRequest(mockUser, mockRequest);
+	}
+	
+	@Test
+	public void testValidateRequestWithEmptyFileName() {
+		String fileName = "";
+		
+		when(mockRequest.getFileName()).thenReturn(fileName);
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			// Call under test
+			handler.validateRequest(mockUser, mockRequest);
+		}).getMessage();
+		
+		assertEquals("MultipartUploadRequest.fileName is required and must not be the empty string.", errorMessage);
+	}
+	
+	@Test
+	public void testValidateRequestWithNoSize() {
+		String fileName = "fileName";
+		Long fileSize = null;
+		
+		when(mockRequest.getFileName()).thenReturn(fileName);
+		when(mockRequest.getFileSizeBytes()).thenReturn(fileSize);
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			// Call under test
+			handler.validateRequest(mockUser, mockRequest);
+		}).getMessage();
+		
+		assertEquals("MultipartUploadRequest.fileSizeBytes is required.", errorMessage);
+	}
+	
+	@Test
+	public void testValidateRequestWithEmptyMD5() {
+		String fileName = "fileName";
+		Long fileSize = 1024L;
+		String md5 = null;
+		
+		when(mockRequest.getFileName()).thenReturn(fileName);
+		when(mockRequest.getFileSizeBytes()).thenReturn(fileSize);
+		when(mockRequest.getContentMD5Hex()).thenReturn(md5);
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			// Call under test
+			handler.validateRequest(mockUser, mockRequest);
+		}).getMessage();
+		
+		assertEquals("MultipartUploadRequest.contentMD5Hex is required and must not be the empty string.", errorMessage);
+	}
+	
+	@Test
+	public void testValidateRequestWithFileNameNoAscii() {
+		String fileName = "文件.txt";
+		
+		when(mockRequest.getFileName()).thenReturn(fileName);
+		
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {			
+			// Call under test
+			handler.validateRequest(mockUser, mockRequest);
+		}).getMessage();
+		
+		assertEquals("Invalid Name: '文件.txt'. Names may only contain: letters, numbers, spaces, underscores, hyphens, periods, plus signs, apostrophes, and parentheses", errorMessage);
+	}
+	
+	@Test
+	public void testInitiateRequest() {
+		String fileName = "fileName";
+		Long partSize = PartUtils.MIN_PART_SIZE_BYTES;
+		Long fileSize = 1024L;
+		
+		Long userId = 1L;
+		String requestHash = "hash";
+		String uploadToken = "token";
+		UploadType uploadType = UploadType.S3;
+		
+		when(mockRequest.getFileName()).thenReturn(fileName);
+		when(mockRequest.getFileSizeBytes()).thenReturn(fileSize);
+		when(mockRequest.getPartSizeBytes()).thenReturn(partSize);
+		when(mockUser.getId()).thenReturn(userId);
+		when(mockStorageLocation.getUploadType()).thenReturn(uploadType);
+		when(mockCloudDaoProvider.getCloudServiceMultipartUploadDao(any())).thenReturn(mockCloudDao);
+		when(mockCloudDao.initiateMultipartUpload(any(), any(), any())).thenReturn(uploadToken);
+		
+		String requestBody = MultipartRequestUtils.createRequestJSON(mockRequest);
+		
+		CreateMultipartRequest expected = new CreateMultipartRequest(userId,
+				requestHash, requestBody, uploadToken, uploadType,
+				null, null, 1, partSize);
+		
+		// Call under test
+		CreateMultipartRequest result = handler.initiateRequest(mockUser, mockRequest, requestHash, mockStorageLocation);
+		
+		expected.setBucket(result.getBucket());
+		expected.setKey(result.getKey());
+		
+		assertEquals(expected, result);
+		
+		verify(mockCloudDaoProvider).getCloudServiceMultipartUploadDao(uploadType);
+		verify(mockCloudDao).initiateMultipartUpload(result.getBucket(), result.getKey(), mockRequest);		
+		
+	}
+	
+	@Test
+	public void testGetPresignedUrl() throws MalformedURLException {
+		String contentType = "plain/text";
+		String partMD5Hex = "md5";
+		UploadType uploadType = UploadType.S3;
+		String bucket = "bucket";
+		String key = "key";
+		Long partNumber = 1L;
+		
+		PresignedUrl url = new PresignedUrl().withUrl(new URL("https://some.url"));
+		
+		when(mockStatus.getBucket()).thenReturn(bucket);
+		when(mockStatus.getKey()).thenReturn(key);
+		when(mockStatus.getUploadType()).thenReturn(uploadType);
+		when(mockCloudDaoProvider.getCloudServiceMultipartUploadDao(any())).thenReturn(mockCloudDao);
+		when(mockCloudDao.createPartUploadPreSignedUrl(any(), any(), any(), any())).thenReturn(url);
+		
+		String partKey = MultipartUploadUtils.createPartKey(key, partNumber);
+		
+		// Call under test
+		PresignedUrl result = handler.getPresignedUrl(mockStatus, 1, contentType, partMD5Hex);
+	
+		assertEquals(url, result);
+		
+		verify(mockCloudDaoProvider).getCloudServiceMultipartUploadDao(uploadType);
+		verify(mockCloudDao).createPartUploadPreSignedUrl(bucket, partKey, contentType, partMD5Hex);
+		
+	}
+	
+	@Test
+	public void testValidateAddedPart() {
+		String partMD5Hex = "md5";
+		UploadType uploadType = UploadType.S3;
+		String uploadId = "id";
+		String uploadToken = "token";
+		String bucket = "bucket";
+		String key = "key";
+		Long partNumber = 1L;
+		
+		MultipartUploadStatus uploadStatus = new MultipartUploadStatus();
+		uploadStatus.setUploadId(uploadId);
+		
+		when(mockStatus.getMultipartUploadStatus()).thenReturn(uploadStatus);
+		when(mockStatus.getUploadToken()).thenReturn(uploadToken);
+		when(mockStatus.getBucket()).thenReturn(bucket);
+		when(mockStatus.getKey()).thenReturn(key);
+		when(mockStatus.getUploadType()).thenReturn(uploadType);
+		when(mockCloudDaoProvider.getCloudServiceMultipartUploadDao(any())).thenReturn(mockCloudDao);
+		
+		String partKey = MultipartUploadUtils.createPartKey(key, partNumber);
+		
+		// Call under test
+		handler.validateAddedPart(mockStatus, partNumber, partMD5Hex);
+		
+		AddPartRequest request = new AddPartRequest(uploadId, uploadToken, bucket, key, partKey, partMD5Hex, partNumber, 1);
+		
+		verify(mockCloudDaoProvider).getCloudServiceMultipartUploadDao(uploadType);
+		verify(mockCloudDao).validateAndAddPart(request);
+	}
+	
+	@Test
+	public void testGetFileHandleCreateRequest() {
+		String fileName = "fileName";
+		Long partSize = PartUtils.MIN_PART_SIZE_BYTES;
+		Long fileSize = 1024L;
+		String contentMd5 = "md5";
+		String contentType = "plain/text";
+		Long storageLocationId = 1L;
+		Boolean generatePreview = true;
+		
+		
+		MultipartUploadRequest request = new MultipartUploadRequest();
+		
+		request.setFileName(fileName);
+		request.setPartSizeBytes(partSize);
+		request.setFileSizeBytes(fileSize);
+		request.setContentMD5Hex(contentMd5);
+		request.setContentType(contentType);
+		request.setStorageLocationId(storageLocationId);
+		request.setGeneratePreview(generatePreview);
+		
+		String originalRequest = MultipartRequestUtils.createRequestJSON(request);
+		
+		FileHandleCreateRequest expected = new FileHandleCreateRequest(fileName, contentType, contentMd5, storageLocationId, generatePreview);
+		
+		// Call under test
+		FileHandleCreateRequest result = handler.getFileHandleCreateRequest(mockStatus, originalRequest);
+		
+		assertEquals(expected, result);
+	}
+	
+}


### PR DESCRIPTION
- Refactoring of the multipart manager that introduces an abstraction over the type of multipart requests, mostly it's moving code around
- I removed the lenient from the manager unit tests, had to rewrite most of those tests :(