### PR TITLE
PLFM-6486

### DIFF
--- a/lib/lib-javadoc/src/main/resources/docHeaderTemplate.html
+++ b/lib/lib-javadoc/src/main/resources/docHeaderTemplate.html
@@ -1,13 +1,22 @@
 <head>
 <meta charset="utf-8" />
-<title>Synapse REST API</title>
+<title>
+	#if(${method})
+	${method.methodLink.display} |
+	#end
+	#if(${model})
+	${model.name} |
+	#end
+	Synapse REST API
+</title>
 
 <!-- Mobile viewport optimisation -->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <!-- (en) Add your meta data here -->
+<link rel="icon" href="https://www.synapse.org/favicon.png?v=4" />
 <link type="text/css" rel="stylesheet"
-	href="${pathToRoot}webapp/Main.css">
+	href="${pathToRoot}webapp/Main.css" />
 <!-- (de) Fuegen Sie hier ihre Meta-Daten ein -->
 <!-- YAML -->
 <link rel="stylesheet"


### PR DESCRIPTION
REST Docs: Show method/object name in page title, add favicon

On main page:
<img width="231" alt="image" src="https://user-images.githubusercontent.com/17580037/118277081-65be5a80-b496-11eb-8453-e9eb5e9a4b97.png">

On page for POST /entity:
<img width="231" alt="image" src="https://user-images.githubusercontent.com/17580037/118276713-f0eb2080-b495-11eb-88f1-f6c7cce1ee79.png">

On page for the Entity object:
<img width="231" alt="image" src="https://user-images.githubusercontent.com/17580037/118276734-f6486b00-b495-11eb-8407-baaaaf6061e0.png">
