### PR TITLE
PLFM-7895: Added support for Arrays during translation process

### DIFF
--- a/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Husky.json
+++ b/lib/lib-openapi/src/main/resources/schema/org/sagebionetworks/openapi/pet/Husky.json
@@ -10,6 +10,13 @@
 		"hasLongHair": {
 			"type": "boolean",
 			"description": "Describes if the husky has long hair."
+		},
+		"owners": {
+			"type": "array",
+			"items": {
+			    "type":"object",
+				"$ref":"org.sagebionetworks.openapi.pet.Owner"
+			}
 		}
 	}
 }


### PR DESCRIPTION
Added support for Arrays when translating classes to their respective schemas.

This resolves: https://sagebionetworks.jira.com/jira/software/c/projects/PLFM/boards/1?modal=detail&selectedIssue=PLFM-7895