### PR TITLE
PLFM-6480: Fix prod detector

### DIFF
--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/versionInfo/SynapseVersionInfo.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/versionInfo/SynapseVersionInfo.json
@@ -1,9 +1,13 @@
 {
-    "description":"The Version of the stack",
+    "description": "Information about the version of the stack",
     "properties":{
-        "version":{
-            "type":"string",
-            "description":"The version of this stack"
-        }  
+        "version": {
+            "type": "string",
+            "description": "The version of this stack"
+        },
+        "stackInstance": {
+        	"type": "string",
+        	"description": "The current stack instance number assigned to the stack"
+        }
     }
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/stack/ProdDetectorImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/stack/ProdDetectorImpl.java
@@ -40,7 +40,7 @@ public class ProdDetectorImpl implements ProdDetector {
 	private final LoggerProvider logProvider;
 	
 	private SimpleHttpRequest versionInfoRequest;
-	private String currentStackVersion;
+	private String currentStackInstance;
 	private Logger log;
 
 	@Autowired
@@ -53,13 +53,13 @@ public class ProdDetectorImpl implements ProdDetector {
 	@PostConstruct
 	protected void init() {
 		this.log = logProvider.getLogger(ProdDetectorImpl.class.getName());
-		this.currentStackVersion = stackConfiguration.getStackInstance();
+		this.currentStackInstance = stackConfiguration.getStackInstance();
 		
 		this.versionInfoRequest = new SimpleHttpRequest();
 		this.versionInfoRequest.setUri(stackConfiguration.getRepositoryServiceProdEndpoint() + VERSION_INFO_ENDPOINT);
 
 		Map<String, String> headers = ImmutableMap.of(
-				HttpHeaders.USER_AGENT, String.format(USER_AGENT_TEMPLATE, currentStackVersion),
+				HttpHeaders.USER_AGENT, String.format(USER_AGENT_TEMPLATE, currentStackInstance),
 				HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType(),
 				// Force revalidation along the way to avoid caching issues
 				HttpHeaders.CACHE_CONTROL, CacheControl.noCache().getHeaderValue()
@@ -74,7 +74,7 @@ public class ProdDetectorImpl implements ProdDetector {
 				.flatMap(this::parseVersionResponse);
 
 		return response.flatMap(versionInfo -> 
-			Optional.of(currentStackVersion.equals(versionInfo.getVersion()))
+			Optional.of(currentStackInstance.equals(versionInfo.getStackInstance()))
 		);
 
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/stack/ProdDetectorUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/stack/ProdDetectorUnitTest.java
@@ -216,7 +216,7 @@ public class ProdDetectorUnitTest {
 		// We use a spy since all other methods are already tested and we can mock them out
 		ProdDetectorImpl prodDetectorSpy = Mockito.spy(prodDetector);
 		
-		when(mockVersionInfo.getVersion()).thenReturn(CURRENT_VERSION);
+		when(mockVersionInfo.getStackInstance()).thenReturn(CURRENT_VERSION);
 
 		doReturn(Optional.of(mockResponse)).when(prodDetectorSpy).sendVersionRequest();
 		doReturn(Optional.of(mockVersionInfo)).when(prodDetectorSpy).parseVersionResponse(mockResponse);
@@ -232,7 +232,7 @@ public class ProdDetectorUnitTest {
 		// We use a spy since all other methods are already tested and we can mock them out
 		ProdDetectorImpl prodDetectorSpy = Mockito.spy(prodDetector);
 		
-		when(mockVersionInfo.getVersion()).thenReturn(CURRENT_VERSION + 1);
+		when(mockVersionInfo.getStackInstance()).thenReturn(CURRENT_VERSION + 1);
 
 		doReturn(Optional.of(mockResponse)).when(prodDetectorSpy).sendVersionRequest();
 		doReturn(Optional.of(mockVersionInfo)).when(prodDetectorSpy).parseVersionResponse(mockResponse);

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/SynapseVersionInfoController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/SynapseVersionInfoController.java
@@ -7,6 +7,7 @@ import java.util.Properties;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.io.IOUtils;
+import org.sagebionetworks.StackConfigurationSingleton;
 import org.sagebionetworks.repo.model.versionInfo.SynapseVersionInfo;
 import org.sagebionetworks.repo.web.RequiredScope;
 import org.sagebionetworks.repo.web.UrlHelpers;
@@ -27,6 +28,7 @@ public class SynapseVersionInfoController {
 	
 	private static class Holder {
 		private static String versionInfo = "";
+		private static String stackInstance = "";
 		
 		static {
 			InputStream s = SynapseVersionInfoController.class.getResourceAsStream("/version-info.properties");
@@ -39,10 +41,15 @@ public class SynapseVersionInfoController {
 				IOUtils.closeQuietly(s);
 			}
 			versionInfo = prop.getProperty("org.sagebionetworks.repository.version");
+			stackInstance = StackConfigurationSingleton.singleton().getStackInstance();
 		}
 		
 		private static String getVersionInfo() {
 			return versionInfo;
+		}
+		
+		public static String getStackInstance() {
+			return stackInstance;
 		}
 				
 	}
@@ -54,6 +61,7 @@ public class SynapseVersionInfoController {
 	SynapseVersionInfo getVersionInfo(HttpServletRequest request) throws RuntimeException {
 		SynapseVersionInfo vInfo = new SynapseVersionInfo();
 		vInfo.setVersion(Holder.getVersionInfo());
+		vInfo.setStackInstance(Holder.getStackInstance());
 		return vInfo;
 	}
 	

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/SynapseVersionInfoControllerTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/controller/SynapseVersionInfoControllerTest.java
@@ -1,21 +1,23 @@
 package org.sagebionetworks.repo.web.controller;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sagebionetworks.repo.model.versionInfo.SynapseVersionInfo;
 
 /**
  *
  * @author xschildw
  */
-public class SynapseVersionInfoControllerTest extends AbstractAutowiredControllerTestBase {
+public class SynapseVersionInfoControllerTest extends AbstractAutowiredControllerJunit5TestBase {
 
 	@Test
 	public void testGetVersionInfo() throws Exception {
 		SynapseVersionInfo vi;
 		vi = servletTestHelper.getVersionInfo();
 		assertTrue(vi.getVersion().length() > 0);
+		assertNotNull(vi.getStackInstance());
 	}
 	
 }


### PR DESCRIPTION
Exposes the stack instance from the version API and the prod detector uses that instead of the version.