### PR TITLE
PLFM-9133 Allow Docker registry a wider range of media types in the events sent to Synapse.

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/DockerManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/DockerManagerImpl.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.repo.manager;
 import static org.sagebionetworks.repo.model.util.DockerNameUtil.REPO_NAME_PATH_SEP;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -46,7 +47,11 @@ import io.jsonwebtoken.Jwt;
 @Service
 public class DockerManagerImpl implements DockerManager {
 	
-	public static final String MANIFEST_MEDIA_TYPE = "application/vnd.docker.distribution.manifest.v2+json";
+	public static final List<String> MANIFEST_MEDIA_TYPES = Arrays.asList(new String[] {
+			"application/vnd.docker.distribution.manifest.v2+json",
+			"application/vnd.oci.image.index.v1+json",
+			"application/vnd.oci.image.manifest.v1+json"
+	});
 	
 	@Autowired
 	private NodeDAO nodeDao;
@@ -139,7 +144,8 @@ public class DockerManagerImpl implements DockerManager {
 			case push:
 				//we only care about the notification if it is a manifest push, which contains metadata about the repository
 				//the other type of push would be layer blob pushes ("mediaType": "application/octet-stream"), which we don't care about
-				if(!event.getTarget().getMediaType().equals(MANIFEST_MEDIA_TYPE))
+				String mediaType = event.getTarget().getMediaType();
+				if(!MANIFEST_MEDIA_TYPES.contains(mediaType))
 					continue;
 				
 				// need to make sure this is a registry we support

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/DockerManagerImplAutowiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/DockerManagerImplAutowiredTest.java
@@ -41,7 +41,7 @@ public class DockerManagerImplAutowiredTest {
 	private static final String TYPE = "repository";
 	private static final String TAG = "lastest";
 	private static final String DIGEST = "sha256:10010101";
-	private static final String MEDIA_TYPE = DockerManagerImpl.MANIFEST_MEDIA_TYPE;
+	private static final String MEDIA_TYPE = DockerManagerImpl.MANIFEST_MEDIA_TYPES.get(0);
 	
 	private String repositoryPath;
 	

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/DockerManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/DockerManagerImplUnitTest.java
@@ -83,7 +83,7 @@ public class DockerManagerImplUnitTest {
 	private static final String TAG = "v1";
 	private static final String DIGEST = "sha256:8900ee859c6808c9f83ce51bf44b508df63d1f2e8a839ca230471f1bac90ee19";
 	
-	private static final String MEDIA_TYPE = DockerManagerImpl.MANIFEST_MEDIA_TYPE;
+	private static final String MEDIA_TYPE = "application/vnd.docker.distribution.manifest.v2+json";
 	
 	private static final String OAUTH_ACCESS_TOKEN = "access token";
 	
@@ -220,6 +220,26 @@ public class DockerManagerImplUnitTest {
 		assertEquals(TAG, commit.getTag());
 	}
 
+	@Test
+	public void testDockerRegistryNotificationPushOCIMediaType() {
+		when(nodeDAO.getNodeTypeById(any())).thenReturn(EntityType.project);
+		when(userManager.getUserInfo(any())).thenReturn(USER_INFO);
+		when(entityManager.createEntity(any(), any(), any())).thenReturn(REPO_ENTITY_ID);
+		when(mockConfig.getDockerRegistryHosts()).thenReturn(Arrays.asList(REGISTRY_HOST));
+		when(dockerNodeDao.getEntityIdForRepositoryName(REPOSITORY_NAME)).thenReturn(null);
+
+		String ociMediaType = "application/vnd.oci.image.manifest.v1+json";
+		
+		DockerRegistryEventList events = 
+				DockerRegistryEventUtil.createDockerRegistryEvent(
+						RegistryEventAction.push, REGISTRY_HOST, USER_ID, REPOSITORY_PATH, TAG, DIGEST, ociMediaType);
+		
+		// method under test:
+		dockerManager.dockerRegistryNotification(events);
+		
+		verify(entityManager).createEntity(eq(USER_INFO), (DockerRepository)any(), (String)eq(null));
+	}
+
 	
 	@Test
 	public void testDockerRegistryNotificationPushExistingEntity() {
@@ -295,6 +315,7 @@ public class DockerManagerImplUnitTest {
 		verify(entityManager, never()).createEntity(any(), any(), anyString());
 		verify(dockerCommitDao, never()).createDockerCommit(anyString(), anyLong(), any());
 	}
+	
 	@Test
 	public void testDockerRegistryNotificationMount() {
 		DockerRegistryEventList events = 


### PR DESCRIPTION
Allow Docker registry a wider range of media types in the events sent to Synapse.