### PR TITLE
PLFM-7771: Added the ability to translate complex type with class hierarchy

### DIFF
--- a/lib/lib-openapi/pom.xml
+++ b/lib/lib-openapi/pom.xml
@@ -10,6 +10,10 @@
 	<artifactId>lib-openapi</artifactId>
 	<dependencies>
 		<dependency>
+			<groupId>org.sagebionetworks</groupId>
+			<artifactId>schema-to-pojo-lib</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 		</dependency>
@@ -20,6 +24,10 @@
 		<dependency>
 			<groupId>org.sagebionetworks</groupId>
 			<artifactId>lib-auto-generated</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.sagebionetworks</groupId>
+			<artifactId>lib-javadoc</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.sagebionetworks</groupId>
@@ -59,6 +67,12 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<properties>
+		<!-- This file is used to provide classpath information to the test javadoc 
+			tool -->
+		<auto.generated.classpath>${project.build.directory}/gen/auto-generated-classpath.txt</auto.generated.classpath>
+		<test.javadoc.output.directory>${project.build.directory}/javadoc</test.javadoc.output.directory>
+	</properties>
 	<build>
 		<resources>
 			<resource>
@@ -71,5 +85,59 @@
 				<directory>src/test/java</directory>
 			</resource>
 		</resources>
