### PR TITLE
PLFM-6751

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/ITAccessTokenTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITAccessTokenTest.java
@@ -149,4 +149,26 @@ public class ITAccessTokenTest {
 		}		
 	}
 
+	@Test
+	public void testPassAccessTokenAsSessionToken() throws Exception {
+		String accessTokenForUser1 = getAccessTokenForUser1("openid modify view download");
+
+		try {
+			// We use the bearer token to authorize the client 
+			synapseClientLackingCredentials.setSessionToken(accessTokenForUser1);
+			// Now the calls made by 'synapseClientLackingCredentials' are authenticated/authorized
+			// as User1.
+
+			project = new Project();
+			project.setName("access token as session token test");
+			project = synapseClientLackingCredentials.createEntity(project);
+			assertNotNull(project.getId());
+			project = synapseClientLackingCredentials.getEntity(project.getId(), Project.class);
+			
+		} finally {
+			synapseClientLackingCredentials.setSessionToken(null);
+		}
+
+	}
+	
 }

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/auth/JSONWebTokenHelper.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/auth/JSONWebTokenHelper.java
@@ -15,11 +15,14 @@ import org.sagebionetworks.repo.model.oauth.JsonWebKeySet;
 import org.sagebionetworks.util.ValidateArgument;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
 
 public class JSONWebTokenHelper {
 	public static final String RSA = "RSA";
@@ -94,7 +97,11 @@ public class JSONWebTokenHelper {
 	}
 	
 	public static String getSubjectFromJWTAccessToken(String accessToken) {
-		return getUnsignedJWTFromToken(accessToken).getBody().getSubject();
+		try {
+			return getUnsignedJWTFromToken(accessToken).getBody().getSubject();
+		} catch (ExpiredJwtException | UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+			throw new IllegalArgumentException(e);
+		}
 	}
 
 

--- a/services/repository/src/main/java/org/sagebionetworks/auth/filter/AuthenticationFilter.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/filter/AuthenticationFilter.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.auth.filter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -28,6 +29,7 @@ import org.sagebionetworks.repo.manager.oauth.OpenIDConnectManager;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
 import org.sagebionetworks.repo.model.UnauthenticatedException;
+import org.sagebionetworks.repo.model.auth.JSONWebTokenHelper;
 import org.sagebionetworks.repo.web.ForbiddenException;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.repo.web.OAuthException;
@@ -78,9 +80,28 @@ public class AuthenticationFilter implements Filter {
 			sessionToken = req.getParameter(AuthorizationConstants.SESSION_TOKEN_PARAM);
 		}
 
-		// Determine the caller's identity
 		Long userId = null;
-		String accessToken = null;
+		
+		String accessToken = HttpAuthUtil.getBearerTokenFromStandardAuthorizationHeader(req);
+		
+		// there is a chance that an access token was passed as a session token
+		if (null!=sessionToken) {
+			try {
+				UUID.fromString(sessionToken);
+				// the session token is a UUID, so it is not an access token
+			} catch (IllegalArgumentException e1) {
+				// the session token is *not* a UUID
+				try {
+					// is it a JWT?
+					JSONWebTokenHelper.getSubjectFromJWTAccessToken(sessionToken);
+					// based on the format, the session token is an access token
+					accessToken = sessionToken;
+					sessionToken = null;
+				} catch (IllegalArgumentException e2) {
+					// Cannot say that the session token is an access token
+				}
+			}
+		}
 
 		// A session token maps to a specific user
 		if (!isTokenEmptyOrNull(sessionToken)) {
@@ -108,7 +129,6 @@ public class AuthenticationFilter implements Filter {
 			}
 			accessToken=oidcTokenHelper.createInternalTotalAccessToken(userId);
 		} else {
-			accessToken=HttpAuthUtil.getBearerTokenFromStandardAuthorizationHeader(req);
 			if (!isTokenEmptyOrNull(accessToken)) {
 				try {
 					// validate token and get userid parameter

--- a/services/repository/src/test/java/org/sagebionetworks/auth/filter/AuthenticationFilterTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/filter/AuthenticationFilterTest.java
@@ -15,10 +15,12 @@ import static org.mockito.Mockito.when;
 
 import java.io.PrintWriter;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -54,6 +56,13 @@ import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.impl.DefaultClaims;
+
 @ExtendWith({MockitoExtension.class})
 public class AuthenticationFilterTest {
 	
@@ -87,14 +96,23 @@ public class AuthenticationFilterTest {
 	@InjectMocks
 	private AuthenticationFilter filter;
 
-	private static final String sessionToken = "someSortaSessionToken";
+	private static final String sessionToken = UUID.randomUUID().toString();
 	private static final String secretKey = "Totally a plain text key :D";
 	private static final String username = "AuthFilter@test.sagebase.org";
 	private static final Long userId = 123456789L;
-	private static final String BEARER_TOKEN = "bearer token";
-	private static final String BEARER_TOKEN_HEADER = "Bearer "+BEARER_TOKEN;
+	private static final String BEARER_TOKEN;
+	private static final String BEARER_TOKEN_HEADER;
 	private static final List<String> HEADER_NAMES = Collections.singletonList("Authorization");
 	private PrincipalAlias pa;
+	
+	static {
+		Claims claims = new DefaultClaims();
+		claims.setSubject("userId");
+		BEARER_TOKEN = Jwts.builder().setClaims(claims).
+				setHeaderParam(Header.TYPE, Header.JWT_TYPE).compact() + "signature";
+		BEARER_TOKEN_HEADER = "Bearer "+BEARER_TOKEN;
+	}
+	
 	
 	@BeforeEach
 	public void setupFilter() throws Exception {
@@ -289,6 +307,24 @@ public class AuthenticationFilterTest {
 		when(mockHttpRequest.getHeader(AuthorizationConstants.AUTHORIZATION_HEADER_NAME)).thenReturn(BEARER_TOKEN_HEADER);
 		when(mockHttpRequest.getHeaderNames()).thenReturn(Collections.enumeration(HEADER_NAMES));
 		when(mockHttpRequest.getHeaders("Authorization")).thenReturn(Collections.enumeration(Collections.singletonList(BEARER_TOKEN_HEADER)));
+		when(mockOidcManager.validateAccessToken(anyString())).thenReturn(""+userId);
+
+		// by default the mocked oidcTokenHelper.validateJWT(bearerToken) won't throw any exception, so the token is deemed valid
+
+		// method under test
+		filter.doFilter(mockHttpRequest, mockHttpResponse, mockFilterChain);
+		
+		verify(mockOidcManager).validateAccessToken(BEARER_TOKEN);
+		verify(mockFilterChain).doFilter(requestCaptor.capture(), (ServletResponse)any());
+		
+		assertEquals(""+userId, requestCaptor.getValue().getParameter(AuthorizationConstants.USER_ID_PARAM));
+		assertEquals("Bearer "+BEARER_TOKEN, requestCaptor.getValue().getHeader(AuthorizationConstants.SYNAPSE_AUTHORIZATION_HEADER_NAME));
+	}
+
+	@Test
+	public void testFilter_AccessTokenPassedAsSessionToken() throws Exception {
+		when(mockHttpRequest.getHeader(AuthorizationConstants.SESSION_TOKEN_PARAM)).thenReturn(BEARER_TOKEN);
+		when(mockHttpRequest.getHeaderNames()).thenReturn(Collections.enumeration(Collections.singletonList("sessionToken")));
 		when(mockOidcManager.validateAccessToken(anyString())).thenReturn(""+userId);
 
 		// by default the mocked oidcTokenHelper.validateJWT(bearerToken) won't throw any exception, so the token is deemed valid

--- a/services/repository/src/test/java/org/sagebionetworks/auth/filter/AuthenticationFilterTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/filter/AuthenticationFilterTest.java
@@ -327,8 +327,6 @@ public class AuthenticationFilterTest {
 		when(mockHttpRequest.getHeaderNames()).thenReturn(Collections.enumeration(Collections.singletonList("sessionToken")));
 		when(mockOidcManager.validateAccessToken(anyString())).thenReturn(""+userId);
 
-		// by default the mocked oidcTokenHelper.validateJWT(bearerToken) won't throw any exception, so the token is deemed valid
-
 		// method under test
 		filter.doFilter(mockHttpRequest, mockHttpResponse, mockFilterChain);
 		


### PR DESCRIPTION
This change allows a client to pass an access token (normally passed as a Bearer authorization header) as a "sessionToken" header.  The change keeps Synapse from breaking embedded app's that take the session token cookie and use the contents to authenticate requests to Synapse.