### PR TITLE
PLFM-7890: Update jdbc + db-sema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -651,7 +651,7 @@
 			<dependency>
 				<groupId>org.sagebionetworks</groupId>
 				<artifactId>database-semaphore</artifactId>
-				<version>4.0.2</version>
+				<version>4.0.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.sagebionetworks</groupId>
@@ -1075,7 +1075,7 @@
 		<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
 		<javax.transaction.jta.version>1.1</javax.transaction.jta.version>
 		<javax.jdo.jdo2-api.version>2.3-ec</javax.jdo.jdo2-api.version>
-		<mysql.mysql-connector-java.version>8.0.31</mysql.mysql-connector-java.version>
+		<mysql.mysql-connector-java.version>8.0.33</mysql.mysql-connector-java.version>
 		<org.aspectj.aspectjlib.version>1.6.2</org.aspectj.aspectjlib.version>
 		<org.aspectj.version>1.8.11</org.aspectj.version>
 		<schema-to-pojo.version>0.6.9</schema-to-pojo.version>


### PR DESCRIPTION
This PR updates the JDBC driver version to 8.0.33 (including new version of database-semaphore also on 8.0.33).
Private build passed.