### PR TITLE
IT-3744: Bump schema-to-pojo to 0.6.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1058,7 +1058,7 @@
 		<mysql.mysql-connector-java.version>8.0.33</mysql.mysql-connector-java.version>
 		<org.aspectj.aspectjlib.version>1.6.2</org.aspectj.aspectjlib.version>
 		<org.aspectj.version>1.8.11</org.aspectj.version>
-		<schema-to-pojo.version>0.6.9</schema-to-pojo.version>
+		<schema-to-pojo.version>0.6.10</schema-to-pojo.version>
 		<com.amazonaws.version>1.12.496</com.amazonaws.version>
 		<findbugs-maven-plugin.version>2.5.2</findbugs-maven-plugin.version>
 		<org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>


### PR DESCRIPTION
This PR updates the version to the latest artifact as the existing dependency 0.6.9 will be deleted next time we delete old artifacts again.
Personal build passed.