### PR TITLE
PLFM-7341: Check for headers not null in RowReferenceSet.

### DIFF
--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/service/table/TableServicesImpl.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/service/table/TableServicesImpl.java
@@ -120,6 +120,7 @@ public class TableServicesImpl implements TableServices {
 	public TableFileHandleResults getFileHandles(Long userId, RowReferenceSet fileHandlesToFind) throws IOException, NotFoundException {
 		Validate.required(fileHandlesToFind, "fileHandlesToFind");
 		Validate.required(fileHandlesToFind.getTableId(), "fileHandlesToFind.tableId");
+		Validate.required(fileHandlesToFind.getHeaders(), "fileHandlesToFind.headers");
 		UserInfo userInfo = userManager.getUserInfo(userId);
 		List<ColumnModel> columns = columnModelManager.getCurrentColumns(userInfo, fileHandlesToFind.getTableId(), fileHandlesToFind.getHeaders());
 		for (ColumnModel cm : columns) {
@@ -206,7 +207,7 @@ public class TableServicesImpl implements TableServices {
 	/**
 	 * Get the file handle ID for a given table cell.
 	 * 
-	 * @param userId
+	 * @param userInfo
 	 * @param tableId
 	 * @param rowRef
 	 * @param columnId

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/service/table/TableServicesImplTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/service/table/TableServicesImplTest.java
@@ -13,6 +13,7 @@ import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.manager.file.FileHandleUrlRequest;
 import org.sagebionetworks.repo.manager.table.ColumnModelManager;
 import org.sagebionetworks.repo.manager.table.TableEntityManager;
+import org.sagebionetworks.repo.model.InvalidModelException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.dbo.dao.table.TableModelTestUtils;
 import org.sagebionetworks.repo.model.entity.IdAndVersion;
@@ -263,6 +264,15 @@ public class TableServicesImplTest {
 		assertEquals(expectedUrl, url);
 		
 		
+	}
+
+	@Test( expected = InvalidModelException.class)
+	public void testGetFileHandlesNullHeadersPlfm7341() throws IOException {
+		RowReferenceSet rowReferenceSet = new RowReferenceSet();
+		rowReferenceSet.setTableId(tableId);
+		rowReferenceSet.setHeaders(null);
+		// Call under test
+		TableFileHandleResults results = tableService.getFileHandles(userInfo.getId(), rowReferenceSet);
 	}
 	
 }


### PR DESCRIPTION
API current allows passing a RowReferenceSet with null headers, which causes the NPE. This PR adds a check.