### PR TITLE
PLFM-7770 - Add Translator that translates multiple ControllerModels to a single OpenAPIModel

### DIFF
--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/translator/ControllerModelsToOpenAPIModelTranslator.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/translator/ControllerModelsToOpenAPIModelTranslator.java
@@ -1,0 +1,193 @@
+package org.sagebionetworks.translator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.sagebionetworks.controller.model.ControllerModel;
+import org.sagebionetworks.controller.model.MethodModel;
+import org.sagebionetworks.controller.model.ParameterModel;
+import org.sagebionetworks.controller.model.RequestBodyModel;
+import org.sagebionetworks.controller.model.ResponseModel;
+import org.sagebionetworks.openapi.datamodel.ApiInfo;
+import org.sagebionetworks.openapi.datamodel.ComponentInfo;
+import org.sagebionetworks.openapi.datamodel.OpenAPISpecModel;
+import org.sagebionetworks.openapi.datamodel.ServerInfo;
+import org.sagebionetworks.openapi.datamodel.pathinfo.EndpointInfo;
+import org.sagebionetworks.openapi.datamodel.pathinfo.ParameterInfo;
+import org.sagebionetworks.openapi.datamodel.pathinfo.RequestBodyInfo;
+import org.sagebionetworks.openapi.datamodel.pathinfo.ResponseInfo;
+import org.sagebionetworks.openapi.datamodel.pathinfo.Schema;
+import org.sagebionetworks.util.ValidateArgument;
+
+public class ControllerModelsToOpenAPIModelTranslator {
+	/**
+	 * Translates a list of controller models to an OpenAPI model.
+	 * 
+	 * @param controllerModels - the list of controller models to be translated
+	 * @return the resulting OpenAPI model.
+	 */
+	public OpenAPISpecModel translate(List<ControllerModel> controllerModels) {
+		ValidateArgument.required(controllerModels, "controllerModels");
+		Map<String, Map<String, EndpointInfo>> paths = new LinkedHashMap<>();
+		for (ControllerModel controllerModel : controllerModels) {
+			String displayName = controllerModel.getDisplayName();
+			String basePath = controllerModel.getPath();
+			List<MethodModel> methods = controllerModel.getMethods();
+			insertPaths(methods, basePath, displayName, paths);
+		}
+		return new OpenAPISpecModel().withInfo(getApiInfo()).withOpenapi("3.0.1").withServers(getServers())
+				.withComponents(null).withPaths(paths);
+	}
+
+	/**
+	 * Get the API information, such as the title and the version.
+	 * 
+	 * @return an object that represents the API information
+	 */
+	public ApiInfo getApiInfo() {
+		return new ApiInfo().withTitle("Sample OpenAPI definition").withVersion("v0");
+	}
+
+	/**
+	 * Get server information, such as URLs and description.
+	 * 
+	 * @return a list of objects that represents information on the servers.
+	 */
+	public List<ServerInfo> getServers() {
+		ServerInfo server = new ServerInfo().withUrl("https://localhost:8080")
+				.withDescription("This is the generated server URL");
+		return new ArrayList<>(Arrays.asList(server));
+	}
+
+	/**
+	 * Inserts the paths from the given methods into the "paths" map
+	 * 
+	 * @param methods     - the methods whose paths are to be inserted
+	 * @param basePath    - the base path of the controller
+	 * @param displayName - the display name of the controller
+	 * @param paths       - the map which we are inserting paths into.
+	 */
+	public void insertPaths(List<MethodModel> methods, String basePath, String displayName,
+			Map<String, Map<String, EndpointInfo>> paths) {
+		ValidateArgument.required(methods, "methods");
+		ValidateArgument.required(basePath, "basePath");
+		ValidateArgument.required(displayName, "displayName");
+		ValidateArgument.required(paths, "paths");
+		for (MethodModel method : methods) {
+			String fullPath = basePath + method.getPath();
+			if (!paths.containsKey(fullPath)) {
+				paths.put(fullPath, new HashMap<>());
+			}
+			insertOperationAndEndpointInfo(paths.get(fullPath), method, displayName);
+		}
+	}
+
+	/**
+	 * Insert an operation and its corresponding endpoint information into the map.
+	 * 
+	 * @param operationToEndpoint - the map to which we are inserting these values
+	 * @param method              - the method being looked at
+	 * @param displayName         - the display name of the controller in which this
+	 *                            method resides.
+	 */
+	public void insertOperationAndEndpointInfo(Map<String, EndpointInfo> operationToEndpoint, MethodModel method,
+			String displayName) {
+		ValidateArgument.required(operationToEndpoint, "operationToEndpoint");
+		ValidateArgument.required(method, "method");
+		ValidateArgument.required(displayName, "displayName");
+		String operation = method.getOperation().toString();
+		if (operationToEndpoint.containsKey(operation)) {
+			throw new IllegalArgumentException("OperationToEndpoint already contains operation " + operation);
+		}
+		operationToEndpoint.put(operation, getEndpointInfo(method, displayName));
+	}
+
+	/**
+	 * Get a object that represents the endpoint information from the method being
+	 * looked at.
+	 * 
+	 * @param method      - the method being looked at
+	 * @param displayName - the name of the controller where this method resides.
+	 * @return an object that represents the endpoint of the method.
+	 */
+	public EndpointInfo getEndpointInfo(MethodModel method, String displayName) {
+		ValidateArgument.required(method, "method");
+		ValidateArgument.required(displayName, "displayName");
+		List<String> tags = new ArrayList<>(Arrays.asList(displayName));
+		String operationId = method.getName();
+		EndpointInfo endpointInfo = new EndpointInfo().withTags(tags).withOperationId(operationId)
+				.withParameters(getParameters(method.getParameters()))
+				.withRequestBody(method.getRequestBody() == null ? null : getRequestBodyInfo(method.getRequestBody()))
+				.withResponses(getResponses(method.getResponse()));
+		return endpointInfo;
+	}
+
+	/**
+	 * Constructs and object that represents the responses of a method.
+	 * 
+	 * @param response - a model that represents the response of a method.
+	 * @return a map whose keys represent the status code and values are objects
+	 *         that describe the response.
+	 */
+	public Map<String, ResponseInfo> getResponses(ResponseModel response) {
+		ValidateArgument.required(response, "response");
+		Map<String, ResponseInfo> responses = new LinkedHashMap<>();
+		Map<String, Schema> contentTypeToSchema = new HashMap<>();
+		contentTypeToSchema.put(response.getContentType(), new Schema().withSchema(response.getSchema()));
+		ResponseInfo responseInfo = new ResponseInfo().withDescription(response.getDescription())
+				.withContent(contentTypeToSchema);
+
+		String statusCode = "" + response.getStatusCode();
+		responses.put(statusCode, responseInfo);
+		return responses;
+	}
+
+	/**
+	 * Construct a model that represents the Request Body for the OpenAPI model.
+	 * 
+	 * @param requestBody - the request body representation from the ControllerModel
+	 * @return a model that represents the request body
+	 */
+	public RequestBodyInfo getRequestBodyInfo(RequestBodyModel requestBody) {
+		ValidateArgument.required(requestBody, "requestBody");
+		String contentType = "application/json";
+		Map<String, Schema> contentTypeToSchema = new LinkedHashMap<>();
+		contentTypeToSchema.put(contentType, new Schema().withSchema(requestBody.getSchema()));
+		return new RequestBodyInfo().withRequired(requestBody.isRequired()).withContent(contentTypeToSchema);
+	}
+
+	/**
+	 * Constructs a list of objects that represents the parameters of the method.
+	 * 
+	 * @param method - the method being looked at.
+	 * @return a list that represents the parameters of the method/endpoint.
+	 */
+	public List<ParameterInfo> getParameters(List<ParameterModel> params) {
+		ValidateArgument.required(params, "params");
+		List<ParameterInfo> parameters = new ArrayList<>();
+		for (ParameterModel parameter : params) {
+			parameters.add(getParameterInfo(parameter));
+		}
+		return parameters;
+	}
+
+	/**
+	 * Converts the ControllerModel way of representing a parameter to the OpenAPI
+	 * model's way.
+	 * 
+	 * @param parameter - the parameter being looked at.
+	 * @return a model that represents the parameter.
+	 */
+	public ParameterInfo getParameterInfo(ParameterModel parameter) {
+		ValidateArgument.required(parameter, "parameter");
+		ParameterInfo parameterInfo = new ParameterInfo();
+		parameterInfo.withName(parameter.getName()).withDescription(parameter.getDescription())
+				.withRequired(parameter.isRequired()).withIn(parameter.getIn().toString())
+				.withSchema(parameter.getSchema());
+		return parameterInfo;
+	}
+}

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ControllerModelsToOpenAPIModelTranslatorTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ControllerModelsToOpenAPIModelTranslatorTest.java
@@ -1,0 +1,349 @@
+package org.sagebionetworks.translator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sagebionetworks.controller.model.ControllerModel;
+import org.sagebionetworks.controller.model.MethodModel;
+import org.sagebionetworks.controller.model.Operation;
+import org.sagebionetworks.controller.model.ParameterLocation;
+import org.sagebionetworks.controller.model.ParameterModel;
+import org.sagebionetworks.controller.model.RequestBodyModel;
+import org.sagebionetworks.controller.model.ResponseModel;
+import org.sagebionetworks.openapi.datamodel.ApiInfo;
+import org.sagebionetworks.openapi.datamodel.OpenAPISpecModel;
+import org.sagebionetworks.openapi.datamodel.ServerInfo;
+import org.sagebionetworks.openapi.datamodel.pathinfo.EndpointInfo;
+import org.sagebionetworks.openapi.datamodel.pathinfo.ParameterInfo;
+import org.sagebionetworks.openapi.datamodel.pathinfo.RequestBodyInfo;
+import org.sagebionetworks.openapi.datamodel.pathinfo.ResponseInfo;
+import org.sagebionetworks.openapi.datamodel.pathinfo.Schema;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.repo.model.schema.Type;
+
+public class ControllerModelsToOpenAPIModelTranslatorTest {
+	ControllerModelsToOpenAPIModelTranslator translator;
+
+	private static final String DESCRIPTION = "DESCRIPTION";
+
+	@BeforeEach
+	private void setUp() {
+		this.translator = Mockito.spy(new ControllerModelsToOpenAPIModelTranslator());
+	}
+	
+	@Test
+	public void testTranslate() {
+		String displayName = "DISPLAY_NAME";
+		String basePath = "/BASE_PATH";
+		List<MethodModel> methods = new ArrayList<>();
+		ControllerModel controllerModel = new ControllerModel().withDisplayName(displayName).withPath(basePath)
+				.withMethods(methods);
+		ApiInfo apiInfo = new ApiInfo();
+		List<ServerInfo> servers = new ArrayList<>();
+
+		Mockito.doNothing().when(translator).insertPaths(any(List.class), any(String.class), any(String.class),
+				any(Map.class));
+		Mockito.doReturn(apiInfo).when(translator).getApiInfo();
+		Mockito.doReturn(servers).when(translator).getServers();
+
+		OpenAPISpecModel result = translator.translate(Arrays.asList(controllerModel));
+		OpenAPISpecModel expected = new OpenAPISpecModel().withInfo(apiInfo).withOpenapi("3.0.1").withServers(servers)
+				.withComponents(null).withPaths(new LinkedHashMap<>());
+		assertEquals(expected, result);
+
+		Mockito.verify(translator).insertPaths(methods, basePath, displayName, result.getPaths());
+		Mockito.verify(translator).getApiInfo();
+		Mockito.verify(translator).getServers();
+	}
+
+	@Test
+	public void testTranslateWithNull() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.translate(null);
+		});
+		assertEquals("controllerModels is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testGetApiInfo() {
+		ApiInfo expectedApiInfo = new ApiInfo().withTitle("Sample OpenAPI definition").withVersion("v0");
+		assertEquals(expectedApiInfo, translator.getApiInfo());
+	}
+
+	@Test
+	public void testGetServers() {
+		ServerInfo server = new ServerInfo().withUrl("https://localhost:8080")
+				.withDescription("This is the generated server URL");
+		assertEquals(new ArrayList<>(Arrays.asList(server)), translator.getServers());
+	}
+
+	@Test
+	public void testInsertPaths() {
+		List<MethodModel> methods = new ArrayList<>();
+		String basePath = "/BASE_PATH";
+		String displayName = "DISPLAY_NAME";
+		Map<String, Map<String, EndpointInfo>> paths = new LinkedHashMap<>();
+
+		String methodPath = "/METHOD_PATH";
+		MethodModel method = new MethodModel().withPath(methodPath).withOperation(Operation.get);
+		methods.add(method);
+
+		EndpointInfo endpointInfo = new EndpointInfo();
+		Mockito.doReturn(endpointInfo).when(translator).getEndpointInfo(any(MethodModel.class), any(String.class));
+
+		// call under test.
+		translator.insertPaths(methods, basePath, displayName, paths);
+
+		Map<String, Map<String, EndpointInfo>> expectedPaths = new LinkedHashMap<>();
+		Map<String, EndpointInfo> operationToEndpoint = new LinkedHashMap<>();
+		operationToEndpoint.put("get", endpointInfo);
+		expectedPaths.put(basePath + methodPath, operationToEndpoint);
+
+		assertEquals(expectedPaths, paths);
+		Mockito.verify(translator).getEndpointInfo(method, displayName);
+	}
+
+	@Test
+	public void testInsertPathsWithNullPaths() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.insertPaths(new ArrayList<>(), "", "", null);
+		});
+		assertEquals("paths is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testInsertPathsWithNullDisplayName() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.insertPaths(new ArrayList<>(), "", null, new LinkedHashMap<>());
+		});
+		assertEquals("displayName is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testInsertPathsWithNullBasePath() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.insertPaths(new ArrayList<>(), null, "", new LinkedHashMap<>());
+		});
+		assertEquals("basePath is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testInsertPathsWithNullMethods() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.insertPaths(null, "", "", new LinkedHashMap<>());
+		});
+		assertEquals("methods is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testInsertOperationAndEndpointInfoWithDuplicateOperation() {
+		Map<String, EndpointInfo> operationToEndpointInfo = new LinkedHashMap<>();
+		MethodModel method1 = new MethodModel().withOperation(Operation.get);
+		String displayName = "DISPLAY_NAME";
+		EndpointInfo endpointInfo = new EndpointInfo();
+		Mockito.doReturn(endpointInfo).when(translator).getEndpointInfo(any(MethodModel.class), any(String.class));
+		translator.insertOperationAndEndpointInfo(operationToEndpointInfo, method1, displayName);
+
+		MethodModel method2 = new MethodModel().withOperation(Operation.get);
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.insertOperationAndEndpointInfo(operationToEndpointInfo, method2, displayName);
+		});
+		assertEquals("OperationToEndpoint already contains operation get", exception.getMessage());
+		Mockito.verify(translator).getEndpointInfo(method1, displayName);
+	}
+
+	@Test
+	public void testInsertOperationAndEndpointInfo() {
+		Map<String, EndpointInfo> operationToEndpointInfo = new LinkedHashMap<>();
+		MethodModel method = new MethodModel().withOperation(Operation.get);
+		String displayName = "DISPLAY_NAME";
+		EndpointInfo endpointInfo = new EndpointInfo();
+		Mockito.doReturn(endpointInfo).when(translator).getEndpointInfo(any(MethodModel.class), any(String.class));
+
+		// call under test.
+		translator.insertOperationAndEndpointInfo(operationToEndpointInfo, method, displayName);
+		Mockito.verify(translator).getEndpointInfo(method, displayName);
+		assertTrue(operationToEndpointInfo.containsKey("get"));
+		assertEquals(endpointInfo, operationToEndpointInfo.get("get"));
+	}
+
+	@Test
+	public void testInsertOperationAndEndpointInfoWithNullDisplayName() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.insertOperationAndEndpointInfo(new HashMap<>(), new MethodModel(), null);
+		});
+		assertEquals("displayName is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testInsertOperationAndEndpointInfoWithNullMethod() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.insertOperationAndEndpointInfo(new HashMap<>(), null, "");
+		});
+		assertEquals("method is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testInsertOperationAndEndpointInfoWithNullOperationToEndpoints() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.insertOperationAndEndpointInfo(null, new MethodModel(), "");
+		});
+		assertEquals("operationToEndpoint is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testGetEndpointInfo() {
+		String methodName = "METHOD_NAME";
+		String displayName = "DISPLAY_NAME";
+		List<ParameterModel> parameters = new ArrayList<>();
+		RequestBodyModel requestBodyModel = new RequestBodyModel();
+		ResponseModel responses = new ResponseModel();
+		List<String> tags = new ArrayList<>(Arrays.asList(displayName));
+		MethodModel method = new MethodModel().withName(methodName).withRequestBody(requestBodyModel)
+				.withParameters(parameters).withResponse(responses);
+
+		List<ParameterInfo> expectedParameters = new ArrayList<>();
+		RequestBodyInfo requestBodyInfo = new RequestBodyInfo();
+		Map<String, ResponseInfo> respones = new LinkedHashMap<>();
+		Mockito.doReturn(expectedParameters).when(translator).getParameters(any(List.class));
+		Mockito.doReturn(requestBodyInfo).when(translator).getRequestBodyInfo(any(RequestBodyModel.class));
+		Mockito.doReturn(respones).when(translator).getResponses(any(ResponseModel.class));
+
+		EndpointInfo expectedEndpointInfo = new EndpointInfo().withTags(tags).withOperationId(methodName)
+				.withParameters(expectedParameters).withRequestBody(requestBodyInfo).withResponses(respones);
+
+		// call under test.
+		assertEquals(expectedEndpointInfo, translator.getEndpointInfo(method, displayName));
+		Mockito.verify(translator).getParameters(parameters);
+		Mockito.verify(translator).getRequestBodyInfo(requestBodyModel);
+		Mockito.verify(translator).getResponses(responses);
+	}
+
+	@Test
+	public void testGetEndpointInfoWithNullDisplayName() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.getEndpointInfo(new MethodModel(), null);
+		});
+		assertEquals("displayName is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testGetEndpointInfoWithNullMethod() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.getEndpointInfo(null, "");
+		});
+		assertEquals("method is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testGetResponses() {
+		JsonSchema js = new JsonSchema();
+		js.setType(Type.integer);
+		js.setFormat("int32");
+		ResponseModel input = new ResponseModel().withDescription(DESCRIPTION).withSchema(js).withStatusCode(200);
+
+		Map<String, ResponseInfo> expectedResponses = new LinkedHashMap<>();
+		Map<String, Schema> contentTypeToSchema = new HashMap<>();
+		contentTypeToSchema.put("application/json", new Schema().withSchema(js));
+		ResponseInfo responseInfo = new ResponseInfo().withDescription(DESCRIPTION).withContent(contentTypeToSchema);
+		String statusCode = "200";
+		expectedResponses.put(statusCode, responseInfo);
+
+		// call under test.
+		assertEquals(expectedResponses, translator.getResponses(input));
+	}
+
+	@Test
+	public void testGetResponsesWithNull() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.getResponses(null);
+		});
+		assertEquals("response is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testGetRequestBodyInfo() {
+		JsonSchema js = new JsonSchema();
+		js.setType(Type.integer);
+		js.setFormat("int32");
+		RequestBodyModel input = new RequestBodyModel().withDescription(DESCRIPTION).withSchema(js).withRequired(true);
+
+		Map<String, Schema> contentTypeToSchema = new LinkedHashMap<>();
+		contentTypeToSchema.put("application/json", new Schema().withSchema(js));
+		RequestBodyInfo expected = new RequestBodyInfo().withRequired(true).withContent(contentTypeToSchema);
+
+		// call under test.
+		assertEquals(expected, translator.getRequestBodyInfo(input));
+	}
+
+	@Test
+	public void testGetRequestBodyInfoWithNull() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.getRequestBodyInfo(null);
+		});
+		assertEquals("requestBody is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testGetParameters() {
+		ParameterInfo paramInfo = new ParameterInfo();
+		ParameterModel paramModel = new ParameterModel();
+		Mockito.doReturn(paramInfo).when(translator).getParameterInfo(any(ParameterModel.class));
+		// call under test.
+		assertEquals(Arrays.asList(paramInfo), translator.getParameters(Arrays.asList(paramModel)));
+		Mockito.verify(translator).getParameterInfo(paramModel);
+	}
+
+	@Test
+	public void testGetParametersWithNull() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.getParameters(null);
+		});
+		assertEquals("params is required.", exception.getMessage());
+	}
+
+	@Test
+	public void testGetParameterInfo() {
+		ParameterModel input = new ParameterModel().withDescription(DESCRIPTION).withIn(ParameterLocation.query)
+				.withRequired(false);
+		ParameterInfo expected = new ParameterInfo().withDescription(DESCRIPTION).withIn("query").withRequired(false);
+
+		// call under test.
+		assertEquals(expected, translator.getParameterInfo(input));
+	}
+
+	@Test
+	public void testGetParameterInfoWithNull() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			translator.getParameterInfo(null);
+		});
+		assertEquals("parameter is required.", exception.getMessage());
+	}
+}

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ControllerModelsToOpenAPIModelTranslatorTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ControllerModelsToOpenAPIModelTranslatorTest.java
@@ -239,6 +239,32 @@ public class ControllerModelsToOpenAPIModelTranslatorTest {
 		Mockito.verify(translator).getRequestBodyInfo(requestBodyModel);
 		Mockito.verify(translator).getResponses(responses);
 	}