+		
+		<plugins>
+			<plugin>
+				<groupId>org.sagebionetworks</groupId>
+				<artifactId>schema-to-pojo-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<configuration>
+							<sourceDirectory>src/main/resources/schema</sourceDirectory>
+							<outputDirectory>target/auto-generated-pojos</outputDirectory>
+							<createRegister>org.sagebionetworks.openapi.server.ServerSideOnlyFactory</createRegister>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>build-classpath</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>build-classpath</goal>
+						</goals>
+						<configuration>
+							<excludeArtifactIds>tools</excludeArtifactIds>
+							<!-- We this plugin to generate a classpath file that can be used 
+								for javadoc testing. -->
+							<outputFile>${auto.generated.classpath}</outputFile>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<systemProperties>
+						<property>
+							<name>auto.generated.classpath</name>
+							<value>${auto.generated.classpath}</value>
+						</property>
+						<property>
+							<name>test.javadoc.output.directory</name>
+							<value>${test.javadoc.output.directory}</value>
+						</property>
+					</systemProperties>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 </project>	

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/model/ParameterModel.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/model/ParameterModel.java
@@ -14,7 +14,7 @@ public class ParameterModel {
 	private ParameterLocation in;
 	private boolean required;
 	private String description;
-	private JsonSchema schema;
+	private String id;
 	
 	public String getName() {
 		return name;
@@ -58,18 +58,18 @@ public class ParameterModel {
 		return this;
 	}
 	
-	public JsonSchema getSchema() {
-		return schema;
+	public String getId() {
+		return id;
 	}
 	
-	public ParameterModel withSchema(JsonSchema schema) {
-		this.schema = schema;
+	public ParameterModel withId(String id) {
+		this.id = id;
 		return this;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(description, in, name, required, schema);
+		return Objects.hash(description, id, in, name, required);
 	}
 
 	@Override
@@ -81,13 +81,13 @@ public class ParameterModel {
 		if (getClass() != obj.getClass())
 			return false;
 		ParameterModel other = (ParameterModel) obj;
-		return Objects.equals(description, other.description) && in == other.in && Objects.equals(name, other.name)
-				&& required == other.required && Objects.equals(schema, other.schema);
+		return Objects.equals(description, other.description) && Objects.equals(id, other.id) && in == other.in
+				&& Objects.equals(name, other.name) && required == other.required;
 	}
 
 	@Override
 	public String toString() {
-		return "ParameterModel [name=" + name + ", in=" + in + ", required=" + required + ", schema=" + schema
-				+ ", description=" + description + "]";
+		return "ParameterModel [name=" + name + ", in=" + in + ", required=" + required + ", description=" + description
+				+ ", id=" + id + "]";
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/model/RequestBodyModel.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/model/RequestBodyModel.java
@@ -12,7 +12,7 @@ import org.sagebionetworks.repo.model.schema.JsonSchema;
 public class RequestBodyModel {
 	private boolean required;
 	private String description;
-	private JsonSchema schema;
+	private String id;
 	
 	public boolean isRequired() {
 		return required;
@@ -32,18 +32,18 @@ public class RequestBodyModel {
 		return this;
 	}
 	
-	public JsonSchema getSchema() {
-		return schema;
+	public String getId() {
+		return id;
 	}
 	
-	public RequestBodyModel withSchema(JsonSchema schema) {
-		this.schema = schema;
+	public RequestBodyModel withId(String id) {
+		this.id = id;
 		return this;
 	}
 	
 	@Override
 	public int hashCode() {
-		return Objects.hash(description, required, schema);
+		return Objects.hash(description, required, id);
 	}
 
 	@Override
@@ -56,11 +56,11 @@ public class RequestBodyModel {
 			return false;
 		RequestBodyModel other = (RequestBodyModel) obj;
 		return Objects.equals(description, other.description) && required == other.required
-				&& Objects.equals(schema, other.schema);
+				&& Objects.equals(id, other.id);
 	}
 
 	@Override
 	public String toString() {
-		return "RequestBodyModel [required=" + required + ", description=" + description + ", schema=" + schema + "]";
+		return "RequestBodyModel [required=" + required + ", description=" + description + ", schema=" + id + "]";
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/model/ResponseModel.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/controller/model/ResponseModel.java
@@ -13,7 +13,7 @@ public class ResponseModel {
 	private int statusCode;
 	private String description;
 	private String contentType = "application/json";
-	private JsonSchema schema;
+	private String id;
 	
 	public int getStatusCode() {
 		return statusCode;
@@ -42,24 +42,18 @@ public class ResponseModel {
 		return this;
 	}
 	
-	public JsonSchema getSchema() {
-		return schema;
+	public String getId() {
+		return this.id;
 	}
 	
-	public ResponseModel withSchema(JsonSchema schema) {
-		this.schema = schema;
+	public ResponseModel withId(String id) {
+		this.id = id;
 		return this;
 	}
 
 	@Override
-	public String toString() {
-		return "ResponseModel [statusCode=" + statusCode + ", description=" + description + ", contentType="
-				+ contentType + ", schema=" + schema + "]";
-	}
-
-	@Override
 	public int hashCode() {
-		return Objects.hash(contentType, description, schema, statusCode);
+		return Objects.hash(contentType, description, id, statusCode);
 	}
 
 	@Override
@@ -72,6 +66,12 @@ public class ResponseModel {
 			return false;
 		ResponseModel other = (ResponseModel) obj;
 		return Objects.equals(contentType, other.contentType) && Objects.equals(description, other.description)
-				&& Objects.equals(schema, other.schema) && statusCode == other.statusCode;
+				&& Objects.equals(id, other.id) && statusCode == other.statusCode;
+	}
+
+	@Override
+	public String toString() {
+		return "ResponseModel [statusCode=" + statusCode + ", description=" + description + ", contentType="
+				+ contentType + ", id=" + id + "]";
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/translator/ControllerModelsToOpenAPIModelTranslator.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/translator/ControllerModelsToOpenAPIModelTranslator.java
@@ -22,9 +22,16 @@ import org.sagebionetworks.openapi.datamodel.pathinfo.ParameterInfo;
 import org.sagebionetworks.openapi.datamodel.pathinfo.RequestBodyInfo;
 import org.sagebionetworks.openapi.datamodel.pathinfo.ResponseInfo;
 import org.sagebionetworks.openapi.datamodel.pathinfo.Schema;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
 import org.sagebionetworks.util.ValidateArgument;
 
 public class ControllerModelsToOpenAPIModelTranslator {
+	private Map<String, JsonSchema> classNameToJsonSchema;
+	
+	public ControllerModelsToOpenAPIModelTranslator(Map<String, JsonSchema> classNameToJsonSchema) {
+		this.classNameToJsonSchema = classNameToJsonSchema;
+	}
+	
 	/**
 	 * Translates a list of controller models to an OpenAPI model.
 	 * 
@@ -142,7 +149,7 @@ public class ControllerModelsToOpenAPIModelTranslator {
 		ValidateArgument.required(response, "response");
 		Map<String, ResponseInfo> responses = new LinkedHashMap<>();
 		Map<String, Schema> contentTypeToSchema = new HashMap<>();
-		contentTypeToSchema.put(response.getContentType(), new Schema().withSchema(response.getSchema()));
+		contentTypeToSchema.put(response.getContentType(), new Schema().withSchema(classNameToJsonSchema.get(response.getId())));
 		ResponseInfo responseInfo = new ResponseInfo().withDescription(response.getDescription())
 				.withContent(contentTypeToSchema);
 
@@ -161,7 +168,7 @@ public class ControllerModelsToOpenAPIModelTranslator {
 		ValidateArgument.required(requestBody, "requestBody");
 		String contentType = "application/json";
 		Map<String, Schema> contentTypeToSchema = new LinkedHashMap<>();
-		contentTypeToSchema.put(contentType, new Schema().withSchema(requestBody.getSchema()));
+		contentTypeToSchema.put(contentType, new Schema().withSchema(classNameToJsonSchema.get(requestBody.getId())));
 		return new RequestBodyInfo().withRequired(requestBody.isRequired()).withContent(contentTypeToSchema);
 	}
 
@@ -192,7 +199,7 @@ public class ControllerModelsToOpenAPIModelTranslator {
 		ParameterInfo parameterInfo = new ParameterInfo();
 		parameterInfo.withName(parameter.getName()).withDescription(parameter.getDescription())
 				.withRequired(parameter.isRequired()).withIn(parameter.getIn().toString())
-				.withSchema(parameter.getSchema());
+				.withSchema(classNameToJsonSchema.get(parameter.getId()));
 		return parameterInfo;
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/translator/ControllersToOpenAPIJsonTranslator.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/translator/ControllersToOpenAPIJsonTranslator.java
@@ -1,0 +1,32 @@
+package org.sagebionetworks.translator;
+
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONObject;
+import org.sagebionetworks.controller.model.ControllerModel;
+import org.sagebionetworks.openapi.server.ServerSideOnlyFactory;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.schema.ObjectSchema;
+
+import jdk.javadoc.doclet.DocletEnvironment;
+
+public class ControllersToOpenAPIJsonTranslator {
+	
+	/**
+	 * Goes through all controllers found in DocletEnvironment and outputs a JSONObject that
+	 * represents all of the controllers and complies to the OpenAPI specification.
+	 * 
+	 * @param env the doclet environment
+	 * @return JSONObject that represents all of the controllers.
+	 */
+	public JSONObject translate(DocletEnvironment env) {
+		ObjectSchemaUtils objectSchemaUtils = new ObjectSchemaUtils();
+		
+		Map<String, ObjectSchema> classNameToObjectSchema = objectSchemaUtils.getConcreteClasses(new ServerSideOnlyFactory());
+		List<ControllerModel> controllerModels = new ControllerToControllerModelTranslator().extractControllerModels(env, classNameToObjectSchema);
+		Map<String, JsonSchema> classNameToJsonSchema = objectSchemaUtils.getClassNameToJsonSchema(classNameToObjectSchema);
+
+		return new ControllerModelsToOpenAPIModelTranslator(classNameToJsonSchema).translate(controllerModels).generateJSON();
+	}
+}

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/translator/ObjectSchemaUtils.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/translator/ObjectSchemaUtils.java
@@ -1,0 +1,205 @@
+package org.sagebionetworks.translator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.sagebionetworks.javadoc.velocity.schema.SchemaUtils;
+import org.sagebionetworks.javadoc.velocity.schema.TypeReference;
+import org.sagebionetworks.openapi.server.ServerSideOnlyFactory;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.repo.model.schema.Type;
+import org.sagebionetworks.schema.ObjectSchema;
+import org.sagebionetworks.schema.TYPE;
+import org.sagebionetworks.util.ValidateArgument;
+
+public class ObjectSchemaUtils {	
+	/**
+	 * Generates a mapping of class id to an ObjectSchema that represents that class.
+	 * Starts out with all of the concrete classes found in `autoGen`
+	 * 
+	 * @param autoGen - the ServerSideOnlyFactory whose class id's represent all concrete classes.
+	 * @return a mapping of concrete classes between class id to an ObjectSchema that represents it.
+	 */
+	public Map<String, ObjectSchema> getConcreteClasses(ServerSideOnlyFactory autoGen) {
+		Map<String, ObjectSchema> classNameToObjectSchema = new HashMap<>();
+		Iterator<String> keySet = autoGen.getKeySetIterator();
+		while (keySet.hasNext()) {
+			String className = keySet.next();
+			ObjectSchema schema = SchemaUtils.getSchema(className);
+			SchemaUtils.recursiveAddTypes(classNameToObjectSchema, className, schema);
+		}
+		return classNameToObjectSchema;
+	}
+	
+	/**
+	 * Translates a mapping from class id to ObjectSchema to a mapping from class id to JsonSchema;
+	 * 
+	 * @param classNameToObjectSchema - the mapping being translated
+	 * @return a translated mapping consisting of class id to JsonSchema
+	 */
+	public Map<String, JsonSchema> getClassNameToJsonSchema(Map<String, ObjectSchema> classNameToObjectSchema) {
+		Map<String, JsonSchema> classNameToJsonSchema = new HashMap<>();
+		for (String className : classNameToObjectSchema.keySet()) {
+			ObjectSchema schema = classNameToObjectSchema.get(className);
+			classNameToJsonSchema.put(className, translateObjectSchemaToJsonSchema(schema));
+		}
+		Map<String, List<TypeReference>> interfaces = SchemaUtils.mapImplementationsToIntefaces(classNameToObjectSchema);
+		insertOneOfPropertyForInterfaces(classNameToJsonSchema, interfaces);
+		return classNameToJsonSchema;
+	}
+
+	/**
+	 * Translates an ObjectSchema to a JsonSchema
+	 * 
+	 * @param objectSchema - the schema being translated.
+	 * @return the resulting JsonSchema
+	 */
+	JsonSchema translateObjectSchemaToJsonSchema(ObjectSchema objectSchema) {
+		ValidateArgument.required(objectSchema, "objectSchema");
+		if (isPrimitive(objectSchema.getType())) {
+			return getSchemaForPrimitiveType(objectSchema.getType());
+		}
+		JsonSchema jsonSchema = new JsonSchema();
+		jsonSchema.setType(translateObjectSchemaTypeToJsonSchemaType(objectSchema.getType()));
+		jsonSchema.setProperties(translatePropertiesFromObjectSchema(objectSchema.getProperties()));
+		if (objectSchema.getDescription() != null) {
+			jsonSchema.setDescription(objectSchema.getDescription());
+		}
+
+		return jsonSchema;
+	}
+	
+	/**
+	 * Translate the "properties" attribute of an ObjectSchema, which is a mapping between class id to ObjectSchema
+	 * 
+	 * @param properties - the properties we are translating
+	 * @return an equivalent mapping between class id to JsonSchema
+	 */
+	Map<String, JsonSchema> translatePropertiesFromObjectSchema(Map<String, ObjectSchema> properties) {
+		ValidateArgument.required(properties, "properties");
+		Map<String, JsonSchema> result = new LinkedHashMap<>();
+		for (String className : properties.keySet()) {
+			// TODO: here we should check if the class is primitive, if it is, then output the JsonSchema, otherwise
+			// 		 create a JsonSchema that is just a ref.
+			result.put(className, translateObjectSchemaToJsonSchema(properties.get(className)));
+		}
+		return result;
+	}
+	
+	/**
+	 * Returns if the given TYPE is primitive.
+	 * 
+	 * @param type - the TYPE in question
+	 * @return true if 'type' is primitive, false otherwise.
+	 */
+	boolean isPrimitive(TYPE type) {
+		return type.equals(TYPE.BOOLEAN) || type.equals(TYPE.NUMBER) || type.equals(TYPE.STRING) || type.equals(TYPE.INTEGER);
+	}
+	
+	/**
+	 * Inserts the oneOf properties into all of the JsonSchemas which represent interfaces.
+	 * 
+	 * @param classNameToJsonSchema mapping from class ids to a JsonSchema that represents that class.
+	 * @param interfaces the interfaces present in the application mapped to the list of classes that implement them.
+	 */
+	void insertOneOfPropertyForInterfaces(Map<String, JsonSchema> classNameToJsonSchema, Map<String, List<TypeReference>> interfaces) {
+		for (String className : classNameToJsonSchema.keySet()) {
+			if (interfaces.containsKey(className)) {
+				Set<TypeReference> implementers = getImplementers(className, interfaces);
+				List<JsonSchema> oneOf = new ArrayList<>();
+				for (TypeReference implementer : implementers) {
+					String id = implementer.getId();
+					if (!classNameToJsonSchema.containsKey(id)) {
+						throw new IllegalArgumentException("Implementation of " + className + " interface with name " + id + " was not found.");
+					}
+					JsonSchema newSchema = new JsonSchema();
+					newSchema.set$ref("#/components/" + id);
+					oneOf.add(newSchema);
+				}
+				classNameToJsonSchema.get(className).setOneOf(oneOf);
+			}
+		}
+	}
+	
+	/**
+	 * Recursively gets all of the concrete implementers of the given interface.
+	 * 
+	 * @param interfaceId the id of the interface
+	 * @param interfaces a mapping between all interfaces and their implementers
+	 * @return a set of all of the concrete implementers of the interface
+	 */
+	Set<TypeReference> getImplementers(String interfaceId, Map<String, List<TypeReference>> interfaces) {
+		Set<TypeReference> allImplementers = new HashSet<>();
+		
+		List<TypeReference> implementers = interfaces.get(interfaceId);
+		for (TypeReference implementer : implementers) {
+			String implementerId = implementer.getId();
+			boolean isInterface = interfaces.containsKey(implementerId);
+			if (isInterface) {
+				// add all of the classes that implement this interface
+				Set<TypeReference> currentImplementers = getImplementers(implementerId, interfaces);
+				allImplementers.addAll(currentImplementers);
+			} else {
+				allImplementers.add(implementer);
+			}
+		}
+		
+		return allImplementers;
+	}
+
+	/**
+	 * Translates the TYPE enum used for ObjectSchema to type used for JsonSchema
+	 * 
+	 * @param type the ObjectSchema type being translated
+	 * @return the equivalent JsonSchema type.
+	 */
+	Type translateObjectSchemaTypeToJsonSchemaType(TYPE type) {
+		ValidateArgument.required(type, "type");
+		switch (type) {
+		case NULL:
+			return Type._null;
+		case ARRAY:
+			return Type.array;
+		case OBJECT:
+		case INTERFACE:
+			return Type.object;
+		default:
+			throw new IllegalArgumentException("Unable to convert non-primitive type " + type);
+		}
+	}
+	
+	/**
+	 * Constructs a JsonSchema for a primitive class.
+	 * 
+	 * @param type - the primitive type
+	 * @return the JsonSchema used to represent this type.
+	 */
+	JsonSchema getSchemaForPrimitiveType(TYPE type) {
+		ValidateArgument.required(type, "type");
+		JsonSchema schema = new JsonSchema();
+		switch (type) {
+		case STRING:
+			schema.setType(Type.string);
+			break;
+		case INTEGER:
+			schema.setType(Type.integer);
+			schema.setFormat("int32");
+			break;
+		case NUMBER:
+			schema.setType(Type.number);
+			break;
+		case BOOLEAN:
+			schema.setType(Type._boolean);
+			break;
+		default:
+			throw new IllegalArgumentException("Unable to translate primitive type " + type);
+		}
+		return schema;
+	}
+}

--- a/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Cat.json
+++ b/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Cat.json
@@ -1,0 +1,15 @@
+{
+	"description": "This class describes a Cat.",
+	"name": "Cat",
+	"implements":[
+        {
+            "$ref":"org.sagebionetworks.openapi.pet.Pet"
+        }
+    ],
+    "properties": {
+		"numWhiskers": {
+			"type": "integer",
+			"description": "The number of whiskers the cat has."
+		}
+	}
+}

--- a/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Dog.json
+++ b/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Dog.json
@@ -1,0 +1,16 @@
+{
+	"description": "This class describes a Dog.",
+	"name": "Dog",
+	"type": "interface",
+	"implements":[
+        {
+            "$ref":"org.sagebionetworks.openapi.pet.Pet"
+        }
+    ],
+	"properties": {
+		"age": {
+			"type": "integer",
+			"description": "The age of the dog."
+		}
+	}
+}

--- a/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Husky.json
+++ b/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Husky.json
@@ -1,0 +1,15 @@
+{
+	"description": "Describes the husky breed of Dog.",
+	"name": "Husky",
+	"implements": [
+		{
+			"$ref": "org.sagebionetworks.openapi.pet.Dog"
+		}
+	],
+	"properties": {
+		"hasLongHair": {
+			"type": "boolean",
+			"description": "Describes if the husky has long hair."
+		}
+	}
+}

--- a/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Pet.json
+++ b/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Pet.json
@@ -1,0 +1,15 @@
+{
+	"description": "This interface represents a pet.",
+	"name": "Pet",
+	"type": "interface",
+	"properties": {
+		"name": {
+			"type": "string",
+			"description": "The name of the Pet."
+		},
+		"hasTail": {
+			"type": "boolean",
+			"description": "Describes if the pet has a tail."
+		}
+	}
+}

--- a/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Poodle.json
+++ b/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Poodle.json
@@ -1,0 +1,15 @@
+{
+	"description": "Describes the poodle breed of Dog.",
+	"name": "Poodle",
+	"implements": [
+		{
+			"$ref": "org.sagebionetworks.openapi.pet.Dog"
+		}
+	],
+	"properties": {
+		"isFluffy": {
+			"type": "boolean",
+			"description": "Describes if the poodle if fluffy."
+		}
+	}
+}

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ControllerModelsToOpenAPIModelTranslatorTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ControllerModelsToOpenAPIModelTranslatorTest.java
@@ -38,10 +38,18 @@ public class ControllerModelsToOpenAPIModelTranslatorTest {
 	ControllerModelsToOpenAPIModelTranslator translator;
 
 	private static final String DESCRIPTION = "DESCRIPTION";
+	private static final String MOCK_CLASS_NAME = "MOCK_CLASS_NAME";
+	private Map<String, JsonSchema> schemaMap;
 
 	@BeforeEach
 	private void setUp() {
-		this.translator = Mockito.spy(new ControllerModelsToOpenAPIModelTranslator());
+		Map<String, JsonSchema> schemaMap = new HashMap<>();
+		JsonSchema js = new JsonSchema();
+		js.setType(Type.integer);
+		schemaMap.put(MOCK_CLASS_NAME, js);
+		this.schemaMap = schemaMap;
+
+		this.translator = Mockito.spy(new ControllerModelsToOpenAPIModelTranslator(schemaMap));
 	}
 	
 	@Test
@@ -290,14 +298,12 @@ public class ControllerModelsToOpenAPIModelTranslatorTest {
 
 	@Test
 	public void testGetResponses() {
-		JsonSchema js = new JsonSchema();
-		js.setType(Type.integer);
-		js.setFormat("int32");
-		ResponseModel input = new ResponseModel().withDescription(DESCRIPTION).withSchema(js).withStatusCode(200);
+		// should use id here instead
+		ResponseModel input = new ResponseModel().withDescription(DESCRIPTION).withId(MOCK_CLASS_NAME).withStatusCode(200);
 
 		Map<String, ResponseInfo> expectedResponses = new LinkedHashMap<>();
 		Map<String, Schema> contentTypeToSchema = new HashMap<>();
-		contentTypeToSchema.put("application/json", new Schema().withSchema(js));
+		contentTypeToSchema.put("application/json", new Schema().withSchema(schemaMap.get(MOCK_CLASS_NAME)));
 		ResponseInfo responseInfo = new ResponseInfo().withDescription(DESCRIPTION).withContent(contentTypeToSchema);
 		String statusCode = "200";
 		expectedResponses.put(statusCode, responseInfo);
@@ -317,13 +323,10 @@ public class ControllerModelsToOpenAPIModelTranslatorTest {
 
 	@Test
 	public void testGetRequestBodyInfo() {
-		JsonSchema js = new JsonSchema();
-		js.setType(Type.integer);
-		js.setFormat("int32");
-		RequestBodyModel input = new RequestBodyModel().withDescription(DESCRIPTION).withSchema(js).withRequired(true);
+		RequestBodyModel input = new RequestBodyModel().withDescription(DESCRIPTION).withId(MOCK_CLASS_NAME).withRequired(true);
 
 		Map<String, Schema> contentTypeToSchema = new LinkedHashMap<>();
-		contentTypeToSchema.put("application/json", new Schema().withSchema(js));
+		contentTypeToSchema.put("application/json", new Schema().withSchema(schemaMap.get(MOCK_CLASS_NAME)));
 		RequestBodyInfo expected = new RequestBodyInfo().withRequired(true).withContent(contentTypeToSchema);
 
 		// call under test.

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ObjectSchemaUtilsTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ObjectSchemaUtilsTest.java
@@ -1,0 +1,411 @@
+package org.sagebionetworks.translator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Iterator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.sagebionetworks.javadoc.velocity.schema.SchemaUtils;
+import org.sagebionetworks.javadoc.velocity.schema.TypeReference;
+import org.sagebionetworks.openapi.server.ServerSideOnlyFactory;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.repo.model.schema.Type;
+import org.sagebionetworks.schema.ObjectSchema;
+import org.sagebionetworks.schema.ObjectSchemaImpl;
+import org.sagebionetworks.schema.TYPE;
+import org.sagebionetworks.schema.adapter.org.json.JSONObjectAdapterImpl;
+
+public class ObjectSchemaUtilsTest {
+	private ObjectSchemaUtils util;
+	
+	@BeforeEach
+	private void setUp() {
+		this.util = Mockito.spy(new ObjectSchemaUtils());
+	}
+	
+	@Test
+	public void testGetConcreteClasses() {
+		ServerSideOnlyFactory autoGen = new ServerSideOnlyFactory();
+		Map<String, ObjectSchema> expected = new HashMap<>();
+		Iterator<String> keySet = autoGen.getKeySetIterator();
+		while (keySet.hasNext()) {
+			String className = keySet.next();
+			ObjectSchema schema = SchemaUtils.getSchema(className);
+			SchemaUtils.recursiveAddTypes(expected, className, schema);
+		}
+		// call under test
+		assertEquals(expected, util.getConcreteClasses(autoGen));
+	}
+	
+	@Test
+	public void testGetClassNameToJsonSchema() {
+		Map<String, ObjectSchema> classNameToObjectSchema = new HashMap<>();
+		ObjectSchema objectSchema;
+		try {
+			JSONObjectAdapterImpl adpater = new JSONObjectAdapterImpl("{}");
+			objectSchema = new ObjectSchemaImpl(adpater);
+		} catch (Exception e) {
+			// this should never happen
+			throw new RuntimeException("Error creating adapter for schema");
+		}
+		objectSchema.setType(TYPE.INTEGER);
+		String className = "className";
+		classNameToObjectSchema.put(className, objectSchema);
+		Mockito.doReturn(new JsonSchema()).when(util).translateObjectSchemaToJsonSchema(any(ObjectSchema.class));
+		
+		Map<String, JsonSchema> expected = new HashMap<>();
+		expected.put(className, new JsonSchema());
+		// call under test
+		assertEquals(expected, util.getClassNameToJsonSchema(classNameToObjectSchema));
+		
+		Mockito.verify(util).translateObjectSchemaToJsonSchema(objectSchema);
+		Mockito.verify(util).insertOneOfPropertyForInterfaces(expected, new HashMap<>());
+	}
+	
+	@Test
+	public void testTranslateObjectSchemaToJsonSchemaWithNDescription() {
+		ObjectSchema objectSchema;
+		try {
+			JSONObjectAdapterImpl adpater = new JSONObjectAdapterImpl("{}");
+			objectSchema = new ObjectSchemaImpl(adpater);
+		} catch (Exception e) {
+			// this should never happen
+			throw new RuntimeException("Error creating adapter for schema");
+		}
+		objectSchema.setType(TYPE.OBJECT);
+		objectSchema.setProperties(new LinkedHashMap<>());
+		objectSchema.setDescription("TESTING");
+		
+		Mockito.doReturn(Type.object).when(util).translateObjectSchemaTypeToJsonSchemaType(any(TYPE.class));
+		Mockito.doReturn(new LinkedHashMap<>()).when(util).translatePropertiesFromObjectSchema(any(Map.class));
+		
+		JsonSchema expected = new JsonSchema();
+		expected.setType(Type.object);
+		expected.setProperties(new LinkedHashMap<>());
+		expected.setDescription("TESTING");
+
+		// call under test
+		assertEquals(expected, util.translateObjectSchemaToJsonSchema(objectSchema));
+		Mockito.verify(util).translateObjectSchemaTypeToJsonSchemaType(TYPE.OBJECT);
+		Mockito.verify(util).translatePropertiesFromObjectSchema(new LinkedHashMap<>());
+	}
+	
+	@Test
+	public void testTranslateObjectSchemaToJsonSchemaWithNonPrimitiveType() {
+		ObjectSchema objectSchema;
+		try {
+			JSONObjectAdapterImpl adpater = new JSONObjectAdapterImpl("{}");
+			objectSchema = new ObjectSchemaImpl(adpater);
+		} catch (Exception e) {
+			// this should never happen
+			throw new RuntimeException("Error creating adapter for schema");
+		}
+		objectSchema.setType(TYPE.OBJECT);
+		objectSchema.setProperties(new LinkedHashMap<>());
+		
+		Mockito.doReturn(Type.object).when(util).translateObjectSchemaTypeToJsonSchemaType(any(TYPE.class));
+		Mockito.doReturn(new LinkedHashMap<>()).when(util).translatePropertiesFromObjectSchema(any(Map.class));
+		
+		JsonSchema expected = new JsonSchema();
+		expected.setType(Type.object);
+		expected.setProperties(new LinkedHashMap<>());
+
+		// call under test
+		assertEquals(expected, util.translateObjectSchemaToJsonSchema(objectSchema));
+		Mockito.verify(util).translateObjectSchemaTypeToJsonSchemaType(TYPE.OBJECT);
+		Mockito.verify(util).translatePropertiesFromObjectSchema(new LinkedHashMap<>());
+	}
+	
+	@Test
+	public void testTranslateObjectSchemaToJsonSchemaWithPrimitiveType() {
+		ObjectSchema objectSchema;
+		try {
+			JSONObjectAdapterImpl adpater = new JSONObjectAdapterImpl("{}");
+			objectSchema = new ObjectSchemaImpl(adpater);
+		} catch (Exception e) {
+			// this should never happen
+			throw new RuntimeException("Error creating adapter for schema");
+		}
+		objectSchema.setType(TYPE.INTEGER);
+		
+		Mockito.doReturn(new JsonSchema()).when(util).getSchemaForPrimitiveType(any(TYPE.class));
+		Mockito.doReturn(true).when(util).isPrimitive(any(TYPE.class));
+		
+		assertEquals(new JsonSchema(), util.translateObjectSchemaToJsonSchema(objectSchema));
+		Mockito.verify(util).isPrimitive(TYPE.INTEGER);
+		Mockito.verify(util).getSchemaForPrimitiveType(TYPE.INTEGER);
+	}
+	
+	@Test
+	public void testTranslateObjectSchemaToJsonSchemaWithNull() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test
+			util.translateObjectSchemaToJsonSchema(null);
+		});
+		assertEquals("objectSchema is required.", exception.getMessage());
+	}
+	
+	@Test
+	public void testTranslatePropertiesFromObjectSchema() {
+		Map<String, ObjectSchema> properties = new LinkedHashMap<>();
+		ObjectSchema objectSchema1;
+		ObjectSchema objectSchema2;
+		try {
+			JSONObjectAdapterImpl adpater1 = new JSONObjectAdapterImpl("{}");
+			JSONObjectAdapterImpl adpater2 = new JSONObjectAdapterImpl("{properties: {}}");
+			objectSchema1 = new ObjectSchemaImpl(adpater1);
+			objectSchema2 = new ObjectSchemaImpl(adpater2);
+		} catch (Exception e) {
+			// this should never happen
+			throw new RuntimeException("Error creating adapter for schema");
+		}
+		String className1 = "ClassName1";
+		String className2 = "ClassName2";
+		properties.put(className1, objectSchema1);
+		properties.put(className2, objectSchema2);
+		
+		Mockito.doReturn(new JsonSchema()).when(util).translateObjectSchemaToJsonSchema(any(ObjectSchema.class));
+		
+		Map<String, JsonSchema> expected = new LinkedHashMap<>();
+		expected.put(className1, new JsonSchema());
+		expected.put(className2, new JsonSchema());
+		
+		// call under test
+		assertEquals(expected, util.translatePropertiesFromObjectSchema(properties));
+		Mockito.verify(util, Mockito.times(2)).translateObjectSchemaToJsonSchema(any(ObjectSchema.class));
+		InOrder inOrder = Mockito.inOrder(util);
+		inOrder.verify(util).translateObjectSchemaToJsonSchema(objectSchema1);
+		inOrder.verify(util).translateObjectSchemaToJsonSchema(objectSchema2);
+	}
+	
+	@Test
+	public void testTranslatePropertiesFromObjectSchemaWithNull() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test
+			util.translatePropertiesFromObjectSchema(null);
+		});
+		assertEquals("properties is required.", exception.getMessage());
+	}
+	
+	@Test
+	public void testIsPrimitiveWithNonPrimitiveType() {
+		assertEquals(false, util.isPrimitive(TYPE.ARRAY));
+	}
+	
+	@Test
+	public void testIsPrimitiveWithPrimitiveTypes() {
+		assertEquals(true, util.isPrimitive(TYPE.BOOLEAN));
+		assertEquals(true, util.isPrimitive(TYPE.NUMBER));
+		assertEquals(true, util.isPrimitive(TYPE.STRING));
+		assertEquals(true, util.isPrimitive(TYPE.INTEGER));
+	}
+	
+	@Test
+	public void testInsertOneOfPropertyForInterfaces() {
+		Map<String, JsonSchema> classNameToJsonSchema = new HashMap<>();
+		Map<String, List<TypeReference>> interfaces = new HashMap<>();
+		String className = "ClassName";
+		classNameToJsonSchema.put(className, new JsonSchema());
+		classNameToJsonSchema.put("mock.implementer.class.name", new JsonSchema());
+		interfaces.put(className, new ArrayList<>());
+
+		Set<TypeReference> implementers = new HashSet<>();
+		TypeReference reference = Mockito.mock(TypeReference.class);
+		Mockito.doReturn("mock.implementer.class.name").when(reference).getId();
+		implementers.add(reference);
+		Mockito.doReturn(implementers).when(util).getImplementers(any(String.class), any(Map.class));
+		
+		// call under test
+		util.insertOneOfPropertyForInterfaces(classNameToJsonSchema, interfaces);
+		
+		JsonSchema expectedSchema = new JsonSchema();
+		expectedSchema.set$ref("#/components/mock.implementer.class.name");
+		List<JsonSchema> oneOf = new ArrayList<>();
+		oneOf.add(expectedSchema);
+		expectedSchema.setOneOf(oneOf);
+
+		Map<String, JsonSchema> expectedClassNameToJsonSchema = new HashMap<>();
+		expectedClassNameToJsonSchema.put(className, expectedSchema);
+		expectedClassNameToJsonSchema.put("mock.implementer.class.name", new JsonSchema());
+		
+		assertEquals(classNameToJsonSchema, classNameToJsonSchema);
+		Mockito.verify(util).getImplementers(className, interfaces);
+	}
+	
+	@Test
+	public void testInsertOneOfPropertyForInterfacesWithNonInterfaceClass() {
+		Map<String, JsonSchema> classNameToJsonSchema = new HashMap<>();
+		Map<String, List<TypeReference>> interfaces = new HashMap<>();
+		String className = "ClassName";
+		classNameToJsonSchema.put(className, new JsonSchema());
+		// call under test
+		util.insertOneOfPropertyForInterfaces(classNameToJsonSchema, interfaces);
+		// should not modify classNameToJsonSchema
+		Map<String, JsonSchema> expectedClassNameToJsonSchema = new HashMap<>();
+		expectedClassNameToJsonSchema.put(className, new JsonSchema());
+		assertEquals(expectedClassNameToJsonSchema, classNameToJsonSchema);
+	}
+	
+	@Test
+	public void testInsertOneOfPropertyForInterfacesWithIdMissingInClassNameToJsonSchema() {
+		Map<String, JsonSchema> classNameToJsonSchema = new HashMap<>();
+		Map<String, List<TypeReference>> interfaces = new HashMap<>();
+		String className = "ClassName";
+		classNameToJsonSchema.put(className, new JsonSchema());
+		interfaces.put(className, new ArrayList<>());
+		
+		Set<TypeReference> implementers = new HashSet<>();
+		TypeReference reference = Mockito.mock(TypeReference.class);
+		Mockito.doReturn("MOCK_ID").when(reference).getId();
+		implementers.add(reference);
+		Mockito.doReturn(implementers).when(util).getImplementers(any(String.class), any(Map.class));
+		
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test.
+			util.insertOneOfPropertyForInterfaces(classNameToJsonSchema, interfaces);
+		});
+		
+		assertEquals("Implementation of ClassName interface with name MOCK_ID was not found.", exception.getMessage());
+		Mockito.verify(util).getImplementers(className, interfaces);
+	}
+	
+	@Test
+	public void testGetImplementersWithComplexCase() {
+		// in the complex case, an interface is implemented by both concrete classes and other interfaces
+		Map<String, List<TypeReference>> interfaces = new HashMap<>();
+		
+		List<TypeReference> references1 = new ArrayList<>();
+		String interfaceId1 = "INTERFACE_ID_1";
+		TypeReference reference1 = new TypeReference("CONCRETE_ID_1", false, false, false, new String[0], new String[0]);
+		TypeReference reference2 = new TypeReference("INTERFACE_ID_2", false, false, false, new String[0], new String[0]);
+		references1.add(reference1);
+		references1.add(reference2);
+		interfaces.put(interfaceId1, references1);
+		
+		String interfaceId2 = "INTERFACE_ID_2";
+		List<TypeReference> references2 = new ArrayList<>();
+		TypeReference reference3 = new TypeReference("CONCRETE_ID_2", false, false, false, new String[0], new String[0]);
+		TypeReference reference4 = new TypeReference("CONCRETE_ID_3", false, false, false, new String[0], new String[0]);
+		references2.add(reference3);
+		references2.add(reference4);
+		interfaces.put(interfaceId2, references2);
+		
+		
+		assertEquals(new HashSet<>(Arrays.asList(reference1, reference3, reference4)), util.getImplementers(interfaceId1, interfaces));
+	}
+	
+	@Test
+	public void testGetImplementersWithBasicCase() {
+		// in the basic case, an interface is only implemented by concrete classes
+		String interfaceId = "INTERFACE_ID"; 
+		Map<String, List<TypeReference>> interfaces = new HashMap<>();
+		List<TypeReference> references = new ArrayList<>();
+		TypeReference reference = new TypeReference("ID", false, false, false, new String[0], new String[0]);
+		references.add(reference);
+		interfaces.put(interfaceId, references);
+		
+		assertEquals(new HashSet<>(Arrays.asList(reference)), util.getImplementers(interfaceId, interfaces));
+	}
+	
+	@Test
+	public void testTranslateObjectSchemaTypeToJsonSchemaTypeWithUnhandledType() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test
+			util.translateObjectSchemaTypeToJsonSchemaType(TYPE.TUPLE_ARRAY_MAP);
+		});
+		assertEquals("Unable to convert non-primitive type TUPLE_ARRAY_MAP", exception.getMessage());
+	}
+	
+	@Test
+	public void testTranslateObjectSchemaTypeToJsonSchemaTypeWithInterface() {
+		assertEquals(Type.object, util.translateObjectSchemaTypeToJsonSchemaType(TYPE.INTERFACE));
+	}
+	
+	@Test
+	public void testTranslateObjectSchemaTypeToJsonSchemaTypeWithObject() {
+		assertEquals(Type.object, util.translateObjectSchemaTypeToJsonSchemaType(TYPE.OBJECT));
+	}
+	
+	@Test
+	public void testTranslateObjectSchemaTypeToJsonSchemaTypeWithArray() {
+		assertEquals(Type.array, util.translateObjectSchemaTypeToJsonSchemaType(TYPE.ARRAY));
+	}
+	
+	@Test
+	public void testTranslateObjectSchemaTypeToJsonSchemaTypeWithNullType() {
+		assertEquals(Type._null, util.translateObjectSchemaTypeToJsonSchemaType(TYPE.NULL));
+	}
+	
+	@Test
+	public void testTranslateObjectSchemaTypeToJsonSchemaTypeWithNull() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test
+			util.translateObjectSchemaTypeToJsonSchemaType(null);
+		});
+		assertEquals("type is required.", exception.getMessage());
+	}
+	
+	@Test
+	public void testGetSchemaForPrimitiveTypeWithUnhandledType() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test
+			util.getSchemaForPrimitiveType(TYPE.MAP);
+		});
+		assertEquals("Unable to translate primitive type MAP", exception.getMessage());
+	}
+	
+	@Test
+	public void testGetSchemaForPrimitiveTypeWithBoolean() {
+		JsonSchema expected = new JsonSchema();
+		expected.setType(Type._boolean);
+		// call under test
+		assertEquals(expected, util.getSchemaForPrimitiveType(TYPE.BOOLEAN));
+	}
+	
+	@Test
+	public void testGetSchemaForPrimitiveTypeWithNumber() {
+		JsonSchema expected = new JsonSchema();
+		expected.setType(Type.number);
+		// call under test
+		assertEquals(expected, util.getSchemaForPrimitiveType(TYPE.NUMBER));
+	}
+	
+	@Test
+	public void testGetSchemaForPrimitiveTypeWithInteger() {
+		JsonSchema expected = new JsonSchema();
+		expected.setType(Type.integer);
+		expected.setFormat("int32");
+		// call under test
+		assertEquals(expected, util.getSchemaForPrimitiveType(TYPE.INTEGER));
+	}
+	
+	@Test
+	public void testGetSchemaForPrimitiveTypeWithString() {
+		JsonSchema expected = new JsonSchema();
+		expected.setType(Type.string);
+		// call under test
+		assertEquals(expected, util.getSchemaForPrimitiveType(TYPE.STRING));
+	}
+	
+	@Test
+	public void testGetSchemaForPrimitiveTypeWithNull() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test
+			util.getSchemaForPrimitiveType(null);
+		});
+		assertEquals("type is required.", exception.getMessage());
+	}
+}

