### PR TITLE
PLFM-7989 - add service to get versioned EntityHeader

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImpl.java
@@ -1196,7 +1196,16 @@ public class NodeDAOImpl implements NodeDAO, InitializingBean {
 		}
 		return header.get(0);
 	}
-	
+
+	@Override
+	public EntityHeader getEntityHeader(String nodeId, Long versionNumber) throws DatastoreException, NotFoundException {
+		List<EntityHeader> header = getEntityHeader(Collections.singletonList(new Reference().setTargetId(nodeId).setTargetVersionNumber(versionNumber)));
+		if(header.size() != 1){
+			throw new NotFoundException(String.format(RESOURCE_DOES_NOT_EXIST, nodeId + "." + versionNumber));
+		}
+		return header.get(0);
+	}
+
 	@Override
 	public List<EntityHeader> getEntityHeader(List<Reference> references) {
 		ValidateArgument.required(references, "references");

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/NodeDAOImplTest.java
@@ -1725,6 +1725,66 @@ public class NodeDAOImplTest {
 		}).getMessage();
 		assertEquals("Resource: 'syn123' does not exist", message);
 	}
+
+	@Test
+	public void testGetEntityHeaderForVersion() throws Exception {
+		Node parent = privateCreateNew("parent");
+		parent.setNodeType(EntityType.project);
+		String parentId = nodeDao.createNew(parent);
+		toDelete.add(parentId);
+		assertNotNull(parentId);
+		// Get the header of this node
+		EntityHeader parentHeader = nodeDao.getEntityHeader(parentId);
+		assertNotNull(parentHeader);
+		assertEquals(EntityTypeUtils.getEntityTypeClassName(EntityType.project), parentHeader.getType());
+		assertEquals("parent", parentHeader.getName());
+		assertEquals(parentId, parentHeader.getId());
+
+		Node child = privateCreateNew("child");
+		Long childVersion = 1L; // This will be the first version of this node
+		child.setNodeType(EntityType.file);
+		child.setParentId(parentId);
+		String childId = nodeDao.createNew(child);
+		toDelete.add(childId);
+		assertNotNull(childId);
+
+		// Call under test: get the versioned header of this node
+		EntityHeader childHeader = nodeDao.getEntityHeader(childId, childVersion);
+		assertNotNull(childHeader);
+		assertEquals(EntityTypeUtils.getEntityTypeClassName(EntityType.file), childHeader.getType());
+		assertEquals("child", childHeader.getName());
+		assertEquals(childId, childHeader.getId());
+		assertEquals(childVersion, childHeader.getVersionNumber());
+	}
+
+	@Test
+	public void testGetEntityHeaderByVersionDoesNotExist() throws NotFoundException, DatastoreException{
+		Node parent = privateCreateNew("parent");
+		parent.setNodeType(EntityType.project);
+		String parentId = nodeDao.createNew(parent);
+		toDelete.add(parentId);
+		assertNotNull(parentId);
+		// Get the header of this node
+		EntityHeader parentHeader = nodeDao.getEntityHeader(parentId);
+		assertNotNull(parentHeader);
+		assertEquals(EntityTypeUtils.getEntityTypeClassName(EntityType.project), parentHeader.getType());
+		assertEquals("parent", parentHeader.getName());
+		assertEquals(parentId, parentHeader.getId());
+
+		Node child = privateCreateNew("child");
+		Long childVersion = 1L; // This will be the first version of this node
+		child.setNodeType(EntityType.file);
+		child.setParentId(parentId);
+		String childId = nodeDao.createNew(child);
+		toDelete.add(childId);
+		assertNotNull(childId);
+
+		// Call under test: Verify that a different version of the child does not exist
+		String message = assertThrows(NotFoundException.class, ()->{
+			nodeDao.getEntityHeader(childId, childVersion + 1);
+		}).getMessage();
+		assertEquals("Resource: '" + childId + "." + (childVersion + 1) + "' does not exist", message);
+	}
 	
 	@Test
 	public void testGetEntityPathId() throws Exception {

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/NodeDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/NodeDAO.java
@@ -240,6 +240,16 @@ public interface NodeDAO {
 	public EntityHeader getEntityHeader(String nodeId) throws DatastoreException, NotFoundException;
 	
 	/**
+	 * Get the header information for a particular version of an entity.
+	 * @param nodeId
+	 * @param versionNumber
+	 * @return the entity header
+	 * @throws DatastoreException
+	 * @throws NotFoundException
+	 */
+	public EntityHeader getEntityHeader(String nodeId, Long versionNumber) throws DatastoreException, NotFoundException;
+
+	/**
 	 * Get a list of entity headers from a list of references.
 	 * @param references
 	 * @return

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityManager.java
@@ -135,13 +135,26 @@ public interface EntityManager {
 	 * 
 	 * @param userInfo
 	 * @param entityId
-	 * @param versionNumber (optional) null means current version.
 	 * @return
 	 * @throws NotFoundException
 	 * @throws DatastoreException
 	 * @throws UnauthorizedException
 	 */
 	EntityHeader getEntityHeader(UserInfo userInfo, String entityId)
+			throws NotFoundException, DatastoreException, UnauthorizedException;
+
+	/**
+	 * Get the entity header.
+	 *
+	 * @param userInfo
+	 * @param entityId
+	 * @param versionNumber
+	 * @return
+	 * @throws NotFoundException
+	 * @throws DatastoreException
+	 * @throws UnauthorizedException
+	 */
+	EntityHeader getEntityHeader(UserInfo userInfo, String entityId, Long versionNumber)
 			throws NotFoundException, DatastoreException, UnauthorizedException;
 
 	/**

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/EntityManagerImpl.java
@@ -414,6 +414,12 @@ public class EntityManagerImpl implements EntityManager {
 	}
 
 	@Override
+	public EntityHeader getEntityHeader(UserInfo userInfo, String entityId, Long versionNumber)
+			throws NotFoundException, DatastoreException, UnauthorizedException {
+		return nodeManager.getNodeHeader(userInfo, entityId, versionNumber);
+	}
+
+	@Override
 	public List<EntityHeader> getEntityHeader(UserInfo userInfo, List<Reference> references)
 			throws NotFoundException, DatastoreException, UnauthorizedException {
 		return nodeManager.getNodeHeader(userInfo, references);

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NodeManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NodeManager.java
@@ -227,7 +227,6 @@ public interface NodeManager {
 	 * 
 	 * @param userInfo
 	 * @param entityId
-	 * @param versionNumber
 	 * @return
 	 * @throws NotFoundException
 	 * @throws DatastoreException
@@ -235,6 +234,19 @@ public interface NodeManager {
 	 */
 	public EntityHeader getNodeHeader(UserInfo userInfo, String entityId) throws NotFoundException, DatastoreException, UnauthorizedException;
 	
+	/**
+	 * Get a full header for a version of an entity.
+	 *
+	 * @param userInfo
+	 * @param entityId
+	 * @param versionNumber
+	 * @return
+	 * @throws NotFoundException
+	 * @throws DatastoreException
+	 * @throws UnauthorizedException
+	 */
+	public EntityHeader getNodeHeader(UserInfo userInfo, String entityId, Long versionNumber) throws NotFoundException, DatastoreException, UnauthorizedException;
+
 	/**
 	 * Get an entity header for each reference.
 	 * 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NodeManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NodeManagerImpl.java
@@ -639,6 +639,14 @@ public class NodeManagerImpl implements NodeManager {
 		authorizationManager.hasAccess(userInfo, entityId, ACCESS_TYPE.READ).checkAuthorizationOrElseThrow();
 		return nodeDao.getEntityHeader(entityId);
 	}
+
+	@Override
+	public EntityHeader getNodeHeader(UserInfo userInfo, String entityId, Long versionNumber)
+			throws NotFoundException, DatastoreException, UnauthorizedException {
+		UserInfo.validateUserInfo(userInfo);
+		authorizationManager.hasAccess(userInfo, entityId, ACCESS_TYPE.READ).checkAuthorizationOrElseThrow();
+		return nodeDao.getEntityHeader(entityId, versionNumber);
+	}
 	
 	@Override
 	public List<EntityHeader> getNodeHeader(UserInfo userInfo,

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/EntityService.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/EntityService.java
@@ -426,15 +426,28 @@ public interface EntityService {
 	/**
 	 * Get the type of an entity
 	 * 
-	 * @param userInfo
+	 * @param userId
 	 * @param entityId
-	 * @param vertionNumber (optional) null for current version
 	 * @return
 	 * @throws NotFoundException
 	 * @throws DatastoreException
 	 * @throws UnauthorizedException
 	 */
 	EntityHeader getEntityHeader(Long userId, String entityId)
+			throws NotFoundException, DatastoreException, UnauthorizedException;
+
+	/**
+	 * Get the header for an entity
+	 *
+	 * @param userId
+	 * @param entityId
+	 * @param versionNumber
+	 * @return
+	 * @throws NotFoundException
+	 * @throws DatastoreException
+	 * @throws UnauthorizedException
+	 */
+	EntityHeader getEntityHeader(Long userId, String entityId, Long versionNumber)
 			throws NotFoundException, DatastoreException, UnauthorizedException;
 
 	/**

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/EntityServiceImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/EntityServiceImpl.java
@@ -519,6 +519,12 @@ public class EntityServiceImpl implements EntityService {
 	}
 	
 	@Override
+	public EntityHeader getEntityHeader(Long userId, String entityId, Long versionNumber) throws NotFoundException, DatastoreException, UnauthorizedException {
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		return entityManager.getEntityHeader(userInfo, entityId, versionNumber);
+	}
+	
+	@Override
 	public PaginatedResults<EntityHeader> getEntityHeader(Long userId,
 			List<Reference> references) throws NotFoundException,
 			DatastoreException, UnauthorizedException {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/NodeManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/NodeManagerImplUnitTest.java
@@ -1017,6 +1017,66 @@ public class NodeManagerImplUnitTest {
 	
 	@Test
 	public void testGetNodeHeader(){
+		EntityHeader header = createTestEntityHeaders(1).get(0);
+		String id = header.getId();
+
+		when(mockAuthManager.hasAccess(any(UserInfo.class), eq(id), eq(ACCESS_TYPE.READ))).thenReturn(AuthorizationStatus.authorized());
+		when(mockNodeDao.getEntityHeader(id)).thenReturn(header);
+
+		// Call under test
+		EntityHeader result = nodeManager.getNodeHeader(mockUserInfo, id);
+
+		assertNotNull(result);
+		assertEquals(result, header);
+	}
+
+	@Test
+	public void testGetNodeHeaderUnauthorized(){
+		EntityHeader header = createTestEntityHeaders(1).get(0);
+		String id = header.getId();
+
+		when(mockAuthManager.hasAccess(any(UserInfo.class), eq(id), eq(ACCESS_TYPE.READ))).thenReturn(AuthorizationStatus.accessDenied("Mock unauthorized"));
+
+		// Call under test
+		assertThrows(UnauthorizedException.class, () -> nodeManager.getNodeHeader(mockUserInfo, id));
+
+		verify(mockNodeDao, never()).getEntityHeader(any(String.class));
+	}
+
+	@Test
+	public void testGetNodeHeaderWithVersion(){
+		EntityHeader header = createTestEntityHeaders(1).get(0);
+		String id = header.getId();
+		Long versionNumber = 2L;
+		header.setVersionNumber(versionNumber);
+
+		when(mockAuthManager.hasAccess(any(UserInfo.class), eq(id), eq(ACCESS_TYPE.READ))).thenReturn(AuthorizationStatus.authorized());
+		when(mockNodeDao.getEntityHeader(id, versionNumber)).thenReturn(header);
+
+		// Call under test
+		EntityHeader result = nodeManager.getNodeHeader(mockUserInfo, id, versionNumber);
+
+		assertNotNull(result);
+		assertEquals(result, header);
+	}
+
+	@Test
+	public void testGetNodeHeaderWithVersionUnauthorized(){
+		EntityHeader header = createTestEntityHeaders(1).get(0);
+		String id = header.getId();
+		Long versionNumber = 2L;
+		header.setVersionNumber(versionNumber);
+
+		when(mockAuthManager.hasAccess(any(UserInfo.class), eq(id), eq(ACCESS_TYPE.READ))).thenReturn(AuthorizationStatus.accessDenied("Mock unauthorized"));
+
+		// Call under test
+		assertThrows(UnauthorizedException.class, () -> nodeManager.getNodeHeader(mockUserInfo, id, versionNumber));
+
+		verify(mockNodeDao, never()).getEntityHeader(any(String.class), any(Long.class));
+	}
+
+	@Test
+	public void testGetNodeHeaderList(){
 		List<EntityHeader> allResults = createTestEntityHeaders(3);
 		List<Reference> refs = Lists.newArrayList(new Reference(), new Reference(), new Reference(), new Reference());
 		refs.get(0).setTargetId(allResults.get(0).getId());

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
@@ -317,7 +317,7 @@ public class UrlHelpers {
 	 * The base URL for Synapse objects's type (a.k.a. EntityHeader)
 	 */
 	public static final String ENTITY_ID_TYPE = ENTITY_ID+TYPE;
-	public static final String ENTITY_ID_VERSION_NUMBER_TYPE = ENTITY_ID+VERSION_NUMBER+TYPE;
+	public static final String ENTITY_ID_VERSION_NUMBER_TYPE = ENTITY_ID+VERSION+VERSION_NUMBER+TYPE;
 
 	/**
 	 * All of the base URLs for Synapse objects's Annotations.

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
@@ -317,6 +317,7 @@ public class UrlHelpers {
 	 * The base URL for Synapse objects's type (a.k.a. EntityHeader)
 	 */
 	public static final String ENTITY_ID_TYPE = ENTITY_ID+TYPE;
+	public static final String ENTITY_ID_VERSION_NUMBER_TYPE = ENTITY_ID+VERSION_NUMBER+TYPE;
 
 	/**
 	 * All of the base URLs for Synapse objects's Annotations.

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/EntityController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/EntityController.java
@@ -807,6 +807,29 @@ public class EntityController {
 	}
 
 	/**
+	 * Get the EntityHeader of an Entity given its ID and version number. The EntityHeader is a light
+	 * weight object with basic information about an Entity includes its type.
+	 *
+	 * @param userId
+	 * @param id      The ID of the Entity to get the EntityHeader for.
+	 * @param versionNumber      The version number of the Entity to get the EntityHeader for.
+	 * @param request
+	 * @return
+	 * @throws NotFoundException
+	 * @throws DatastoreException
+	 * @throws UnauthorizedException
+	 */
+	@RequiredScope({ view })
+	@ResponseStatus(HttpStatus.OK)
+	@RequestMapping(value = { UrlHelpers.ENTITY_ID_VERSION_NUMBER_TYPE }, method = RequestMethod.GET)
+	public @ResponseBody EntityHeader getEntityType(
+			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM) Long userId, @PathVariable String id, @PathVariable Long versionNumber,
+			HttpServletRequest request) throws NotFoundException, DatastoreException, UnauthorizedException {
+		// Get the type of an entity by ID.
+		return serviceProvider.getEntityService().getEntityHeader(userId, id, versionNumber);
+	}
+
+	/**
 	 * Get a batch of EntityHeader given multile Entity IDs. The EntityHeader is a
 	 * light weight object with basic information about an Entity includes its type.
 	 * 


### PR DESCRIPTION
[PLFM-7989](https://sagebionetworks.jira.com/issues/PLFM-7989)

Adds a service to get the particular version of an entity header, with error codes on client error. Prior to adding this new service, a versioned header can only be retrieved with batch services, which do not throw a 400-level client error when a header cannot be returned.

[PLFM-7989]: https://sagebionetworks.jira.com/browse/PLFM-7989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