+	
+	@Test
+	public void testGetEndpointInfoWithNullRequestBodyModel() {
+		String methodName = "METHOD_NAME";
+		String displayName = "DISPLAY_NAME";
+		List<ParameterModel> parameters = new ArrayList<>();
+		RequestBodyModel requestBodyModel = null;
+		ResponseModel responses = new ResponseModel();
+		List<String> tags = new ArrayList<>(Arrays.asList(displayName));
+		MethodModel method = new MethodModel().withName(methodName).withRequestBody(requestBodyModel)
+				.withParameters(parameters).withResponse(responses);
+
+		List<ParameterInfo> expectedParameters = new ArrayList<>();
+		Map<String, ResponseInfo> respones = new LinkedHashMap<>();
+		Mockito.doReturn(expectedParameters).when(translator).getParameters(any(List.class));
+		Mockito.doReturn(respones).when(translator).getResponses(any(ResponseModel.class));
+
+		EndpointInfo expectedEndpointInfo = new EndpointInfo().withTags(tags).withOperationId(methodName)
+				.withParameters(expectedParameters).withRequestBody(null).withResponses(respones);
+
+		// call under test.
+		assertEquals(expectedEndpointInfo, translator.getEndpointInfo(method, displayName));
+		Mockito.verify(translator).getParameters(parameters);
+		Mockito.verify(translator, Mockito.times(0)).getRequestBodyInfo(any());
+		Mockito.verify(translator).getResponses(responses);
+	}
 
 	@Test
 	public void testGetEndpointInfoWithNullDisplayName() {


### PR DESCRIPTION
Added the `ControllerModelsToOpenAPIModel` translator, which translates multiples ControllerModels to a single OpenAPIModel.

This resolves: https://github.com/leonli33/Synapse-Repository-Services/pull/new/PLFM-7770