### PR TITLE
PLFM-7864 - Generated "Components" section of OpenAPI Specification

### DIFF
--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/ApiInfo.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/ApiInfo.java
@@ -2,13 +2,17 @@ package org.sagebionetworks.openapi.datamodel;
 
 import java.util.Objects;
 
+import org.sagebionetworks.schema.adapter.JSONEntity;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+
 /**
  * Provides metadata about the API being described by the OpenAPI specification.
  * 
  * @author lli
  *
  */
-public class ApiInfo {
+public class ApiInfo implements JSONEntity {
 	private String title;
 	private String summary;
 	private String version;
@@ -61,5 +65,25 @@ public class ApiInfo {
 	@Override
 	public String toString() {
 		return "ApiInfo [title=" + title + ", summary=" + summary + ", version=" + version + "]";
+	}
+
+	@Override
+	public JSONObjectAdapter initializeFromJSONObject(JSONObjectAdapter toInitFrom) throws JSONObjectAdapterException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public JSONObjectAdapter writeToJSONObject(JSONObjectAdapter writeTo) throws JSONObjectAdapterException {
+		if (title == null) {
+			throw new IllegalArgumentException("The 'title' is a required attribute of ApiInfo.");
+		}
+		writeTo.put("title", title);
+		if (version != null) {
+			writeTo.put("version", version);
+		}
+		if (summary != null) {
+			writeTo.put("summary", summary);
+		}
+		return writeTo;
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/ComponentInfo.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/ComponentInfo.java
@@ -1,5 +1,0 @@
-package org.sagebionetworks.openapi.datamodel;
-
-public class ComponentInfo {
-	// Empty object for now
-}

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/ServerInfo.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/ServerInfo.java
@@ -2,12 +2,16 @@ package org.sagebionetworks.openapi.datamodel;
 
 import java.util.Objects;
 
+import org.sagebionetworks.schema.adapter.JSONEntity;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+
 /**
  * Provides connectivity information to a target server 
  * @author lli
  *
  */
-public class ServerInfo {
+public class ServerInfo implements JSONEntity {
 	private String url;
 	private String description;
 	
@@ -50,6 +54,21 @@ public class ServerInfo {
 	public String toString() {
 		return "ServerInfo [url=" + url + ", description=" + description + "]";
 	}
-	
-	
+
+	@Override
+	public JSONObjectAdapter initializeFromJSONObject(JSONObjectAdapter toInitFrom) throws JSONObjectAdapterException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public JSONObjectAdapter writeToJSONObject(JSONObjectAdapter writeTo) throws JSONObjectAdapterException {
+		if (url == null) {
+			throw new IllegalArgumentException("The 'url' field is required.");
+		}
+		writeTo.put("url", url);
+		if (description != null) {
+			writeTo.put("description", description);
+		}
+		return writeTo;
+	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/TagInfo.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/TagInfo.java
@@ -2,12 +2,16 @@ package org.sagebionetworks.openapi.datamodel;
 
 import java.util.Objects;
 
+import org.sagebionetworks.schema.adapter.JSONEntity;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+
 /**
  * Provides information regarding the Controllers in the API.
  * @author lli
  *
  */
-public class TagInfo {
+public class TagInfo implements JSONEntity {
 	private String name;
 	private String description;
 	
@@ -49,5 +53,22 @@ public class TagInfo {
 	@Override
 	public String toString() {
 		return "TagInfo [name=" + name + ", description=" + description + "]";
+	}
+
+	@Override
+	public JSONObjectAdapter initializeFromJSONObject(JSONObjectAdapter toInitFrom) throws JSONObjectAdapterException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public JSONObjectAdapter writeToJSONObject(JSONObjectAdapter writeTo) throws JSONObjectAdapterException {
+		if (name == null) {
+			throw new IllegalArgumentException("The 'name' field is required.");
+		}
+		writeTo.put("name", name);
+		if (description != null) {
+			writeTo.put("description", description);
+		}
+		return writeTo;
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/pathinfo/EndpointInfo.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/pathinfo/EndpointInfo.java
@@ -4,12 +4,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.sagebionetworks.schema.adapter.JSONArrayAdapter;
+import org.sagebionetworks.schema.adapter.JSONEntity;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+
 /**
  * Metadata about a specific endpoint.
  * @author lli
  *
  */
-public class EndpointInfo {
+public class EndpointInfo implements JSONEntity {
 	private List<String> tags;
 	private String operationId;
 	private List<ParameterInfo> parameters;
@@ -83,5 +88,65 @@ public class EndpointInfo {
 	public String toString() {
 		return "EndpointInfo [tags=" + tags + ", operationId=" + operationId + ", parameters=" + parameters
 				+ ", requestBody=" + requestBody + ", responses=" + responses + "]";
+	}
+	
+	@Override
+	public JSONObjectAdapter initializeFromJSONObject(JSONObjectAdapter toInitFrom) throws JSONObjectAdapterException {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public JSONObjectAdapter writeToJSONObject(JSONObjectAdapter writeTo) throws JSONObjectAdapterException {
+		if (this.responses == null) {
+			throw new IllegalArgumentException("Responses must not be null.");
+		}
+		if (this.responses.isEmpty()) {
+			throw new IllegalArgumentException("Responses must not be empty.");
+		}
+		
+		if (this.tags != null) {
+			JSONArrayAdapter tags = writeTo.createNewArray();
+			populateTags(tags);
+			writeTo.put("tags", tags);
+		}
+		
+		if (this.operationId != null) {
+			writeTo.put("operationId", operationId);
+		}
+		
+		if (this.parameters != null) {
+			JSONArrayAdapter parameters = writeTo.createNewArray();
+			populateParameters(parameters);
+			writeTo.put("parameters", parameters);
+		}
+		
+		if (this.requestBody != null) {
+			writeTo.put("requestBody", requestBody.writeToJSONObject(writeTo.createNew()));
+		}
+		
+		JSONObjectAdapter responses = writeTo.createNew();
+		populateResponses(responses);
+		writeTo.put("responses", responses);
+
+		return writeTo;
+	}
+	
+	void populateResponses(JSONObjectAdapter responses) throws JSONObjectAdapterException {
+		for (String responseCode : this.responses.keySet()) {
+			ResponseInfo respose = this.responses.get(responseCode);
+			responses.put(responseCode, respose.writeToJSONObject(responses.createNew()));
+		}
+	}
+	
+	void populateParameters(JSONArrayAdapter parameters) throws JSONObjectAdapterException {
+		for (int i = 0; i < this.parameters.size(); i++) {
+			parameters.put(i, this.parameters.get(i).writeToJSONObject(parameters.createNew()));
+		}
+	}
+	
+	void populateTags(JSONArrayAdapter tags) throws JSONObjectAdapterException {
+		for (int i = 0; i < this.tags.size(); i++) {
+			tags.put(i, this.tags.get(i));
+		}
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/pathinfo/ParameterInfo.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/pathinfo/ParameterInfo.java
@@ -3,13 +3,16 @@ package org.sagebionetworks.openapi.datamodel.pathinfo;
 import java.util.Objects;
 
 import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.schema.adapter.JSONEntity;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 
 /**
  * Describes a single operation parameter.
  * @author lli
  *
  */
-public class ParameterInfo {
+public class ParameterInfo implements JSONEntity {
 	private String name;
 	private String in;
 	private boolean required;
@@ -84,5 +87,32 @@ public class ParameterInfo {
 	public String toString() {
 		return "ParameterInfo [name=" + name + ", in=" + in + ", required=" + required + ", description=" + description
 				+ ", schema=" + schema + "]";
+	}
+
+	@Override
+	public JSONObjectAdapter initializeFromJSONObject(JSONObjectAdapter toInitFrom) throws JSONObjectAdapterException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public JSONObjectAdapter writeToJSONObject(JSONObjectAdapter writeTo) throws JSONObjectAdapterException {
+		if (name == null) {
+			throw new IllegalArgumentException("The 'name' field must not be null.");
+		}
+		if (in == null) {
+			throw new IllegalArgumentException("The 'in' field must not be null.");
+		}
+		writeTo.put("name", name);
+		writeTo.put("in", in);
+		if (required) {
+			writeTo.put("required", required);
+		}
+		if (description != null) {
+			writeTo.put("description", description);
+		}
+		if (schema != null) {
+			writeTo.put("schema", schema.writeToJSONObject(writeTo.createNew()));
+		}
+		return writeTo;
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/pathinfo/RequestBodyInfo.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/pathinfo/RequestBodyInfo.java
@@ -3,12 +3,16 @@ package org.sagebionetworks.openapi.datamodel.pathinfo;
 import java.util.Map;
 import java.util.Objects;
 
+import org.sagebionetworks.schema.adapter.JSONEntity;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+
 /**
  * The request body applicable to an operation.
  * @author lli
  *
  */
-public class RequestBodyInfo {
+public class RequestBodyInfo implements JSONEntity {
 	// This maps content-type -> the appropriate schema
 	private Map<String, Schema> content;
 	private boolean required;
@@ -51,5 +55,32 @@ public class RequestBodyInfo {
 	@Override
 	public String toString() {
 		return "RequestBodyInfo [content=" + content + ", required=" + required + "]";
+	}
+
+	@Override
+	public JSONObjectAdapter initializeFromJSONObject(JSONObjectAdapter toInitFrom) throws JSONObjectAdapterException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public JSONObjectAdapter writeToJSONObject(JSONObjectAdapter writeTo) throws JSONObjectAdapterException {
+		if (content == null) {
+			throw new IllegalArgumentException("The 'content' field must not be null.");
+		}
+		if (content.isEmpty()) {
+			throw new IllegalArgumentException("The 'content' field must not be empty.");
+		}
+		
+		JSONObjectAdapter content = writeTo.createNew();
+		for (String contentType : this.content.keySet()) {
+			Schema schema = this.content.get(contentType);
+			content.put(contentType, schema.writeToJSONObject(writeTo.createNew()));
+		}
+		writeTo.put("content", content);
+		
+		if (required) {
+			writeTo.put("required", required);
+		}
+		return writeTo;
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/pathinfo/ResponseInfo.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/pathinfo/ResponseInfo.java
@@ -3,12 +3,16 @@ package org.sagebionetworks.openapi.datamodel.pathinfo;
 import java.util.Map;
 import java.util.Objects;
 
+import org.sagebionetworks.schema.adapter.JSONEntity;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+
 /**
  * Describes the response information for a particular status code.
  * @author lli
  *
  */
-public class ResponseInfo {
+public class ResponseInfo implements JSONEntity {
 	private String description;
 	// maps contentType -> Schema
 	private Map<String, Schema> content;
@@ -51,5 +55,32 @@ public class ResponseInfo {
 	@Override
 	public String toString() {
 		return "ResponseInfo [description=" + description + ", content=" + content + "]";
+	}
+
+	@Override
+	public JSONObjectAdapter initializeFromJSONObject(JSONObjectAdapter toInitFrom) throws JSONObjectAdapterException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public JSONObjectAdapter writeToJSONObject(JSONObjectAdapter writeTo) throws JSONObjectAdapterException {
+		if (description == null) {
+			throw new IllegalArgumentException("The 'description' field is required.");
+		}
+		writeTo.put("description", description);
+		
+		if (this.content != null && !this.content.isEmpty()) {
+			JSONObjectAdapter content = writeTo.createNew();
+			populateContent(content);
+			writeTo.put("content", content);
+		}
+		return writeTo;
+	}
+	
+	void populateContent(JSONObjectAdapter content) throws JSONObjectAdapterException {
+		for (String contentType : this.content.keySet()) {
+			Schema schema = this.content.get(contentType);
+			content.put(contentType, schema.writeToJSONObject(content.createNew()));
+		}
 	}
 }

--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/pathinfo/Schema.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/openapi/datamodel/pathinfo/Schema.java
@@ -3,13 +3,16 @@ package org.sagebionetworks.openapi.datamodel.pathinfo;
 import java.util.Objects;
 
 import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.schema.adapter.JSONEntity;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
 
 /**
  * Represents the schema of a content type.
  * @author lli
  *
  */
-public class Schema {
+public class Schema implements JSONEntity {
 	private JsonSchema schema;
 
 	public JsonSchema getSchema() {
@@ -41,5 +44,19 @@ public class Schema {
 	@Override
 	public String toString() {
 		return "Schema [schema=" + schema + "]";
+	}
+
+	@Override
+	public JSONObjectAdapter initializeFromJSONObject(JSONObjectAdapter toInitFrom) throws JSONObjectAdapterException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public JSONObjectAdapter writeToJSONObject(JSONObjectAdapter writeTo) throws JSONObjectAdapterException {
+		if (schema == null) {
+			throw new IllegalArgumentException("The 'schema' field must not be null.");
+		}
+		writeTo.put("schema", this.schema.writeToJSONObject(writeTo.createNew()));
+		return writeTo;
 	}
 }

--- a/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Poodle.json
+++ b/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Poodle.json
@@ -10,6 +10,10 @@
 		"isFluffy": {
 			"type": "boolean",
 			"description": "Describes if the poodle if fluffy."
+		},
+		"huskyType": {
+			"type": "object",
+			"$ref": "org.sagebionetworks.openapi.pet.Husky"
 		}
 	}
 }

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/ApiInfoTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/ApiInfoTest.java
@@ -1,0 +1,65 @@
+package org.sagebionetworks.openapi.datamodel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+
+public class ApiInfoTest {
+	@Test
+	public void testInitializeFromJSONObject() {
+		assertThrows(UnsupportedOperationException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new ApiInfo().initializeFromJSONObject(adapter);
+		});
+	}
+	
+	@Test
+	public void testWriteToJSONObject() throws JSONObjectAdapterException {
+		ApiInfo info = new ApiInfo().withTitle("TITLE").withVersion("V0").withSummary("SUMMARY");
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		info.writeToJSONObject(adapter);
+		
+		Mockito.verify(adapter).put("title", "TITLE");
+		Mockito.verify(adapter).put("version", "V0");
+		Mockito.verify(adapter).put("summary", "SUMMARY");
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithMissingTitle() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new ApiInfo().withSummary("SUMMARY").withVersion("V0").writeToJSONObject(adapter);
+		});
+		assertEquals("The 'title' is a required attribute of ApiInfo.", exception.getMessage());
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithMissingVersion() throws JSONObjectAdapterException {
+		ApiInfo info = new ApiInfo().withTitle("TITLE").withSummary("SUMMARY");
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		info.writeToJSONObject(adapter);
+		
+		Mockito.verify(adapter).put("title", "TITLE");
+		Mockito.verify(adapter).put("summary", "SUMMARY");
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("version"), any(String.class));
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithMissingSummary() throws JSONObjectAdapterException {
+		ApiInfo info = new ApiInfo().withTitle("TITLE").withVersion("V0");
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		info.writeToJSONObject(adapter);
+		
+		Mockito.verify(adapter).put("title", "TITLE");
+		Mockito.verify(adapter).put("version", "V0");
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("summary"), any(String.class));
+	}
+}

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/OpenAPISpecModelTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/OpenAPISpecModelTest.java
@@ -2,34 +2,298 @@ package org.sagebionetworks.openapi.datamodel;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sagebionetworks.openapi.datamodel.pathinfo.EndpointInfo;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.schema.adapter.JSONArrayAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.sagebionetworks.schema.adapter.org.json.JSONArrayAdapterImpl;
+import org.sagebionetworks.schema.adapter.org.json.JSONObjectAdapterImpl;
 import org.sagebionetworks.translator.ControllerModelDoclet;
 
 import com.google.gson.Gson;
 
 public class OpenAPISpecModelTest {
-	
+//	@Test
+//	public void testGeneratesCorrectJsonBasicController() throws Exception {
+//		try (InputStream is = OpenAPISpecModel.class.getClassLoader()
+//				.getResourceAsStream("ComplexExampleControllerOpenAPISpec.json")) {
+//			assertNotNull(is);
+//			String jsonTxt = IOUtils.toString(is, StandardCharsets.UTF_8);
+//			JSONObject expectedJson = new JSONObject(jsonTxt);
+//
+//			Gson gson = new Gson();
+//			OpenAPISpecModel openAPISpecModel = gson.fromJson(expectedJson.toString(), OpenAPISpecModel.class);
+//			assertNotNull(openAPISpecModel);
+//
+//			JSONObject generatedJson = openAPISpecModel.generateJSON();
+//			assertEquals(expectedJson.toString(), generatedJson.toString());
+//		} catch (Exception e) {
+//			throw new RuntimeException(e);
+//		}
+//	}
+
 	@Test
-	public void testGeneratesCorrectJsonBasicController() throws Exception {
-		try (InputStream is = OpenAPISpecModel.class.getClassLoader().getResourceAsStream("BasicExampleControllerOpenAPISpec.json")) {
-			assertNotNull(is);
-			String jsonTxt = IOUtils.toString(is, StandardCharsets.UTF_8);
-			JSONObject expectedJson = new JSONObject(jsonTxt);
-			
-			Gson gson = new Gson();
-			OpenAPISpecModel swaggerSpecModel = gson.fromJson(expectedJson.toString(), OpenAPISpecModel.class);
-			assertNotNull(swaggerSpecModel);
-			
-			JSONObject generatedJson = swaggerSpecModel.generateJSON();
-			assertEquals(expectedJson.toString(), generatedJson.toString());
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-    }
+	public void testInitializeFromJSONObject() {
+		assertThrows(UnsupportedOperationException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new OpenAPISpecModel().initializeFromJSONObject(adapter);
+		});
+	}
+
+	@Test
+	public void testWriteToJSONObject() throws JSONObjectAdapterException {
+		JSONObjectAdapter writeTo = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl apiInfoImpl = new JSONObjectAdapterImpl();
+		JSONObjectAdapterImpl pathsImpl = new JSONObjectAdapterImpl();
+		JSONObjectAdapterImpl componentsImpl = new JSONObjectAdapterImpl();
+		JSONArrayAdapterImpl serversImpl = new JSONArrayAdapterImpl();
+		JSONArrayAdapterImpl tagsImpl = new JSONArrayAdapterImpl();
+		Mockito.doReturn(apiInfoImpl, pathsImpl, componentsImpl).when(writeTo).createNew();
+		Mockito.doReturn(serversImpl, tagsImpl).when(writeTo).createNewArray();
+
+		Map<String, Map<String, EndpointInfo>> paths = new LinkedHashMap<>();
+		paths.put("PATH", new LinkedHashMap<>());
+
+		ApiInfo apiInfo = Mockito.mock(ApiInfo.class);
+		JSONObjectAdapterImpl apiInfoResult = new JSONObjectAdapterImpl();
+		Mockito.doReturn(apiInfoResult).when(apiInfo).writeToJSONObject(any());
+		
+		Map<String, Map<String, JsonSchema>> components = new LinkedHashMap<>();
+		components.put("COMPONENT_TYPE_1", new LinkedHashMap<>());
+
+		OpenAPISpecModel model = Mockito.spy(new OpenAPISpecModel().withOpenapi("V3").withInfo(apiInfo).withPaths(paths)
+				.withServers(new ArrayList<>()).withTags(new ArrayList<>()).withComponents(components));
+		Mockito.doNothing().when(model).populateServers(any());
+		Mockito.doNothing().when(model).populateTags(any());
+		Mockito.doNothing().when(model).populatePaths(any());
+		Mockito.doNothing().when(model).populateComponents(any());
+		
+		// call under test
+		model.writeToJSONObject(writeTo);
+		Mockito.verify(writeTo).put("openapi", "V3");
+		Mockito.verify(writeTo).put("info", apiInfoResult);
+		Mockito.verify(apiInfo).writeToJSONObject(apiInfoImpl);
+		Mockito.verify(model).populateServers(serversImpl);
+		Mockito.verify(writeTo).put("servers", serversImpl);
+		Mockito.verify(model).populateTags(tagsImpl);
+		Mockito.verify(writeTo).put("tags", tagsImpl);
+		Mockito.verify(model).populatePaths(pathsImpl);
+		Mockito.verify(writeTo).put("paths", pathsImpl);
+		Mockito.verify(model).populateComponents(componentsImpl);
+		Mockito.verify(writeTo).put("components", componentsImpl);
+	}
+
+	@Test
+	public void testPopulateComponents() throws JSONObjectAdapterException {
+		JSONObjectAdapter componentsAdapter = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl componentsImpl1 = new JSONObjectAdapterImpl();
+		JSONObjectAdapterImpl componentsImpl2 = new JSONObjectAdapterImpl();
+		Mockito.doReturn(componentsImpl1, componentsImpl2).when(componentsAdapter).createNew();
+		Map<String, Map<String, JsonSchema>> components = new LinkedHashMap<>();
+		Map<String, JsonSchema> component1 = new LinkedHashMap<>();
+		Map<String, JsonSchema> component2 = new LinkedHashMap<>();
+		components.put("COMPONENT_TYPE_1", component1);
+		components.put("COMPONENT_TYPE_2", component2);
+
+		OpenAPISpecModel model = Mockito.spy(new OpenAPISpecModel().withComponents(components));
+		// call under test
+		model.populateComponents(componentsAdapter);
+		Mockito.verify(componentsAdapter).put("COMPONENT_TYPE_1", componentsImpl1);
+		Mockito.verify(componentsAdapter).put("COMPONENT_TYPE_2", componentsImpl2);
+		Mockito.verify(model).populateCurrentComponent(componentsImpl1, "COMPONENT_TYPE_1");
+		Mockito.verify(model).populateCurrentComponent(componentsImpl2, "COMPONENT_TYPE_2");
+	}
+
+	@Test
+	public void testPopulateCurrentComponent() throws JSONObjectAdapterException {
+		JSONObjectAdapter currentComponentAdapter = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl currentComponentAdapterImpl = new JSONObjectAdapterImpl();
+		Mockito.doReturn(currentComponentAdapterImpl).when(currentComponentAdapter).createNew();
+
+		Map<String, Map<String, JsonSchema>> components = new LinkedHashMap<>();
+		components.put("SCHEMA", new LinkedHashMap<>());
+		JsonSchema schema1 = Mockito.mock(JsonSchema.class);
+		JsonSchema schema2 = Mockito.mock(JsonSchema.class);
+		JSONObjectAdapterImpl schema1Impl = new JSONObjectAdapterImpl();
+		JSONObjectAdapterImpl schema2Impl = new JSONObjectAdapterImpl();
+		Mockito.doReturn(schema1Impl).when(schema1).writeToJSONObject(any());
+		Mockito.doReturn(schema2Impl).when(schema2).writeToJSONObject(any());
+		components.get("SCHEMA").put("COMPONENT_1", schema1);
+		components.get("SCHEMA").put("COMPONENT_2", schema2);
+
+		// call under test
+		new OpenAPISpecModel().withComponents(components).populateCurrentComponent(currentComponentAdapter, "SCHEMA");
+		Mockito.verify(currentComponentAdapter).put("COMPONENT_1", schema1Impl);
+		Mockito.verify(currentComponentAdapter).put("COMPONENT_2", schema2Impl);
+		Mockito.verify(schema1).writeToJSONObject(currentComponentAdapterImpl);
+		Mockito.verify(schema2).writeToJSONObject(currentComponentAdapterImpl);
+	}
+
+	@Test
+	public void testPopulatePaths() throws JSONObjectAdapterException {
+		JSONObjectAdapter pathsAdapter = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl pathAdapterImpl1 = new JSONObjectAdapterImpl();
+		JSONObjectAdapterImpl pathAdapterImpl2 = new JSONObjectAdapterImpl();
+		Mockito.doReturn(pathAdapterImpl1, pathAdapterImpl2).when(pathsAdapter).createNew();
+		Map<String, Map<String, EndpointInfo>> paths = new LinkedHashMap<>();
+		Map<String, EndpointInfo> path1 = new LinkedHashMap<>();
+		Map<String, EndpointInfo> path2 = new LinkedHashMap<>();
+		paths.put("PATH_1", path1);
+		paths.put("PATH_2", path2);
+
+		OpenAPISpecModel model = Mockito.spy(new OpenAPISpecModel().withPaths(paths));
+		// call under test
+		model.populatePaths(pathsAdapter);
+		Mockito.verify(pathsAdapter).put("PATH_1", pathAdapterImpl1);
+		Mockito.verify(pathsAdapter).put("PATH_2", pathAdapterImpl2);
+		Mockito.verify(model).populateCurrentPath(pathAdapterImpl1, "PATH_1");
+		Mockito.verify(model).populateCurrentPath(pathAdapterImpl2, "PATH_2");
+	}
+
+	@Test
+	public void testPopulateCurrentPath() throws JSONObjectAdapterException {
+		JSONObjectAdapter currentPathAdapter = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl currentPathAdapterImpl = new JSONObjectAdapterImpl();
+		Mockito.doReturn(currentPathAdapterImpl).when(currentPathAdapter).createNew();
+
+		Map<String, Map<String, EndpointInfo>> paths = new LinkedHashMap<>();
+		paths.put("PATH_1", new LinkedHashMap<>());
+		EndpointInfo endpoint1 = Mockito.mock(EndpointInfo.class);
+		EndpointInfo endpoint2 = Mockito.mock(EndpointInfo.class);
+		JSONObjectAdapterImpl endpoint1Impl = new JSONObjectAdapterImpl();
+		JSONObjectAdapterImpl endpoint2Impl = new JSONObjectAdapterImpl();
+		Mockito.doReturn(endpoint1Impl).when(endpoint1).writeToJSONObject(any());
+		Mockito.doReturn(endpoint2Impl).when(endpoint2).writeToJSONObject(any());
+		paths.get("PATH_1").put("OPERATION_1", endpoint1);
+		paths.get("PATH_1").put("OPERATION_2", endpoint2);
+
+		// call under test
+		new OpenAPISpecModel().withPaths(paths).populateCurrentPath(currentPathAdapter, "PATH_1");
+		Mockito.verify(currentPathAdapter).put("OPERATION_1", endpoint1Impl);
+		Mockito.verify(currentPathAdapter).put("OPERATION_2", endpoint2Impl);
+		Mockito.verify(endpoint1).writeToJSONObject(currentPathAdapterImpl);
+		Mockito.verify(endpoint2).writeToJSONObject(currentPathAdapterImpl);
+	}
+
+	@Test
+	public void testPopulateTags() throws JSONObjectAdapterException {
+		JSONArrayAdapter tags = Mockito.mock(JSONArrayAdapter.class);
+		JSONObjectAdapterImpl tagsImpl = new JSONObjectAdapterImpl();
+		Mockito.doReturn(tagsImpl).when(tags).createNew();
+		TagInfo tag1 = Mockito.mock(TagInfo.class);
+		TagInfo tag2 = Mockito.mock(TagInfo.class);
+		JSONObjectAdapterImpl tag1Impl = new JSONObjectAdapterImpl();
+		JSONObjectAdapterImpl tag2Impl = new JSONObjectAdapterImpl();
+		Mockito.doReturn(tag1Impl).when(tag1).writeToJSONObject(any());
+		Mockito.doReturn(tag2Impl).when(tag2).writeToJSONObject(any());
+		List<TagInfo> tagInfoList = new ArrayList<>(Arrays.asList(tag1, tag2));
+
+		// call under test
+		new OpenAPISpecModel().withTags(tagInfoList).populateTags(tags);
+		Mockito.verify(tags).put(0, tag1Impl);
+		Mockito.verify(tags).put(1, tag2Impl);
+		Mockito.verify(tag1).writeToJSONObject(tagsImpl);
+		Mockito.verify(tag2).writeToJSONObject(tagsImpl);
+	}
+
+	@Test
+	public void testPopulateServers() throws JSONObjectAdapterException {
+		JSONArrayAdapter servers = Mockito.mock(JSONArrayAdapter.class);
+		JSONObjectAdapterImpl serversImpl = new JSONObjectAdapterImpl();
+		Mockito.doReturn(serversImpl).when(servers).createNew();
+		ServerInfo server1 = Mockito.mock(ServerInfo.class);
+		ServerInfo server2 = Mockito.mock(ServerInfo.class);
+		JSONObjectAdapterImpl server1Impl = new JSONObjectAdapterImpl();
+		JSONObjectAdapterImpl server2Impl = new JSONObjectAdapterImpl();
+		Mockito.doReturn(server1Impl).when(server1).writeToJSONObject(any());
+		Mockito.doReturn(server2Impl).when(server2).writeToJSONObject(any());
+		List<ServerInfo> serverInfoList = new ArrayList<>(Arrays.asList(server1, server2));
+
+		// call under test
+		new OpenAPISpecModel().withServers(serverInfoList).populateServers(servers);
+		Mockito.verify(servers).put(0, server1Impl);
+		Mockito.verify(servers).put(1, server2Impl);
+		Mockito.verify(server1).writeToJSONObject(serversImpl);
+		Mockito.verify(server2).writeToJSONObject(serversImpl);
+	}
+
+	@Test
+	public void testWriteToJSONObjectWithOnlyRequiredProperties() throws JSONObjectAdapterException {
+		Map<String, Map<String, EndpointInfo>> paths = new LinkedHashMap<>();
+		paths.put("PATH", new LinkedHashMap<>());
+		ApiInfo apiInfo = Mockito.mock(ApiInfo.class);
+		Mockito.doReturn(new JSONObjectAdapterImpl()).when(apiInfo).writeToJSONObject(any());
+		OpenAPISpecModel model = Mockito
+				.spy(new OpenAPISpecModel().withOpenapi("V3").withInfo(apiInfo).withPaths(paths));
+		Mockito.doNothing().when(model).populatePaths(any());
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+
+		// call under test
+		model.writeToJSONObject(adapter);
+		Mockito.verify(model, Mockito.times(0)).populateServers(any());
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("servers"), any(JSONArrayAdapter.class));
+		Mockito.verify(model, Mockito.times(0)).populateTags(any());
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("tags"), any(JSONArrayAdapter.class));
+		Mockito.verify(model, Mockito.times(0)).populateComponents(any());
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("components"), any(JSONObjectAdapter.class));
+	}
+
+	@Test
+	public void testWriteToJSONObjectWithEmptyPaths() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new OpenAPISpecModel().withOpenapi("V3").withInfo(new ApiInfo()).withPaths(new LinkedHashMap<>())
+					.writeToJSONObject(adapter);
+		});
+		assertEquals("The 'paths' field should not be empty.", exception.getMessage());
+	}
+
+	@Test
+	public void testWriteToJSONObjectWithNullPaths() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new OpenAPISpecModel().withOpenapi("V3").withInfo(new ApiInfo()).withPaths(null).writeToJSONObject(adapter);
+		});
+		assertEquals("The 'paths' field should not be null.", exception.getMessage());
+	}
+
+	@Test
+	public void testWriteToJSONObjectWithNullInfo() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new OpenAPISpecModel().withOpenapi("V3").withInfo(null).writeToJSONObject(adapter);
+		});
+		assertEquals("The 'info' field should not be null.", exception.getMessage());
+	}
+
+	@Test
+	public void testWriteToJSONObjectWithNullOpenapi() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new OpenAPISpecModel().withOpenapi(null).writeToJSONObject(adapter);
+		});
+		assertEquals("The 'openapi' field should not be null.", exception.getMessage());
+	}
 }

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/ServerInfoTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/ServerInfoTest.java
@@ -1,0 +1,52 @@
+package org.sagebionetworks.openapi.datamodel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+
+public class ServerInfoTest {
+	@Test
+	public void testInitializeFromJSONObject() {
+		assertThrows(UnsupportedOperationException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new ServerInfo().initializeFromJSONObject(adapter);
+		});
+	}
+	
+	@Test
+	public void testWriteToJSONObject() throws JSONObjectAdapterException {
+		ServerInfo info = new ServerInfo().withDescription("DESCRIPTION").withUrl("URL");
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		info.writeToJSONObject(adapter);
+		
+		Mockito.verify(adapter).put("url", "URL");
+		Mockito.verify(adapter).put("description", "DESCRIPTION");
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithoutUrl() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			ServerInfo info = new ServerInfo().withDescription("DESCRIPTION");
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			info.writeToJSONObject(adapter);
+		});
+		assertEquals("The 'url' field is required.", exception.getMessage());
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithoutDescription() throws JSONObjectAdapterException {
+		ServerInfo info = new ServerInfo().withUrl("URL");
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		info.writeToJSONObject(adapter);
+		
+		Mockito.verify(adapter).put("url", "URL");
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("description"), any(String.class));
+	}
+}

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/TagInfoTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/TagInfoTest.java
@@ -1,0 +1,52 @@
+package org.sagebionetworks.openapi.datamodel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+
+public class TagInfoTest {
+	@Test
+	public void testInitializeFromJSONObject() {
+		assertThrows(UnsupportedOperationException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new TagInfo().initializeFromJSONObject(adapter);
+		});
+	}
+	
+	@Test
+	public void testWriteToJSONObject() throws JSONObjectAdapterException {
+		TagInfo info = new TagInfo().withName("NAME").withDescription("DESCRIPTION");
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		info.writeToJSONObject(adapter);
+		
+		Mockito.verify(adapter).put("name", "NAME");
+		Mockito.verify(adapter).put("description", "DESCRIPTION");
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithMissingName() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new TagInfo().withDescription("DESCRIPTION").writeToJSONObject(adapter);
+		});
+		assertEquals("The 'name' field is required.", exception.getMessage());
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithMissingDescription() throws JSONObjectAdapterException {
+		TagInfo info = new TagInfo().withName("NAME");
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		info.writeToJSONObject(adapter);
+		
+		Mockito.verify(adapter).put("name", "NAME");
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("description"), any(String.class));
+	}
+}

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/pathinfo/EndpointInfoTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/pathinfo/EndpointInfoTest.java
@@ -1,0 +1,167 @@
+package org.sagebionetworks.openapi.datamodel.pathinfo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.sagebionetworks.schema.adapter.JSONArrayAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.sagebionetworks.schema.adapter.org.json.JSONArrayAdapterImpl;
+import org.sagebionetworks.schema.adapter.org.json.JSONObjectAdapterImpl;
+
+public class EndpointInfoTest {
+	@Test
+	public void testInitializeFromJSONObject() {
+		assertThrows(UnsupportedOperationException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new EndpointInfo().initializeFromJSONObject(adapter);
+		});
+	}
+
+	@Test
+	public void testWriteToJSONObject() throws JSONObjectAdapterException {
+		Map<String, ResponseInfo> responses = new LinkedHashMap<>();
+		responses.put("RESPONSE", new ResponseInfo());
+		String operationId = "OPERATION_ID";
+		RequestBodyInfo requestBody = Mockito.mock(RequestBodyInfo.class);
+		JSONObjectAdapterImpl requestBodyObjectAdapter = new JSONObjectAdapterImpl();
+		Mockito.doReturn(requestBodyObjectAdapter).when(requestBody).writeToJSONObject(any());
+
+		EndpointInfo info = Mockito.spy(new EndpointInfo().withTags(new ArrayList<>()).withOperationId(operationId)
+				.withParameters(new ArrayList<>()).withRequestBody(requestBody).withResponses(responses));
+		Mockito.doReturn(responses).when(info).getResponses();
+		Mockito.doNothing().when(info).populateResponses(any());
+		Mockito.doNothing().when(info).populateTags(any());
+		Mockito.doNothing().when(info).populateParameters(any());
+
+		JSONObjectAdapter writeTo = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl writeToObjectAdapter = new JSONObjectAdapterImpl();
+		Mockito.doReturn(writeToObjectAdapter).when(writeTo).createNew();
+		JSONArrayAdapterImpl writeToArrayAdapter = new JSONArrayAdapterImpl();
+		Mockito.doReturn(writeToArrayAdapter).when(writeTo).createNewArray();
+		
+		// call under test
+		info.writeToJSONObject(writeTo);
+		Mockito.verify(info).populateTags(writeToArrayAdapter);
+		Mockito.verify(writeTo).put("tags", writeToArrayAdapter);
+		Mockito.verify(writeTo).put("operationId", operationId);
+		Mockito.verify(writeTo).put("parameters", writeToArrayAdapter);
+		Mockito.verify(info).populateParameters(writeToArrayAdapter);
+		Mockito.verify(writeTo).put("requestBody", requestBodyObjectAdapter);
+		Mockito.verify(requestBody).writeToJSONObject(writeToObjectAdapter);
+		Mockito.verify(info).populateResponses(writeToObjectAdapter);
+		Mockito.verify(writeTo).put("responses", writeToObjectAdapter);
+	}
+
+	@Test
+	public void testWriteToJSONObjectWithOnlyResponses() throws JSONObjectAdapterException {
+		Map<String, ResponseInfo> responses = new LinkedHashMap<>();
+		responses.put("RESPONSE", new ResponseInfo());
+		EndpointInfo info = Mockito.spy(new EndpointInfo().withResponses(responses));
+		Mockito.doReturn(responses).when(info).getResponses();
+		Mockito.doNothing().when(info).populateResponses(any());
+
+		JSONObjectAdapter writeTo = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl adapter = new JSONObjectAdapterImpl();
+		Mockito.doReturn(adapter).when(writeTo).createNew();
+		// call under test
+		info.writeToJSONObject(writeTo);
+		Mockito.verify(writeTo, Mockito.times(0)).put(eq("tags"), any(JSONArrayAdapter.class));
+		Mockito.verify(writeTo, Mockito.times(0)).put(eq("operationId"), any(String.class));
+		Mockito.verify(writeTo, Mockito.times(0)).put(eq("parameters"), any(JSONArrayAdapter.class));
+		Mockito.verify(writeTo, Mockito.times(0)).put(eq("requestBody"), any(JSONObjectAdapter.class));
+		Mockito.verify(info).populateResponses(any());
+		Mockito.verify(writeTo).put("responses", adapter);
+	}
+
+	@Test
+	public void testWriteToJSONObjectWithEmptyResponses() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new EndpointInfo().withResponses(new LinkedHashMap<>()).writeToJSONObject(adapter);
+		});
+		assertEquals("Responses must not be empty.", exception.getMessage());
+	}
+
+	@Test
+	public void testWriteToJSONObjectWithNullResponses() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new EndpointInfo().writeToJSONObject(adapter);
+		});
+		assertEquals("Responses must not be null.", exception.getMessage());
+	}
+
+	@Test
+	public void testPopulateResponses() throws JSONObjectAdapterException {
+		Map<String, ResponseInfo> responses = new LinkedHashMap<>();
+		ResponseInfo response1 = Mockito.mock(ResponseInfo.class);
+		ResponseInfo response2 = Mockito.mock(ResponseInfo.class);
+		JSONObjectAdapterImpl impl1 = new JSONObjectAdapterImpl();
+		JSONObjectAdapterImpl impl2 = new JSONObjectAdapterImpl();
+		Mockito.doReturn(impl1).when(response1).writeToJSONObject(any());
+		Mockito.doReturn(impl2).when(response2).writeToJSONObject(any());
+		responses.put("RESPONSE_1", response1);
+		responses.put("RESPONSE_2", response2);
+
+		EndpointInfo info = new EndpointInfo();
+		info.withResponses(responses);
+		JSONObjectAdapter responsesJson = Mockito.mock(JSONObjectAdapter.class);
+
+		// call under test
+		info.populateResponses(responsesJson);
+		Mockito.verify(responsesJson, Mockito.times(2)).put(anyString(), any(JSONObjectAdapter.class));
+		InOrder inOrder = Mockito.inOrder(responsesJson);
+		inOrder.verify(responsesJson).put("RESPONSE_1", impl1);
+		inOrder.verify(responsesJson).put("RESPONSE_2", impl2);
+	}
+
+	@Test
+	public void testPopulateParameters() throws JSONObjectAdapterException {
+		ParameterInfo param1 = Mockito.mock(ParameterInfo.class);
+		ParameterInfo param2 = Mockito.mock(ParameterInfo.class);
+		JSONObjectAdapterImpl impl1 = new JSONObjectAdapterImpl();
+		JSONObjectAdapterImpl impl2 = new JSONObjectAdapterImpl();
+		Mockito.doReturn(impl1).when(param1).writeToJSONObject(any());
+		Mockito.doReturn(impl2).when(param2).writeToJSONObject(any());
+		EndpointInfo info = new EndpointInfo();
+		info.withParameters(new ArrayList<>(Arrays.asList(param1, param2)));
+		JSONArrayAdapter parameters = Mockito.mock(JSONArrayAdapter.class);
+
+		// call under test
+		info.populateParameters(parameters);
+		Mockito.verify(parameters, Mockito.times(2)).put(anyInt(), any(JSONObjectAdapter.class));
+		InOrder inOrder = Mockito.inOrder(parameters);
+		inOrder.verify(parameters).put(0, impl1);
+		inOrder.verify(parameters).put(1, impl2);
+	}
+
+	@Test
+	public void testPopulateTags() throws JSONObjectAdapterException {
+		EndpointInfo info = new EndpointInfo();
+		info.withTags(new ArrayList<>(Arrays.asList("TAG_1", "TAG_2")));
+		JSONArrayAdapter tags = Mockito.mock(JSONArrayAdapter.class);
+
+		// call under test
+		info.populateTags(tags);
+		Mockito.verify(tags, Mockito.times(2)).put(anyInt(), anyString());
+		InOrder inOrder = Mockito.inOrder(tags);
+		inOrder.verify(tags).put(0, "TAG_1");
+		inOrder.verify(tags).put(1, "TAG_2");
+	}
+}

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/pathinfo/ParameterInfoTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/pathinfo/ParameterInfoTest.java
@@ -1,0 +1,79 @@
+package org.sagebionetworks.openapi.datamodel.pathinfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.sagebionetworks.schema.adapter.org.json.JSONObjectAdapterImpl;
+
+public class ParameterInfoTest {
+	@Test
+	public void testInitializeFromJSONObject() {
+		assertThrows(UnsupportedOperationException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new ParameterInfo().initializeFromJSONObject(adapter);
+		});
+	}
+	
+	@Test
+	public void testWriteToJSONObject() throws JSONObjectAdapterException {
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		JsonSchema schema = Mockito.mock(JsonSchema.class);
+		JSONObjectAdapterImpl impl = new JSONObjectAdapterImpl();
+		Mockito.doReturn(impl).when(schema).writeToJSONObject(any());
+		Mockito.doReturn(impl).when(adapter).createNew();
+		ParameterInfo info = new ParameterInfo().withName("NAME").withIn("IN").withDescription("DESCRIPTION").withRequired(true)
+				.withSchema(schema);
+		// call under test.
+		info.writeToJSONObject(adapter);
+		Mockito.verify(adapter).put("name", "NAME");
+		Mockito.verify(adapter).put("in", "IN");
+		Mockito.verify(adapter).put("description", "DESCRIPTION");
+		Mockito.verify(adapter).put("required", true);
+		Mockito.verify(adapter).put("schema", impl);
+		Mockito.verify(schema).writeToJSONObject(impl);
+	}
+
+	@Test
+	public void testWriteToJSONObjectWithOnlyNameAndInFields() throws JSONObjectAdapterException {
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		ParameterInfo info = new ParameterInfo().withName("NAME").withIn("IN").withDescription(null).withRequired(false)
+				.withSchema(null);
+		// call under test.
+		info.writeToJSONObject(adapter);
+		Mockito.verify(adapter).put("name", "NAME");
+		Mockito.verify(adapter).put("in", "IN");
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("description"), anyString());
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("required"), anyBoolean());
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("schema"), any(JSONObjectAdapter.class));
+	}
+
+	@Test
+	public void testWriteToJSONObjectWithoutIn() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new ParameterInfo().withName("Name").withIn(null).writeToJSONObject(adapter);
+		});
+		assertEquals("The 'in' field must not be null.", exception.getMessage());
+	}
+
+	@Test
+	public void testWriteToJSONObjectWithoutName() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new ParameterInfo().withName(null).writeToJSONObject(adapter);
+		});
+		assertEquals("The 'name' field must not be null.", exception.getMessage());
+	}
+}

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/pathinfo/RequestBodyInfoTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/pathinfo/RequestBodyInfoTest.java
@@ -1,0 +1,82 @@
+package org.sagebionetworks.openapi.datamodel.pathinfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.sagebionetworks.schema.adapter.org.json.JSONObjectAdapterImpl;
+
+public class RequestBodyInfoTest {
+	@Test
+	public void testInitializeFromJSONObject() {
+		assertThrows(UnsupportedOperationException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new RequestBodyInfo().initializeFromJSONObject(adapter);
+		});
+	}
+	
+	@Test
+	public void testWriteToJSONObject() throws JSONObjectAdapterException {
+		Map<String, Schema> content = new LinkedHashMap<>();
+		Schema schema = Mockito.mock(Schema.class);
+		content.put("CONTENT", schema);
+		RequestBodyInfo info = new RequestBodyInfo().withContent(content).withRequired(true);
+
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl adapterCreateNewResult = Mockito.mock(JSONObjectAdapterImpl.class);
+		Mockito.doReturn(adapterCreateNewResult).when(adapter).createNew();
+		JSONObjectAdapterImpl resultFromSchema = new JSONObjectAdapterImpl();
+		Mockito.doReturn(resultFromSchema).when(schema).writeToJSONObject(any());
+		
+		// call under test
+		info.writeToJSONObject(adapter);
+		Mockito.verify(adapterCreateNewResult).put("CONTENT", resultFromSchema);
+		Mockito.verify(schema).writeToJSONObject(adapterCreateNewResult);
+		Mockito.verify(adapter).put("required", true);
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithoutRequired() throws JSONObjectAdapterException {
+		Map<String, Schema> content = new LinkedHashMap<>();
+		Schema schema = Mockito.mock(Schema.class);
+		content.put("CONTENT", schema);
+		RequestBodyInfo info = new RequestBodyInfo().withContent(content).withRequired(false);
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl adapterCreateNewResult = Mockito.mock(JSONObjectAdapterImpl.class);
+		Mockito.doReturn(adapterCreateNewResult).when(adapter).createNew();
+
+		// call under test
+		info.writeToJSONObject(adapter);
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("required"), anyBoolean());
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithEmptyContent() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new RequestBodyInfo().withContent(new LinkedHashMap<>()).writeToJSONObject(adapter);
+		});
+		assertEquals("The 'content' field must not be empty.", exception.getMessage());
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithMissingContent() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new RequestBodyInfo().withContent(null).writeToJSONObject(adapter);
+		});
+		assertEquals("The 'content' field must not be null.", exception.getMessage());
+	}
+}

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/pathinfo/ResponseInfoTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/pathinfo/ResponseInfoTest.java
@@ -1,0 +1,102 @@
+package org.sagebionetworks.openapi.datamodel.pathinfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.sagebionetworks.schema.adapter.org.json.JSONObjectAdapterImpl;
+
+public class ResponseInfoTest {
+	@Test
+	public void testInitializeFromJSONObject() {
+		assertThrows(UnsupportedOperationException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new ResponseInfo().initializeFromJSONObject(adapter);
+		});
+	}
+	
+	@Test
+	public void testWriteToJSONObject() throws JSONObjectAdapterException {
+		Map<String, Schema> content = new LinkedHashMap<>();
+		Schema schema = Mockito.mock(Schema.class);
+		content.put("CONTENT", schema);
+		ResponseInfo info = Mockito.spy(new ResponseInfo().withContent(content).withDescription("DESCRIPTION"));
+		Mockito.doNothing().when(info).populateContent(any());
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl impl = Mockito.mock(JSONObjectAdapterImpl.class);
+		Mockito.doReturn(impl).when(adapter).createNew();
+		
+		// call under test
+		info.writeToJSONObject(adapter);
+		Mockito.verify(adapter).put("description", "DESCRIPTION");
+		Mockito.verify(adapter).put("content", impl);
+		Mockito.verify(info).populateContent(impl);
+	}
+	
+	@Test
+	public void testPopulateContent() throws JSONObjectAdapterException {
+		Map<String, Schema> content = new LinkedHashMap<>();
+		Schema schema1 = Mockito.mock(Schema.class);
+		Schema schema2 = Mockito.mock(Schema.class);
+		JSONObjectAdapterImpl resultSchema1 = Mockito.mock(JSONObjectAdapterImpl.class);
+		JSONObjectAdapterImpl resultSchema2 = Mockito.mock(JSONObjectAdapterImpl.class);
+		Mockito.doReturn(resultSchema1).when(schema1).writeToJSONObject(any());
+		Mockito.doReturn(resultSchema2).when(schema2).writeToJSONObject(any());
+		content.put("CONTENT_1", schema1);
+		content.put("CONTENT_2", schema2);
+		ResponseInfo info = new ResponseInfo().withContent(content);
+		JSONObjectAdapter contentJson = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl impl = Mockito.mock(JSONObjectAdapterImpl.class);
+		Mockito.doReturn(impl).when(contentJson).createNew();
+		
+		// call under test
+		info.populateContent(contentJson);
+		Mockito.verify(schema1).writeToJSONObject(impl);
+		Mockito.verify(schema2).writeToJSONObject(impl);
+		Mockito.verify(contentJson, Mockito.times(2)).put(anyString(), any(JSONObjectAdapter.class));
+		InOrder inOrder = Mockito.inOrder(contentJson);
+		inOrder.verify(contentJson).put("CONTENT_1", resultSchema1);
+		inOrder.verify(contentJson).put("CONTENT_2", resultSchema2);
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithEmptyContent() throws JSONObjectAdapterException {
+		ResponseInfo info = new ResponseInfo().withDescription("DESCRIPTION").withContent(new LinkedHashMap<>());
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		
+		// call under test
+		info.writeToJSONObject(adapter);
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("content"), any(JSONObjectAdapter.class));
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithNullContent() throws JSONObjectAdapterException {
+		ResponseInfo info = new ResponseInfo().withDescription("DESCRIPTION").withContent(null);
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		
+		// call under test
+		info.writeToJSONObject(adapter);
+		Mockito.verify(adapter, Mockito.times(0)).put(eq("content"), any(JSONObjectAdapter.class));
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithMissingDescription() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new ResponseInfo().withDescription(null).writeToJSONObject(adapter);
+		});
+		assertEquals("The 'description' field is required.", exception.getMessage());
+	}
+}

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/pathinfo/SchemaTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/openapi/datamodel/pathinfo/SchemaTest.java
@@ -1,0 +1,49 @@
+package org.sagebionetworks.openapi.datamodel.pathinfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapter;
+import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+import org.sagebionetworks.schema.adapter.org.json.JSONObjectAdapterImpl;
+
+public class SchemaTest {
+	@Test
+	public void testInitializeFromJSONObject() {
+		assertThrows(UnsupportedOperationException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new Schema().initializeFromJSONObject(adapter);
+		});
+	}
+	
+	@Test
+	public void testWriteToJSONObject() throws JSONObjectAdapterException {
+		JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+		JSONObjectAdapterImpl adapterImpl = Mockito.mock(JSONObjectAdapterImpl.class);
+		Mockito.doReturn(adapterImpl).when(adapter).createNew();
+		JsonSchema jsonSchema = Mockito.mock(JsonSchema.class);
+		JSONObjectAdapterImpl jsonSchemaImpl = Mockito.mock(JSONObjectAdapterImpl.class);
+		Mockito.doReturn(jsonSchemaImpl).when(jsonSchema).writeToJSONObject(any());
+		Schema schema = new Schema().withSchema(jsonSchema);
+		
+		// call under test
+		schema.writeToJSONObject(adapter);
+		Mockito.verify(jsonSchema).writeToJSONObject(adapterImpl);
+		Mockito.verify(adapter).put("schema", jsonSchemaImpl);
+	}
+	
+	@Test
+	public void testWriteToJSONObjectWithNullSchema() throws JSONObjectAdapterException {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			JSONObjectAdapter adapter = Mockito.mock(JSONObjectAdapter.class);
+			// call under test
+			new Schema().withSchema(null).writeToJSONObject(adapter);
+		});
+		assertEquals("The 'schema' field must not be null.", exception.getMessage());
+	}
+}

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ControllerModelDocletTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ControllerModelDocletTest.java
@@ -110,7 +110,7 @@ public class ControllerModelDocletTest {
 	@Test
 	public void testTagsIsCorrectInPath() {
 		JSONObject pathsObj = generatedOpenAPISpec.getJSONObject("paths");
-		JSONObject pathObj = pathsObj.getJSONObject("repo/v1/complex-pet/{petName}");
+		JSONObject pathObj = pathsObj.getJSONObject("/repo/v1/complex-pet/{petName}");
 		JSONObject operationObj = pathObj.getJSONObject("get");
 		
 		// test tags is correct
@@ -128,7 +128,7 @@ public class ControllerModelDocletTest {
 	@Test
 	public void testOperationIdIsCorrectInPath() {
 		JSONObject pathsObj = generatedOpenAPISpec.getJSONObject("paths");
-		JSONObject pathObj = pathsObj.getJSONObject("repo/v1/complex-pet/{petName}");
+		JSONObject pathObj = pathsObj.getJSONObject("/repo/v1/complex-pet/{petName}");
 		JSONObject operationObj = pathObj.getJSONObject("get");
 		
 		// test operationId is correct
@@ -138,7 +138,7 @@ public class ControllerModelDocletTest {
 	@Test
 	public void testParametersAreCorrectInPath() {
 		JSONObject pathsObj = generatedOpenAPISpec.getJSONObject("paths");
-		JSONObject pathObj = pathsObj.getJSONObject("repo/v1/complex-pet/{petName}");
+		JSONObject pathObj = pathsObj.getJSONObject("/repo/v1/complex-pet/{petName}");
 		JSONObject operationObj = pathObj.getJSONObject("get");
 		
 		// test parameters are correct
@@ -150,7 +150,7 @@ public class ControllerModelDocletTest {
 				assertEquals("path", param.getString("in"));
 				assertEquals(true, param.getBoolean("required"));
 				JSONObject schema = param.getJSONObject("schema");
-				assertEquals("string", schema.getString("type"));
+				assertEquals("#/components/schemas/java.lang.String", schema.getString("$ref"));
 				foundPetNameParam = true;
 			}
 		}
@@ -160,7 +160,7 @@ public class ControllerModelDocletTest {
 	@Test
 	public void testResponseObjectIsCorrectInPath() {
 		JSONObject pathsObj = generatedOpenAPISpec.getJSONObject("paths");
-		JSONObject pathObj = pathsObj.getJSONObject("repo/v1/complex-pet/{petName}");
+		JSONObject pathObj = pathsObj.getJSONObject("/repo/v1/complex-pet/{petName}");
 		JSONObject operationObj = pathObj.getJSONObject("get");
 		
 		// test response object is correct
@@ -172,32 +172,13 @@ public class ControllerModelDocletTest {
 		JSONObject responseSchema = contentType.getJSONObject("schema");
 
 		// test to see if Pet interface is represented correctly as the return type.
-		assertEquals("object", responseSchema.getString("type"));
-		assertEquals("This interface represents a pet.", responseSchema.getString("description"));
-		JSONObject responseSchemaProperties = responseSchema.getJSONObject("properties");
-		JSONObject responseSchemaNameProperty = responseSchemaProperties.getJSONObject("name");
-		assertEquals("string", responseSchemaNameProperty.getString("type"));
-		JSONObject responseSchemaHasTailProperty = responseSchemaProperties.getJSONObject("hasTail");
-		assertEquals("_boolean", responseSchemaHasTailProperty.getString("type"));
-		
-		// test to see if the oneof property is being set correctly.
-		JSONArray oneOf = responseSchema.getJSONArray("oneOf");
-		assertTrue(oneOf.length() == 3);
-		Set<String> references = new HashSet<>();
-		for (int i = 0; i < oneOf.length(); i++) {
-			JSONObject reference = oneOf.getJSONObject(i);
-			String ref = reference.getString("$ref");
-			references.add(ref);
-		}
-		assertTrue(references.contains("#/components/org.sagebionetworks.openapi.pet.Husky"));
-		assertTrue(references.contains("#/components/org.sagebionetworks.openapi.pet.Poodle"));
-		assertTrue(references.contains("#/components/org.sagebionetworks.openapi.pet.Cat"));
+		assertEquals("#/components/schemas/org.sagebionetworks.openapi.pet.Pet", responseSchema.getString("$ref"));
 	}
 	
 	@Test
 	public void testRequestBodyIsCorrectInPath() {
 		JSONObject pathsObj = generatedOpenAPISpec.getJSONObject("paths");
-		JSONObject pathObj = pathsObj.getJSONObject("repo/v1/complex-pet/cat/{name}");
+		JSONObject pathObj = pathsObj.getJSONObject("/repo/v1/complex-pet/cat/{name}");
 		JSONObject operationObj = pathObj.getJSONObject("post");
 
 		JSONObject requestBody = operationObj.getJSONObject("requestBody");
@@ -206,16 +187,34 @@ public class ControllerModelDocletTest {
 		JSONObject contentType = content.getJSONObject("application/json");
 		JSONObject schema = contentType.getJSONObject("schema");
 		
-		assertEquals("object", schema.getString("type"));
-		assertEquals("This class describes a Cat.", schema.getString("description"));
+		assertEquals("#/components/schemas/org.sagebionetworks.openapi.pet.Cat", schema.getString("$ref"));
+	}
+	
+	@Test
+	public void testSchemasGeneratedCorrectlyInComponents() {
+		JSONObject componentsObj = generatedOpenAPISpec.getJSONObject("components");
+		JSONObject schemasObj = componentsObj.getJSONObject("schemas");
+		JSONObject petInterface = schemasObj.getJSONObject("org.sagebionetworks.openapi.pet.Pet");
 		
-		JSONObject properties = schema.getJSONObject("properties");
-		JSONObject nameProperty = properties.getJSONObject("name");
-		assertEquals("string", nameProperty.getString("type"));
-		JSONObject hasTailProperty = properties.getJSONObject("hasTail");
-		assertEquals("_boolean", hasTailProperty.getString("type"));
-		JSONObject numWhiskersProperty = properties.getJSONObject("numWhiskers");
-		assertEquals("integer", numWhiskersProperty.getString("type"));
-		assertEquals("int32", numWhiskersProperty.getString("format"));
+		assertEquals("object", petInterface.getString("type"));
+		assertEquals("This interface represents a pet.", petInterface.getString("description"));
+		JSONObject petInterfaceProperties = petInterface.getJSONObject("properties");
+		JSONObject petInterfaceNameProperty = petInterfaceProperties.getJSONObject("name");
+		assertEquals("string", petInterfaceNameProperty.getString("type"));
+		JSONObject responseSchemaHasTailProperty = petInterfaceProperties.getJSONObject("hasTail");
+		assertEquals("boolean", responseSchemaHasTailProperty.getString("type"));
+		
+		// test to see if the oneof property is being set correctly.
+		JSONArray oneOf = petInterface.getJSONArray("oneOf");
+		assertTrue(oneOf.length() == 3);
+		Set<String> references = new HashSet<>();
+		for (int i = 0; i < oneOf.length(); i++) {
+			JSONObject reference = oneOf.getJSONObject(i);
+			String ref = reference.getString("$ref");
+			references.add(ref);
+		}
+		assertTrue(references.contains("#/components/schemas/org.sagebionetworks.openapi.pet.Husky"));
+		assertTrue(references.contains("#/components/schemas/org.sagebionetworks.openapi.pet.Poodle"));
+		assertTrue(references.contains("#/components/schemas/org.sagebionetworks.openapi.pet.Cat"));
 	}
 }

--- a/lib/lib-openapi/src/test/resources/ComplexExampleControllerOpenAPISpec.json
+++ b/lib/lib-openapi/src/test/resources/ComplexExampleControllerOpenAPISpec.json
@@ -1,0 +1,400 @@
+{
+   "openapi": "3.0.1",
+   "info": {
+      "title": "Sample OpenAPI definition",
+      "version": "v1"
+   },
+   "servers": [
+      {
+         "url": "https://repo-prod.prod.sagebase.org",
+         "description": "This is the generated server URL"
+      }
+   ],
+   "tags": [
+      {
+         "name": "Pet",
+         "description": "This exists to test the multiple controller case."
+      },
+      {
+         "name": "Person",
+         "description": "This is a basic example controller."
+      },
+      {
+         "name": "ComplexPets",
+         "description": "This controller is used to test translating for complex types."
+      }
+   ],
+   "paths": {
+      "/repo/v1/pet/num-pets/{name}": {
+         "get": {
+            "tags": [
+               "Pet"
+            ],
+            "operationId": "getNumPets",
+            "parameters": [
+               {
+                  "name": "name",
+                  "in": "path",
+                  "required": true,
+                  "description": "- the name of the person",
+                  "schema": {
+                     "$ref": "#/components/schemas/java.lang.String"
+                  }
+               }
+            ],
+            "responses": {
+               "200": {
+                  "description": "the number of pets this person has, default to 0 if name of person does not exist.",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/int"
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/repo/v1/pet/{name}": {
+         "post": {
+            "tags": [
+               "Pet"
+            ],
+            "operationId": "addPets",
+            "parameters": [
+               {
+                  "name": "name",
+                  "in": "path",
+                  "required": true,
+                  "description": "- the name of the person",
+                  "schema": {
+                     "$ref": "#/components/schemas/java.lang.String"
+                  }
+               }
+            ],
+            "requestBody": {
+               "content": {
+                  "application/json": {
+                     "schema": {
+                        "$ref": "#/components/schemas/int"
+                     }
+                  }
+               },
+               "required": true
+            },
+            "responses": {
+               "200": {
+                  "description": "the name of the person that was added",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/java.lang.String"
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/repo/v1/person/age/{name}": {
+         "get": {
+            "tags": [
+               "Person"
+            ],
+            "operationId": "getPersonAge",
+            "parameters": [
+               {
+                  "name": "name",
+                  "in": "path",
+                  "required": true,
+                  "description": "- the name of the person",
+                  "schema": {
+                     "$ref": "#/components/schemas/java.lang.String"
+                  }
+               }
+            ],
+            "responses": {
+               "200": {
+                  "description": "the age of the person. If no record of person is found, then return 0.",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/int"
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/repo/v1/person/{name}": {
+         "post": {
+            "tags": [
+               "Person"
+            ],
+            "operationId": "addPerson",
+            "parameters": [
+               {
+                  "name": "name",
+                  "in": "path",
+                  "required": true,
+                  "description": "- the name of the person",
+                  "schema": {
+                     "$ref": "#/components/schemas/java.lang.String"
+                  }
+               }
+            ],
+            "requestBody": {
+               "content": {
+                  "application/json": {
+                     "schema": {
+                        "$ref": "#/components/schemas/int"
+                     }
+                  }
+               },
+               "required": true
+            },
+            "responses": {
+               "200": {
+                  "description": "the name of the person that was added",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/java.lang.String"
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/repo/v1/complex-pet/{petName}": {
+         "get": {
+            "tags": [
+               "ComplexPets"
+            ],
+            "operationId": "getPet",
+            "parameters": [
+               {
+                  "name": "petName",
+                  "in": "path",
+                  "required": true,
+                  "schema": {
+                     "$ref": "#/components/schemas/java.lang.String"
+                  }
+               }
+            ],
+            "responses": {
+               "200": {
+                  "description": "the Pet associated with 'name'.",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/org.sagebionetworks.openapi.pet.Pet"
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/repo/v1/complex-pet/dog/{name}": {
+         "post": {
+            "tags": [
+               "ComplexPets"
+            ],
+            "operationId": "addDog",
+            "parameters": [
+               {
+                  "name": "name",
+                  "in": "path",
+                  "required": true,
+                  "description": "- the name of the dog",
+                  "schema": {
+                     "$ref": "#/components/schemas/java.lang.String"
+                  }
+               }
+            ],
+            "requestBody": {
+               "content": {
+                  "application/json": {
+                     "schema": {
+                        "$ref": "#/components/schemas/org.sagebionetworks.openapi.pet.Poodle"
+                     }
+                  }
+               },
+               "required": true
+            },
+            "responses": {
+               "200": {
+                  "description": "the name of the Dog that was added",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/java.lang.String"
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      },
+      "/repo/v1/complex-pet/cat/{name}": {
+         "post": {
+            "tags": [
+               "ComplexPets"
+            ],
+            "operationId": "addCat",
+            "parameters": [
+               {
+                  "name": "name",
+                  "in": "path",
+                  "required": true,
+                  "description": "- the name of the cat",
+                  "schema": {
+                     "$ref": "#/components/schemas/java.lang.String"
+                  }
+               }
+            ],
+            "requestBody": {
+               "content": {
+                  "application/json": {
+                     "schema": {
+                        "$ref": "#/components/schemas/org.sagebionetworks.openapi.pet.Cat"
+                     }
+                  }
+               },
+               "required": true
+            },
+            "responses": {
+               "200": {
+                  "description": "the name of the cat that was added",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/java.lang.String"
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   },
+   "components": {
+      "schemas": {
+         "org.sagebionetworks.openapi.pet.Dog": {
+            "type": "object",
+            "properties": {
+               "name": {
+                  "type": "string"
+               },
+               "hasTail": {
+                  "type": "boolean"
+               },
+               "age": {
+                  "type": "integer",
+                  "format": "int32"
+               }
+            },
+            "description": "This class describes a Dog.",
+            "oneOf": [
+               {
+                  "$ref": "#/components/schemas/org.sagebionetworks.openapi.pet.Husky"
+               },
+               {
+                  "$ref": "#/components/schemas/org.sagebionetworks.openapi.pet.Poodle"
+               }
+            ]
+         },
+         "org.sagebionetworks.openapi.pet.Pet": {
+            "type": "object",
+            "properties": {
+               "name": {
+                  "type": "string"
+               },
+               "hasTail": {
+                  "type": "boolean"
+               }
+            },
+            "description": "This interface represents a pet.",
+            "oneOf": [
+               {
+                  "$ref": "#/components/schemas/org.sagebionetworks.openapi.pet.Husky"
+               },
+               {
+                  "$ref": "#/components/schemas/org.sagebionetworks.openapi.pet.Poodle"
+               },
+               {
+                  "$ref": "#/components/schemas/org.sagebionetworks.openapi.pet.Cat"
+               }
+            ]
+         },
+         "org.sagebionetworks.openapi.pet.Husky": {
+            "type": "object",
+            "properties": {
+               "name": {
+                  "type": "string"
+               },
+               "hasTail": {
+                  "type": "boolean"
+               },
+               "age": {
+                  "type": "integer",
+                  "format": "int32"
+               },
+               "hasLongHair": {
+                  "type": "boolean"
+               }
+            },
+            "description": "Describes the husky breed of Dog."
+         },
+         "org.sagebionetworks.openapi.pet.Poodle": {
+            "type": "object",
+            "properties": {
+               "name": {
+                  "type": "string"
+               },
+               "hasTail": {
+                  "type": "boolean"
+               },
+               "age": {
+                  "type": "integer",
+                  "format": "int32"
+               },
+               "isFluffy": {
+                  "type": "boolean"
+               },
+               "huskyType": {
+                  "$ref": "#/components/schemas/org.sagebionetworks.openapi.pet.Husky"
+               }
+            },
+            "description": "Describes the poodle breed of Dog."
+         },
+         "org.sagebionetworks.openapi.pet.Cat": {
+            "type": "object",
+            "properties": {
+               "name": {
+                  "type": "string"
+               },
+               "hasTail": {
+                  "type": "boolean"
+               },
+               "numWhiskers": {
+                  "type": "integer",
+                  "format": "int32"
+               }
+            },
+            "description": "This class describes a Cat."
+         },
+         "java.lang.String": {
+            "type": "string"
+         },
+         "int": {
+            "type": "integer",
+            "format": "int32"
+         }
+      }
+   }
+}

--- a/lib/lib-openapi/src/test/resources/controller/ComplexExampleController.java
+++ b/lib/lib-openapi/src/test/resources/controller/ComplexExampleController.java
@@ -43,7 +43,7 @@ public class ComplexExampleController {
 	 */
 	@ResponseStatus(HttpStatus.OK)
 	@RequestMapping(value = "/complex-pet/dog/{name}", method = RequestMethod.POST)
-	public @ResponseBody String addDog(@PathVariable String name, @RequestBody Dog dog) {
+	public @ResponseBody String addDog(@PathVariable String name, @RequestBody Poodle dog) {
 		petNameToPet.put(name, dog);
 		return name;
 	}


### PR DESCRIPTION
Generating the "Components" section of the OpenAPI specification. In the "paths" object, all types are now references to the Components section.

This resolves: https://sagebionetworks.jira.com/jira/software/c/projects/PLFM/boards/1?modal=detail&selectedIssue=PLFM-7864