### PR TITLE
PLFM-6954: Throw illegal arg exception on email address invalid format.

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/SendRawEmailRequestBuilder.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/SendRawEmailRequestBuilder.java
@@ -191,7 +191,7 @@ public class SendRawEmailRequestBuilder {
 			msg.setContent(multipart);
 			msg.writeTo(out);
 		} catch (AddressException e) {
-			throw new RuntimeException(e);
+			throw new IllegalArgumentException("Invalid format for email address", e);
 		} catch (MessagingException e) {
 			throw new RuntimeException(e);
 		} catch (IOException e) {


### PR DESCRIPTION
This PR converts an AddressException to an IllegalArgumentException which is surfaced as a 400 instead of a 500.