### PR TITLE
PLFM-6872

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/schema/AnnotationsTranslatorImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/schema/AnnotationsTranslatorImpl.java
@@ -433,8 +433,12 @@ public class AnnotationsTranslatorImpl implements AnnotationsTranslator {
 			return value;
 		case DOUBLE:
 			// NaN is not a valid value in JSON, so we convert it to string "NaN"
-			if (value.equals(Double.toString(Double.NaN))) {
+			if (Double.toString(Double.NaN).equals(value)) {
 				return Double.toString(Double.NaN);
+			} else if (Double.toString(Double.POSITIVE_INFINITY).equals(value)) {
+				return Double.toString(Double.POSITIVE_INFINITY);
+			} else if (Double.toString(Double.NEGATIVE_INFINITY).equals(value)) {
+				return Double.toString(Double.NEGATIVE_INFINITY);
 			}
 			return Double.parseDouble(value);
 		case LONG:

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/schema/AnnotationsTranslatorImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/schema/AnnotationsTranslatorImpl.java
@@ -432,6 +432,10 @@ public class AnnotationsTranslatorImpl implements AnnotationsTranslator {
 		case STRING:
 			return value;
 		case DOUBLE:
+			// NaN is not a valid value in JSON, so we convert it to string "NaN"
+			if (value.equals(Double.toString(Double.NaN))) {
+				return Double.toString(Double.NaN);
+			}
 			return Double.parseDouble(value);
 		case LONG:
 			return Long.parseLong(value);


### PR DESCRIPTION
[Jira](https://sagebionetworks.jira.com/browse/PLFM-6872)

`NaN` isn't a valid JSON value, so we convert it to the string "NaN".

Open questions: 
- Should this fix be in schema-to-pojo?
- Is there a bug in schema-to-pojo?

Throws an exception:
```java
double nan = Double.NaN; // primitive
JSONArray array = new JSONArray();
array.put(nan);
```

Does not throw an exception:
```java
Double nan = new Double(Double.NaN); // Object
JSONArray array = new JSONArray();
array.put(nan);

// We can trigger the exception by calling this:
array.write(new StringWriter());
```