### PR TITLE
PLFM-6709: Throw IllegalArgumentException instead of DuplicateKeyException

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImpl.java
@@ -122,6 +122,7 @@ import org.sagebionetworks.util.ValidateArgument;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
@@ -2039,9 +2040,13 @@ public class NodeDAOImpl implements NodeDAO, InitializingBean {
 		long modifiedOn = System.currentTimeMillis();
 		Long revisionNumber = this.getCurrentRevisionNumber(nodeIdString);
 		String label = request.getSnapshotLabel() != null ? request.getSnapshotLabel() : revisionNumber.toString();
-		this.jdbcTemplate.update(SQL_CREATE_SNAPSHOT_VERSION, request.getSnapshotComment(), label,
-				request.getSnapshotActivityId(), userId, modifiedOn, nodeId, revisionNumber);
-		return revisionNumber;
+		try {
+			this.jdbcTemplate.update(SQL_CREATE_SNAPSHOT_VERSION, request.getSnapshotComment(), label,
+					request.getSnapshotActivityId(), userId, modifiedOn, nodeId, revisionNumber);
+			return revisionNumber;
+		} catch (DuplicateKeyException e) {
+			throw new IllegalArgumentException(e);
+		}
 	}
 
 	@Override

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImpl.java
@@ -2045,7 +2045,11 @@ public class NodeDAOImpl implements NodeDAO, InitializingBean {
 					request.getSnapshotActivityId(), userId, modifiedOn, nodeId, revisionNumber);
 			return revisionNumber;
 		} catch (DuplicateKeyException e) {
-			throw new IllegalArgumentException(e);
+			if (e.getMessage().contains("UNIQUE_REVISION_LABEL")) {
+				throw new IllegalArgumentException(String.format("The label '%s' has already been used for a version of this entity", label), e);
+			} else {
+				throw(e);
+			}
 		}
 	}
 

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImplTest.java
@@ -77,6 +77,7 @@ import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -4082,11 +4083,14 @@ public class NodeDAOImplTest {
 		request2.setSnapshotLabel("some label");
 		request2.setSnapshotActivityId(testActivity2.getId());
 
-		// call under test: this should fail
+		// call under test
 		String id = node.getId();
-		assertThrows(
+		Throwable thrownException = assertThrows(
 			IllegalArgumentException.class, () -> {nodeDao.snapshotVersion(user1Id, id, request2);}
 		);
+		assertTrue(thrownException.getMessage().equals(String.format("The label '%s' has already been used for a version of this entity", "some label")));
+		assertTrue(thrownException.getCause() instanceof DuplicateKeyException);
+
 	}
 	
 	@Test


### PR DESCRIPTION
[PLFM-6709]: This should return a 400 instead of a 500 called with duplicate label.

[PLFM-6709]: https://sagebionetworks.jira.com/browse/PLFM-6709