### PR TITLE
PLFM-6582: Return unversioned DOI for Tables in unversioned bundle request

### DIFF
--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EntityBundleServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EntityBundleServiceImpl.java
@@ -8,10 +8,8 @@ import java.util.List;
 
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.dataaccess.AccessRequirementManager;
-import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.ACLInheritanceException;
 import org.sagebionetworks.repo.model.AccessControlList;
-import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.Entity;
@@ -25,7 +23,6 @@ import org.sagebionetworks.repo.model.EntityTypeUtils;
 import org.sagebionetworks.repo.model.FileEntity;
 import org.sagebionetworks.repo.model.InvalidModelException;
 import org.sagebionetworks.repo.model.ObjectType;
-import org.sagebionetworks.repo.model.RestrictableObjectDescriptor;
 import org.sagebionetworks.repo.model.RestrictableObjectType;
 import org.sagebionetworks.repo.model.RestrictionInformationRequest;
 import org.sagebionetworks.repo.model.RestrictionInformationResponse;
@@ -38,6 +35,7 @@ import org.sagebionetworks.repo.model.discussion.EntityThreadCounts;
 import org.sagebionetworks.repo.model.entity.IdAndVersion;
 import org.sagebionetworks.repo.model.file.FileHandle;
 import org.sagebionetworks.repo.model.jdo.KeyFactory;
+import org.sagebionetworks.repo.model.table.Table;
 import org.sagebionetworks.repo.queryparser.ParseException;
 import org.sagebionetworks.repo.transactions.WriteTransaction;
 import org.sagebionetworks.repo.web.NotFoundException;
@@ -53,9 +51,9 @@ public class EntityBundleServiceImpl implements EntityBundleService {
 
 	@Autowired
 	AccessRequirementManager accessRequirementManager;
-	
+
 	public EntityBundleServiceImpl() {}
-	
+
 	/**
 	 * Direct constructor (for testing purposes)
 	 * 
@@ -160,8 +158,9 @@ public class EntityBundleServiceImpl implements EntityBundleService {
 		}
 		if(isTrue(request.getIncludeDOIAssociation()) ){
 			try {
-				if (versionNumber == null && (entity instanceof VersionableEntity)) {
-					// DOIs on VersionableEntity cannot be versionless, so we want to get the DOI for the current version
+				if (versionNumber == null && (entity instanceof VersionableEntity) && !(entity instanceof Table)) {
+					// For versionable entities (except tables), we assume that the user wants the DOI of the current version, if it exists.
+					// We exclude tables and views because the 'current version' is mutable. In this case, we get the versionless DOI.
 					Long currentVersionNumber = ((VersionableEntity) entity).getVersionNumber();
 					eb.setDoiAssociation(serviceProvider.getDoiServiceV2().getDoiAssociation(entityId, ObjectType.ENTITY, currentVersionNumber));
 				} else {

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EntityBundleServiceImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/EntityBundleServiceImpl.java
@@ -158,12 +158,13 @@ public class EntityBundleServiceImpl implements EntityBundleService {
 		}
 		if(isTrue(request.getIncludeDOIAssociation()) ){
 			try {
-				if (versionNumber == null && (entity instanceof VersionableEntity) && !(entity instanceof Table)) {
-					// For versionable entities (except tables), we assume that the user wants the DOI of the current version, if it exists.
-					// We exclude tables and views because the 'current version' is mutable. In this case, we get the versionless DOI.
+				if (versionNumber == null && (entity instanceof FileEntity)) {
+					// For File Entities, we assume that the user wants the DOI of the most recent version, if it exists.
 					Long currentVersionNumber = ((VersionableEntity) entity).getVersionNumber();
 					eb.setDoiAssociation(serviceProvider.getDoiServiceV2().getDoiAssociation(entityId, ObjectType.ENTITY, currentVersionNumber));
-				} else {
+				} else { // Handle non-versionable entities and other types of versionable entities
+					// For other versionable entity types (e.g. tables), the 'current version' is mutable.
+					// In this case, we get the DOI of the specified version, which may be null.
 					eb.setDoiAssociation(serviceProvider.getDoiServiceV2().getDoiAssociation(entityId, ObjectType.ENTITY, versionNumber));
 				}
 			} catch (NotFoundException e) {

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/service/EntityBundleServiceImplTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/service/EntityBundleServiceImplTest.java
@@ -229,15 +229,15 @@ public class EntityBundleServiceImplTest {
 	}
 
 	@Test
-	public void testDoiAssociationForUnversionedRequestForVersionable() throws Exception {
-		// Must retrieve entity to determine if it is VersionableEntity
+	public void testDoiAssociationForUnversionedRequestForFileEntity() throws Exception {
+		// Must retrieve entity to determine if it is a FileEntity
 		EntityBundleRequest request = new EntityBundleRequest();
 		request.setIncludeEntity(true);
 		request.setIncludeDOIAssociation(true);
 		DoiAssociation doi = new DoiAssociation();
 		doi.setObjectType(ObjectType.ENTITY);
 		doi.setObjectId(FILE_ID);
-		doi.setObjectVersion(FILE_VERSION);
+		doi.setObjectVersion(FILE_VERSION); // The DOI should be tied to a version even though the bundle request has no version!
 
 		when(mockEntityService.getEntity(eq(TEST_USER1), eq(FILE_ID))).thenReturn(file);
 		when(mockDoiServiceV2.getDoiAssociation(FILE_ID, ObjectType.ENTITY, FILE_VERSION)).thenReturn(doi);
@@ -250,7 +250,7 @@ public class EntityBundleServiceImplTest {
 		assertEquals(doi, bundle.getDoiAssociation());
 	}
 
-	@Test
+	@Test // PLFM-6582
 	public void testDoiAssociationForUnversionedRequestForTable() throws Exception {
 		EntityBundleRequest request = new EntityBundleRequest();
 		request.setIncludeEntity(true);

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/service/EntityBundleServiceImplTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/service/EntityBundleServiceImplTest.java
@@ -229,7 +229,7 @@ public class EntityBundleServiceImplTest {
 	}
 
 	@Test
-	public void testDoiAssociationWithNoVersion() throws Exception {
+	public void testDoiAssociationForUnversionedRequestForVersionable() throws Exception {
 		// Must retrieve entity to determine if it is VersionableEntity
 		EntityBundleRequest request = new EntityBundleRequest();
 		request.setIncludeEntity(true);
@@ -251,7 +251,7 @@ public class EntityBundleServiceImplTest {
 	}
 
 	@Test
-	public void testDoiAssociationWithNoVersion_Table() throws Exception {
+	public void testDoiAssociationForUnversionedRequestForTable() throws Exception {
 		EntityBundleRequest request = new EntityBundleRequest();
 		request.setIncludeEntity(true);
 		request.setIncludeDOIAssociation(true);


### PR DESCRIPTION
For versionable entities, by default we return the DOI for the most recent version if no version is specified in the entity bundle request.

This is the wrong thing to do for tables because the current version is mutable. Instead, we return the unversioned DOI. A user can still retrieve the versioned DOI in a bundle by specifying the table version.