### PR TITLE
obfuscate details about invalid access token

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/ITOpenIDConnectTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITOpenIDConnectTest.java
@@ -238,7 +238,7 @@ public class ITOpenIDConnectTest {
 				synapseAnonymous.getUserInfoAsJSON();
 			});
 			
-			assertEquals("The OAuth client (" + client.getClient_id() + ") is not verified.", uex.getMessage());
+			assertEquals("Invalid access token", uex.getMessage());
 			
 			// Verify the client once again
 			client = adminSynapse.updateOAuthClientVerifiedStatus(client.getClient_id(), client.getEtag(), true);

--- a/services/repository/src/main/java/org/sagebionetworks/auth/filter/AuthenticationFilter.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/filter/AuthenticationFilter.java
@@ -104,9 +104,6 @@ public class AuthenticationFilter implements Filter {
 					userId = Long.parseLong(oidcManager.validateAccessToken(accessToken));
 				} catch (IllegalArgumentException | ForbiddenException | OAuthClientNotVerifiedException e) {
 					String failureReason = "Invalid access token";
-					if (StringUtils.isNotEmpty(e.getMessage())) {
-						failureReason = e.getMessage();
-					}
 					HttpAuthUtil.reject((HttpServletResponse)servletResponse, failureReason);
 					log.warn(failureReason, e);
 					return;


### PR DESCRIPTION
Today the API will return the message, "Expected three sections of the token but found 1" if a garbage access token is passed.  What we want is to return a more generic message, "Invalid access token".