### PR TITLE
PLFM-6616 Apply limit and offset to getFavoritesEntityHeader

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOFavoriteDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOFavoriteDAOImpl.java
@@ -82,9 +82,13 @@ public class DBOFavoriteDAOImpl implements FavoriteDAO {
 																"AND f."+ COL_FAVORITE_NODE_ID +" = n."+ COL_NODE_ID +" " +
 																"AND n."+ COL_NODE_ID +" = r."+ COL_REVISION_OWNER_NODE +" " +
 																"AND n."+ COL_NODE_CURRENT_REV +" = r."+ COL_REVISION_NUMBER +" " +
-																"AND n."+ COL_NODE_PARENT_ID +" <> " + TRASH_FOLDER_ID;
+																"AND n."+ COL_NODE_PARENT_ID +" <> " + TRASH_FOLDER_ID +" " +
+																"ORDER BY " + COL_FAVORITE_NODE_ID +" " +
+																"LIMIT :" + LIMIT_PARAM_NAME +" " +
+																"OFFSET :" + OFFSET_PARAM_NAME;
 
-	
+
+
 	private static final RowMapper<Favorite> favoriteRowMapper = new RowMapper<Favorite>() {
 		@Override
 		public Favorite mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOFavoriteDAOImplAutowiredTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOFavoriteDAOImplAutowiredTest.java
@@ -262,24 +262,33 @@ public class DBOFavoriteDAOImplAutowiredTest {
 		favoritesToDelete.add(fav1created);
 		Favorite fav2created = favoriteDao.add(fav2);
 		favoritesToDelete.add(fav2created);
-		
+
 		PaginatedResults<EntityHeader> favs = favoriteDao.getFavoritesEntityHeader(creatorUserGroupId.toString(), Integer.MAX_VALUE, 0);
 
 		assertEquals(2, favs.getTotalNumberOfResults());		
 		assertEquals(2, favs.getResults().size());
 		
-		EntityHeader eh1 = null;
-		EntityHeader eh2 = null;
-		for(EntityHeader eh : favs.getResults()) {
-			if(eh.getName().equals(node1Name)) eh1 = eh;
-			if(eh.getName().equals(node2Name)) eh2 = eh;
-		}
+		EntityHeader eh1 = favs.getResults().get(0);
+		EntityHeader eh2 = favs.getResults().get(1);
+
 		assertNotNull(eh1);
 		assertNotNull(eh2);
 		assertEquals(node1Id, eh1.getId());
 		assertEquals(Project.class.getName(), eh1.getType());
 		assertEquals(new Long(1), eh1.getVersionNumber());
 		assertEquals("1", eh1.getVersionLabel());
+
+		// Test limit and offset (PLFM-6616)
+		int limit = 1;
+		int offset = 0;
+		favs = favoriteDao.getFavoritesEntityHeader(creatorUserGroupId.toString(), limit, offset);
+		assertEquals(1, favs.getResults().size());
+		assertEquals(node1Id, favs.getResults().get(0));
+
+		offset = 1;
+		favs = favoriteDao.getFavoritesEntityHeader(creatorUserGroupId.toString(), limit, offset);
+		assertEquals(1, favs.getResults().size());
+		assertEquals(node2Id, favs.getResults().get(0));
 	}
 
 	@Test

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOFavoriteDAOImplAutowiredTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOFavoriteDAOImplAutowiredTest.java
@@ -283,12 +283,12 @@ public class DBOFavoriteDAOImplAutowiredTest {
 		int offset = 0;
 		favs = favoriteDao.getFavoritesEntityHeader(creatorUserGroupId.toString(), limit, offset);
 		assertEquals(1, favs.getResults().size());
-		assertEquals(node1Id, favs.getResults().get(0));
+		assertEquals(node1Id, favs.getResults().get(0).getId());
 
 		offset = 1;
 		favs = favoriteDao.getFavoritesEntityHeader(creatorUserGroupId.toString(), limit, offset);
 		assertEquals(1, favs.getResults().size());
-		assertEquals(node2Id, favs.getResults().get(0));
+		assertEquals(node2Id, favs.getResults().get(0).getId());
 	}
 
 	@Test


### PR DESCRIPTION
The limit and offset parameters were not in the SQL statement.

I am maintaining the current behavior of `getTotalResults`, which does return the total number of results. For performance reasons, in other places we have changed the behavior to return something like `offset + numberOfPageResults + 1` if there are more results. Let me know if this is necessary here.