### PR TITLE
PLFM-8606 - Fix links to reapply for profile validation

### DIFF
--- a/services/repository-managers/src/main/resources/message/verificationApprovedTemplate.html
+++ b/services/repository-managers/src/main/resources/message/verificationApprovedTemplate.html
@@ -5,7 +5,7 @@
       Hello  #displayName#,</p><p style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0 0 10px;">
       Your request for identity verification has been approved.  The verification is now indicated on
        <a href="https://www.synapse.org/#!Profile:#userid#" style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;background-color: transparent;color: #337ab7;text-decoration: none;">
-      your home page</a>.</p>
+      your Synapse profile</a>.</p>
       <br style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;">
       <p style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0 0 10px;">
         Sincerely,

--- a/services/repository-managers/src/main/resources/message/verificationRejectedNoReasonTemplate.html
+++ b/services/repository-managers/src/main/resources/message/verificationRejectedNoReasonTemplate.html
@@ -4,8 +4,8 @@
       <p style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0 0 10px;margin-bottom: 20px;font-size: 16px;font-weight: 300;line-height: 1.4;">
       Hello #displayName#,</p><p style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0 0 10px;">
       Your request for identity verification has been rejected. You may reapply for verification from       
-       <a href="https://www.synapse.org/#!Profile:#userid#" style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;background-color: transparent;color: #337ab7;text-decoration: none;">
-      your home page</a>.</p>
+       <a href="https://accounts.synapse.org/authenticated/myaccount" style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;background-color: transparent;color: #337ab7;text-decoration: none;">
+      your account settings page</a>.</p>
       <br style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;">
       <p style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0 0 10px;">
         Sincerely,

--- a/services/repository-managers/src/main/resources/message/verificationRejectedTemplate.html
+++ b/services/repository-managers/src/main/resources/message/verificationRejectedTemplate.html
@@ -10,8 +10,8 @@
        </p>
       <br style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;">
 	You may reapply for verification from       
-       <a href="https://www.synapse.org/#!Profile:#userid#" style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;background-color: transparent;color: #337ab7;text-decoration: none;">
-      your home page</a>.</p>
+       <a href="https://accounts.synapse.org/authenticated/myaccount" style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;background-color: transparent;color: #337ab7;text-decoration: none;">
+      your account settings page</a>.</p>
       <br style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;">
       <p style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0 0 10px;">
         Sincerely,

--- a/services/repository-managers/src/main/resources/message/verificationSuspendedNoReasonTemplate.html
+++ b/services/repository-managers/src/main/resources/message/verificationSuspendedNoReasonTemplate.html
@@ -4,8 +4,8 @@
       <p style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0 0 10px;margin-bottom: 20px;font-size: 16px;font-weight: 300;line-height: 1.4;">
       Hello #displayName#,</p><p style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0 0 10px;">
       Your identity verification has been suspended. If you wish, you may reapply for identity verification from      
-       <a href="https://www.synapse.org/#!Profile:#userid#" style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;background-color: transparent;color: #337ab7;text-decoration: none;">
-      your home page</a>.</p>
+       <a href="https://accounts.synapse.org/authenticated/myaccount" style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;background-color: transparent;color: #337ab7;text-decoration: none;">
+      your account settings page</a>.</p>
       <br style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;">
       <p style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0 0 10px;">
         Sincerely,

--- a/services/repository-managers/src/main/resources/message/verificationSuspendedTemplate.html
+++ b/services/repository-managers/src/main/resources/message/verificationSuspendedTemplate.html
@@ -8,8 +8,8 @@
  	#reason#     
       <br style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;">
 	 If you wish, you may reapply for identity verification from      
-       <a href="https://www.synapse.org/#!Profile:#userid#" style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;background-color: transparent;color: #337ab7;text-decoration: none;">
-      your home page</a>.</p>
+       <a href="https://accounts.synapse.org/authenticated/myaccount" style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;background-color: transparent;color: #337ab7;text-decoration: none;">
+      your account settings page</a>.</p>
       <br style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;">
       <p style="-webkit-box-sizing: border-box;-moz-box-sizing: border-box;box-sizing: border-box;margin: 0 0 10px;">
         Sincerely,

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/verification/VerificationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/verification/VerificationManagerImplTest.java
@@ -548,7 +548,7 @@ public class VerificationManagerImplTest {
 				TEMPLATE_KEY_USER_ID
 		});
 		
