### PR TITLE
PLFM-7492

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/oauth/OAuthClientManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/oauth/OAuthClientManagerImpl.java
@@ -83,18 +83,18 @@ public class OAuthClientManagerImpl implements OAuthClientManager {
 		}
 	}
 
-	public List<String> readSectorIdentifierFile(URI uri) throws ServiceUnavailableException {
+	public List<String> readSectorIdentifierFile(URI uri) {
 		SimpleHttpRequest request = new SimpleHttpRequest();
 		request.setUri(uri.toString());
 		SimpleHttpResponse response = null;
 		try {
 			response = httpClient.get(request);
 		} catch (IOException e) {
-			throw new ServiceUnavailableException("Failed to read the content of "+uri+
+			throw new IllegalArgumentException("Failed to read the content of "+uri+
 					".  Please check the URL and the file at the address, then try again.", e);
 		}
 		if (response.getStatusCode() != HttpStatus.SC_OK) {
-			throw new ServiceUnavailableException("Received "+response.getStatusCode()+" status while trying to read the content of "+uri+
+			throw new IllegalArgumentException("Received "+response.getStatusCode()+" status while trying to read the content of "+uri+
 					".  Please check the URL and the file at the address, then try again.");
 		}
 		List<String> result = new ArrayList<String>();

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/oauth/OAuthClientManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/oauth/OAuthClientManagerImplUnitTest.java
@@ -49,7 +49,6 @@ import org.sagebionetworks.repo.model.oauth.OAuthClient;
 import org.sagebionetworks.repo.model.oauth.OAuthClientIdAndSecret;
 import org.sagebionetworks.repo.model.oauth.OIDCSigningAlgorithm;
 import org.sagebionetworks.repo.web.NotFoundException;
-import org.sagebionetworks.repo.web.ServiceUnavailableException;
 import org.sagebionetworks.securitytools.PBKDF2Utils;
 import org.sagebionetworks.simpleHttpClient.SimpleHttpClient;
 import org.sagebionetworks.simpleHttpClient.SimpleHttpRequest;
@@ -218,7 +217,7 @@ public class OAuthClientManagerImplUnitTest {
 		when(mockHttpResponse.getStatusCode()).thenReturn(400);
 		when(mockHttpClient.get((SimpleHttpRequest)any())).thenReturn(mockHttpResponse);
 
-		assertThrows(ServiceUnavailableException.class, () -> {
+		assertThrows(IllegalArgumentException.class, () -> {
 			// method under test
 			oauthClientManagerImpl.readSectorIdentifierFile(sector_identifier_uri);
 		});
@@ -229,7 +228,7 @@ public class OAuthClientManagerImplUnitTest {
 		// try throwing IOException
 		when(mockHttpClient.get((SimpleHttpRequest)any())).thenThrow(new IOException());
 		
-		assertThrows(ServiceUnavailableException.class, () -> {
+		assertThrows(IllegalArgumentException.class, () -> {
 			// method under test
 			oauthClientManagerImpl.readSectorIdentifierFile(sector_identifier_uri);
 		});


### PR DESCRIPTION
When resolving a sector identifier, if the referenced JSON file is not readable, then return a 400 rather than a 503 response status.