--- a/lib/lib-openapi/src/test/resources/controller/ComplexExampleController.java
+++ b/lib/lib-openapi/src/test/resources/controller/ComplexExampleController.java
@@ -1,0 +1,64 @@
+package controller;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.sagebionetworks.repo.web.rest.doc.ControllerInfo;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.sagebionetworks.openapi.pet.*;
+
+/**
+ *  This exists to test translating for complex types.
+ * @author lli
+ *
+ */
+@ControllerInfo(displayName = "ComplexPets", path = "repo/v1")
+public class ComplexExampleController {
+	ConcurrentMap<String, Pet> petNameToPet = new ConcurrentHashMap<>();
+	
+	/**
+	 * This method returns the Pet with 'name'.
+	 * 
+	 * @param name - the name of the pet
+	 * @return the Pet associated with 'name'.
+	 */
+	@ResponseStatus(HttpStatus.OK)
+	@RequestMapping(value = "/pet/{petName}", method = RequestMethod.GET)
+	public @ResponseBody Pet getPet(@PathVariable String petName) {
+		return petNameToPet.get(petName);
+	}
+	
+	/**
+	 * Adds a dog with name 'name'.
+	 * 
+	 * @param name - the name of the dog
+	 * @param dog - the dog object to add
+	 * @return the name of the Dog that was added
+	 */
+	@ResponseStatus(HttpStatus.OK)
+	@RequestMapping(value = "/pet/dog/{name}", method = RequestMethod.POST)
+	public @ResponseBody String addDog(@PathVariable String name, @RequestBody Dog dog) {
+		petNameToPet.put(name, dog);
+		return name;
+	}
+	
+	/**
+	 * Adds a cat with name 'name'.
+	 * 
+	 * @param name - the name of the cat
+	 * @param cat - the cat to be added
+	 * @return the name of the cat that was added
+	 */
+	@ResponseStatus(HttpStatus.OK)
+	@RequestMapping(value = "/pet/cat/{name}", method = RequestMethod.POST)
+	public @ResponseBody String addCat(@PathVariable String name, @RequestBody Cat cat) {
+		petNameToPet.put(name, cat);
+		return name;
+	}
+}


### PR DESCRIPTION
As a full step to fully supporting complex types (still need to fill in the `components` section of the OpenAPI spec), complex types are now able to be translated and also contain the `oneOf` property if it is an interface.

This resolves: https://sagebionetworks.jira.com/jira/software/c/projects/PLFM/boards/1?selectedIssue=PLFM-7771