### PR TITLE
PLFM-7654 Hide Entity Header Names in Entity Path Appropriately

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NodeManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NodeManagerImpl.java
@@ -599,7 +599,7 @@ public class NodeManagerImpl implements NodeManager {
 		for (EntityHeader entityHeader : entityHeaders) {
 			Optional<UsersEntityAccessInfo> entityAccessInfo = userEntitysAccessInfo.stream()
 					.filter(e -> e.getEntityId().equals(KeyFactory.stringToKey(entityHeader.getId()))).findAny();
-			if (entityAccessInfo.isPresent() && !entityAccessInfo.get().getAuthorizationStatus().isAuthorized()) {
+			if (!entityAccessInfo.isPresent() || !entityAccessInfo.get().getAuthorizationStatus().isAuthorized()) {
 				entityHeader.setName(ENTITY_NAME_PERMISSION_DENIED);
 			}
 		}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/NodeManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/NodeManagerImplUnitTest.java
@@ -1866,8 +1866,7 @@ public class NodeManagerImplUnitTest {
 	@Test
 	public void testGetNodePathWithUserLacksSomePermission() {
 		when(mockAuthManager.hasAccess(any(), any(), any())).thenReturn(AuthorizationStatus.authorized());
-		when(mockAuthManager.batchHasAccess(any(), any(), any())).thenReturn(List.of(new UsersEntityAccessInfo().withEntityId(123L).withAuthorizationStatus(AuthorizationStatus.authorized()),
-				new UsersEntityAccessInfo().withEntityId(124L).withAuthorizationStatus(AuthorizationStatus.accessDenied("ACCESS_DENIED")),
+		when(mockAuthManager.batchHasAccess(any(), any(), any())).thenReturn(List.of(new UsersEntityAccessInfo().withEntityId(124L).withAuthorizationStatus(AuthorizationStatus.accessDenied("ACCESS_DENIED")),
 				new UsersEntityAccessInfo().withEntityId(125L).withAuthorizationStatus(AuthorizationStatus.accessDenied("ACCESS_DENIED")),
 				new UsersEntityAccessInfo().withEntityId(126L).withAuthorizationStatus(AuthorizationStatus.authorized())));
 		when(mockNodeDao.getEntityPath(any())).thenReturn(List.of(new NameIdType().withName("root").withId("123").withType("foo"),
@@ -1877,7 +1876,7 @@ public class NodeManagerImplUnitTest {
 
 		// Call under test
 		List<EntityHeader> entityHeaders = nodeManager.getNodePath(mockUserInfo, nodeId);
-		List<EntityHeader> expectedEntityHeaders = List.of(new EntityHeader().setName("root").setId("123").setType("foo"),
+		List<EntityHeader> expectedEntityHeaders = List.of(new EntityHeader().setName(NodeManagerImpl.ENTITY_NAME_PERMISSION_DENIED).setId("123").setType("foo"),
 				new EntityHeader().setName(NodeManagerImpl.ENTITY_NAME_PERMISSION_DENIED).setId("124").setType("bar"),
 				new EntityHeader().setName(NodeManagerImpl.ENTITY_NAME_PERMISSION_DENIED).setId("125").setType("baz"),
 				new EntityHeader().setName("child").setId("126").setType("qux"));

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/NodeManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/NodeManagerImplUnitTest.java
@@ -1835,17 +1835,18 @@ public class NodeManagerImplUnitTest {
 	public void testGetNodePathWithUserHasPermission() {
 		when(mockAuthManager.hasAccess(any(), any(), any())).thenReturn(AuthorizationStatus.authorized());
 		when(mockAuthManager.batchHasAccess(any(), any(), any())).thenReturn(List.of(new UsersEntityAccessInfo().withEntityId(123L).withAuthorizationStatus(AuthorizationStatus.authorized()),
-																					 new UsersEntityAccessInfo().withEntityId(124L).withAuthorizationStatus(AuthorizationStatus.authorized()),
-																					 new UsersEntityAccessInfo().withEntityId(125L).withAuthorizationStatus(AuthorizationStatus.authorized())));
-		when(mockNodeDao.getEntityPath(any())).thenReturn(List.of(new NameIdType().withName("root").withId("123").withType("foo"), 
-																  new NameIdType().withName("parent").withId("124").withType("bar"),
-																  new NameIdType().withName("child").withId("125").withType("baz")));
+				new UsersEntityAccessInfo().withEntityId(124L).withAuthorizationStatus(AuthorizationStatus.authorized()),
+				new UsersEntityAccessInfo().withEntityId(125L).withAuthorizationStatus(AuthorizationStatus.authorized())));
+		when(mockNodeDao.getEntityPath(any())).thenReturn(List.of(new NameIdType().withName("root").withId("123").withType("foo"),				
+				new NameIdType().withName("parent").withId("124").withType("bar"),
+				new NameIdType().withName("child").withId("125").withType("baz")));
+
 		// Call under test
 		List<EntityHeader> entityHeaders = nodeManager.getNodePath(mockUserInfo, nodeId);
 		List<EntityHeader> expectedEntityHeaders = List.of(new EntityHeader().setName("root").setId("123").setType("foo"),
-														   new EntityHeader().setName("parent").setId("124").setType("bar"),
-														   new EntityHeader().setName("child").setId("125").setType("baz"));
-		
+				new EntityHeader().setName("parent").setId("124").setType("bar"),
+				new EntityHeader().setName("child").setId("125").setType("baz"));
+
 		assertEquals(entityHeaders, expectedEntityHeaders);
 		verify(mockAuthManager).hasAccess(mockUserInfo, nodeId, ACCESS_TYPE.READ);
 		verify(mockNodeDao).getEntityPath(nodeId);
@@ -1866,19 +1867,20 @@ public class NodeManagerImplUnitTest {
 	public void testGetNodePathWithUserLacksSomePermission() {
 		when(mockAuthManager.hasAccess(any(), any(), any())).thenReturn(AuthorizationStatus.authorized());
 		when(mockAuthManager.batchHasAccess(any(), any(), any())).thenReturn(List.of(new UsersEntityAccessInfo().withEntityId(123L).withAuthorizationStatus(AuthorizationStatus.authorized()),
-																					 new UsersEntityAccessInfo().withEntityId(124L).withAuthorizationStatus(AuthorizationStatus.accessDenied("ACCESS_DENIED")),
-																					 new UsersEntityAccessInfo().withEntityId(125L).withAuthorizationStatus(AuthorizationStatus.accessDenied("ACCESS_DENIED")),
-																					 new UsersEntityAccessInfo().withEntityId(126L).withAuthorizationStatus(AuthorizationStatus.authorized())));
+				new UsersEntityAccessInfo().withEntityId(124L).withAuthorizationStatus(AuthorizationStatus.accessDenied("ACCESS_DENIED")),
+				new UsersEntityAccessInfo().withEntityId(125L).withAuthorizationStatus(AuthorizationStatus.accessDenied("ACCESS_DENIED")),
+				new UsersEntityAccessInfo().withEntityId(126L).withAuthorizationStatus(AuthorizationStatus.authorized())));
 		when(mockNodeDao.getEntityPath(any())).thenReturn(List.of(new NameIdType().withName("root").withId("123").withType("foo"),
-																  new NameIdType().withName("grandparent").withId("124").withType("bar"),
-																  new NameIdType().withName("parent").withId("125").withType("baz"),
-																  new NameIdType().withName("child").withId("126").withType("qux")));
+				new NameIdType().withName("grandparent").withId("124").withType("bar"),
+				new NameIdType().withName("parent").withId("125").withType("baz"),
+				new NameIdType().withName("child").withId("126").withType("qux")));
+
 		// Call under test
 		List<EntityHeader> entityHeaders = nodeManager.getNodePath(mockUserInfo, nodeId);
 		List<EntityHeader> expectedEntityHeaders = List.of(new EntityHeader().setName("root").setId("123").setType("foo"),
-														   new EntityHeader().setName(NodeManagerImpl.ENTITY_NAME_PERMISSION_DENIED).setId("124").setType("bar"),
-														   new EntityHeader().setName(NodeManagerImpl.ENTITY_NAME_PERMISSION_DENIED).setId("125").setType("baz"),
-														   new EntityHeader().setName("child").setId("126").setType("qux"));
+				new EntityHeader().setName(NodeManagerImpl.ENTITY_NAME_PERMISSION_DENIED).setId("124").setType("bar"),
+				new EntityHeader().setName(NodeManagerImpl.ENTITY_NAME_PERMISSION_DENIED).setId("125").setType("baz"),
+				new EntityHeader().setName("child").setId("126").setType("qux"));
 		
 		assertEquals(entityHeaders, expectedEntityHeaders);
 		verify(mockAuthManager).hasAccess(mockUserInfo, nodeId, ACCESS_TYPE.READ);


### PR DESCRIPTION
When a user calls the `GET /entity/{id}/path` API, we should hide the names of the entities that they do not have read permissions on. When hidden, the name of the entity is `Redacted`.

This resolves https://sagebionetworks.jira.com/browse/PLFM-7654.