### PR TITLE
ControllerToControllerModelTranslator PR Follow-up

### DIFF
--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/annotations/model/ControllerInfoModel.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/annotations/model/ControllerInfoModel.java
@@ -1,0 +1,48 @@
+package org.sagebionetworks.controller.annotations.model;
+
+import java.util.Objects;
+
+public class ControllerInfoModel {
+	private String displayName;
+	private String path;
+	
+	public String getDisplayName() {
+		return displayName;
+	}
+	
+	public ControllerInfoModel withDisplayName(String displayName) {
+		this.displayName = displayName;
+		return this;
+	}
+	
+	public String getPath() {
+		return path;
+	}
+	
+	public ControllerInfoModel withPath(String path) {
+		this.path = path;
+		return this;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(displayName, path);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ControllerInfoModel other = (ControllerInfoModel) obj;
+		return Objects.equals(displayName, other.displayName) && Objects.equals(path, other.path);
+	}
+
+	@Override
+	public String toString() {
+		return "ControllerInfoModel [displayName=" + displayName + ", path=" + path + "]";
+	}
+}

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/annotations/model/ResponseStatusModel.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/annotations/model/ResponseStatusModel.java
@@ -2,23 +2,21 @@ package org.sagebionetworks.controller.annotations.model;
 
 import java.util.Objects;
 
-import org.springframework.http.HttpStatus;
-
 public class ResponseStatusModel {
-	private HttpStatus status;
+	private Integer statusCode;
 
-	public HttpStatus getStatus() {
-		return status;
+	public Integer getStatusCode() {
+		return statusCode;
 	}
 
-	public ResponseStatusModel withStatus(HttpStatus status) {
-		this.status = status;
+	public ResponseStatusModel withStatusCode(Integer statusCode) {
+		this.statusCode = statusCode;
 		return this;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(status);
+		return Objects.hash(statusCode);
 	}
 
 	@Override
@@ -30,11 +28,11 @@ public class ResponseStatusModel {
 		if (getClass() != obj.getClass())
 			return false;
 		ResponseStatusModel other = (ResponseStatusModel) obj;
-		return status == other.status;
+		return Objects.equals(statusCode, other.statusCode);
 	}
 
 	@Override
 	public String toString() {
-		return "ResponseStatusModel [status=" + status + "]";
+		return "ResponseStatusModel [statusCode=" + statusCode + "]";
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/model/Operation.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/model/Operation.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.controller.model;
 
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.sagebionetworks.util.ValidateArgument;
 
 /**
  * The possible CRUD operations performed in a request.
@@ -17,19 +18,13 @@ public enum Operation {
 		this.requestMethod = method;
 	}
 
-	public static Operation get(Object method) {
-		if (method instanceof RequestMethod) {
-			return get((RequestMethod) method);
-		}
-		throw new IllegalArgumentException();
-	}
-
 	public static Operation get(RequestMethod method) {
+		ValidateArgument.required(method, "Request mapping is required.");
 		for (Operation opp : Operation.values()) {
 			if (opp.requestMethod.equals(method)) {
 				return opp;
 			}
 		}
-		throw new IllegalArgumentException();
+		throw new IllegalArgumentException("No operation found for RequestMethod " + method.getClass().getName());
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/model/ResponseModel.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/model/ResponseModel.java
@@ -12,7 +12,7 @@ import org.sagebionetworks.repo.model.schema.JsonSchema;
 public class ResponseModel {
 	private int statusCode;
 	private String description;
-	private String contentType;
+	private String contentType = "application/json";
 	private JsonSchema schema;
 	
 	public int getStatusCode() {

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/controller/model/OperationTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/controller/model/OperationTest.java
@@ -8,9 +8,9 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 public class OperationTest {
 	@Test
-	public void testGetWithUnhandledObjectType() {
+	public void testGetWithNull() {
 		assertThrows(IllegalArgumentException.class, () -> {
-			Operation.get("STRING");
+			Operation.get(null);
 		});
 	}
 	

--- a/lib/lib-openapi/src/test/resources/controller/BasicExampleController.java
+++ b/lib/lib-openapi/src/test/resources/controller/BasicExampleController.java
@@ -1,16 +1,17 @@
 package controller;
 
 import org.springframework.web.bind.annotation.PathVariable;
-
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.http.HttpStatus;
+import org.sagebionetworks.repo.web.rest.doc.ControllerInfo;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+@ControllerInfo(displayName = "Person", path = "repo/v1/person")
 public class BasicExampleController {
 	ConcurrentMap<String, Integer> personNameToAge = new ConcurrentHashMap<>();
 	


### PR DESCRIPTION
This PR is a follow up to https://github.com/Sage-Bionetworks/Synapse-Repository-Services/pull/4835 and responds to unresolved comments on it.

These changes include:
- Added ability to pull controller path + displayName from ControllerInfo annotation
- Splits apart the previously large getAnnotationToModel method
- Uses ValidateArgument instead of manually checking + throwing errors.
- contentType in ResponseModel has default value "application/json"
- Increased test coverage.
- Stores HttpStatus directly as an Integer