-		// this will create 7 pieces
+		// this will create 5 pieces
 		List<String> templatePieces = EmailParseUtil.splitEmailTemplate(
 				VerificationManagerImpl.VERIFICATION_REJECTED_TEMPLATE, delims);
 		
@@ -559,9 +559,7 @@ public class VerificationManagerImplTest {
 		assertTrue(result.getBody().indexOf(templatePieces.get(4))>0);
 		String reason = EmailParseUtil.getTokenFromString(result.getBody(), templatePieces.get(2), templatePieces.get(4));
 		assertEquals(expectedReason, reason);
-		assertTrue(result.getBody().endsWith(templatePieces.get(6)));
-		String userId = EmailParseUtil.getTokenFromString(result.getBody(), templatePieces.get(4), templatePieces.get(6));
-		assertEquals(USER_ID.toString(), userId);
+		assertTrue(result.getBody().endsWith(templatePieces.get(4)));
 	}
 
 	@Test
@@ -592,7 +590,7 @@ public class VerificationManagerImplTest {
 				TEMPLATE_KEY_USER_ID
 		});
 		
-		// this will create 5 pieces
+		// this will create 3 pieces
 		List<String> templatePieces = EmailParseUtil.splitEmailTemplate(
 				VerificationManagerImpl.VERIFICATION_REJECTED_NO_REASON_TEMPLATE, delims);
 		
@@ -600,9 +598,7 @@ public class VerificationManagerImplTest {
 		assertTrue(result.getBody().indexOf(templatePieces.get(2))>0);
 		String displayName = EmailParseUtil.getTokenFromString(result.getBody(), templatePieces.get(0), templatePieces.get(2));
 		assertEquals("fname lname (username)", displayName);	
-		assertTrue(result.getBody().endsWith(templatePieces.get(4)));
-		String userId = EmailParseUtil.getTokenFromString(result.getBody(), templatePieces.get(2), templatePieces.get(4));
-		assertEquals(USER_ID.toString(), userId);
+		assertTrue(result.getBody().endsWith(templatePieces.get(2)));
 	}
 
 	@Test
@@ -636,7 +632,7 @@ public class VerificationManagerImplTest {
 				TEMPLATE_KEY_USER_ID
 		});
 		
-		// this will create 7 pieces
+		// this will create 5 pieces
 		List<String> templatePieces = EmailParseUtil.splitEmailTemplate(
 				VerificationManagerImpl.VERIFICATION_SUSPENDED_TEMPLATE, delims);
 		
@@ -647,9 +643,7 @@ public class VerificationManagerImplTest {
 		assertTrue(result.getBody().indexOf(templatePieces.get(4))>0);
 		String reason = EmailParseUtil.getTokenFromString(result.getBody(), templatePieces.get(2), templatePieces.get(4));
 		assertEquals(expectedReason, reason);
-		assertTrue(result.getBody().endsWith(templatePieces.get(6)));
-		String userId = EmailParseUtil.getTokenFromString(result.getBody(), templatePieces.get(4), templatePieces.get(6));
-		assertEquals(USER_ID.toString(), userId);
+		assertTrue(result.getBody().endsWith(templatePieces.get(4)));
 	}
 
 	@Test
@@ -680,16 +674,14 @@ public class VerificationManagerImplTest {
 				TEMPLATE_KEY_USER_ID
 		});
 		
-		// this will create 5 pieces
+		// this will create 3 pieces
 		List<String> templatePieces = EmailParseUtil.splitEmailTemplate(
 				VerificationManagerImpl.VERIFICATION_SUSPENDED_NO_REASON_TEMPLATE, delims);
 		
 		assertTrue(result.getBody().startsWith(templatePieces.get(0)));
 		assertTrue(result.getBody().indexOf(templatePieces.get(2))>0);
 		String displayName = EmailParseUtil.getTokenFromString(result.getBody(), templatePieces.get(0), templatePieces.get(2));
-		assertEquals("fname lname (username)", displayName);	
-		assertTrue(result.getBody().endsWith(templatePieces.get(4)));
-		String userId = EmailParseUtil.getTokenFromString(result.getBody(), templatePieces.get(2), templatePieces.get(4));
-		assertEquals(USER_ID.toString(), userId);
+		assertEquals("fname lname (username)", displayName);
+		assertTrue(result.getBody().endsWith(templatePieces.get(2)));
 	}
 }


### PR DESCRIPTION
Identity verification approval link goes to the profile page, so the text should say so (not "your home page")

Identity verification rejection links should go to the account settings page, where users can re-apply.