### PR TITLE
Error message should match request object

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImpl.java
@@ -92,7 +92,7 @@ public class AuthenticationManagerImpl implements AuthenticationManager {
 	 * @return id of user for which password change occurred
 	 */
 	long validateChangePassword(ChangePasswordWithCurrentPassword changePasswordWithCurrentPassword) {
-		ValidateArgument.required(changePasswordWithCurrentPassword.getUsername(), "changePasswordWithCurrentPassword.userName");
+		ValidateArgument.required(changePasswordWithCurrentPassword.getUsername(), "changePasswordWithCurrentPassword.username");
 		ValidateArgument.required(changePasswordWithCurrentPassword.getCurrentPassword(), "changePasswordWithCurrentPassword.currentPassword");
 
 		final long userId = findUserIdForAuthentication(changePasswordWithCurrentPassword.getUsername());


### PR DESCRIPTION
The ChangePasswordWithCurrentPassword object has field `username`, so the validation message should match (all lowercase)