### PR TITLE
PLFM-6847 replacing replaceAll with replace

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EmailUtils.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EmailUtils.java
@@ -184,7 +184,7 @@ public class EmailUtils {
 		for (String fieldMarker : fieldValues.keySet()) {
 			String replacementValue = fieldValues.get(fieldMarker);
 			if (replacementValue==null) replacementValue = "";
-			template = template.replaceAll(fieldMarker, replacementValue);
+			template = template.replace(fieldMarker, replacementValue);
 		}
 		return template;
 	}


### PR DESCRIPTION
String.replace() replaces all occurrences just like replaceAll() does.  The difference is that it does not use regular expressions.  The error in PLFM-6847 was due to something that looks like a regexp getting into the string under replacement.  Since the regular expressions are not needed in the application, the fix is simply to use the non-regexp string replacement function.