### PR TITLE
the bug was caused by the GridReplicaPatchBuilderManagerImpl.getCurre…

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/change/GridReplicaPatchBuilderManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/change/GridReplicaPatchBuilderManagerImpl.java
@@ -6,11 +6,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.sagebionetworks.grid.db.ConstantProvider;
 import org.sagebionetworks.grid.db.GridIndexDao;
 import org.sagebionetworks.repo.manager.grid.PatchUtils;
 import org.sagebionetworks.repo.model.dbo.grid.GridDao;
 import org.sagebionetworks.repo.model.grid.GridConnectionInfo;
+import org.sagebionetworks.repo.model.grid.GridSession;
 import org.sagebionetworks.repo.model.grid.patch.LogicalTimestamp;
 import org.sagebionetworks.util.ValidateArgument;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
@@ -18,6 +21,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class GridReplicaPatchBuilderManagerImpl implements GridReplicaPatchBuilderManager {
+
+	private static final Logger log = LogManager.getLogger(GridReplicaPatchBuilderManagerImpl.class);
 
 	private final GridDao gridDao;
 	private final GridIndexDao gridIndexDao;
@@ -37,6 +42,11 @@ public class GridReplicaPatchBuilderManagerImpl implements GridReplicaPatchBuild
 	@Override
 	public void buildPatch(IntendedChangeSet changeSet) throws IOException {
 		validateChangeSet(changeSet);
+		Optional<GridSession> session = gridDao.getGridSession(changeSet.getSessionId());
+		if (session.isEmpty()) {
+			log.info("No session found for: '{}' the message will be ignored", changeSet.getSessionId());
+			return;
+		}
 
 		Optional<LogicalTimestamp> currentClock = getCurrentClock(changeSet.getSessionId(), changeSet.getReplicaId());
 		if (currentClock.isEmpty()) {
@@ -79,13 +89,12 @@ public class GridReplicaPatchBuilderManagerImpl implements GridReplicaPatchBuild
 	}
 
 	Optional<LogicalTimestamp> getCurrentClock(String sessionId, Long replicaId) {
+		List<LogicalTimestamp> missingPatches = gridDao.listMissingPatchIdsForClock(sessionId,
+				gridIndexDao.getClock(sessionId, replicaId), 1);
+		if (!missingPatches.isEmpty()) {
+			return Optional.empty();
+		}
 		Optional<Long> sequenceNumber = gridIndexDao.getClockSequenceNumber(sessionId, replicaId, replicaId);
-		LogicalTimestamp currentClock = new LogicalTimestamp().setReplicaId(replicaId)
-				.setSequenceNumber(sequenceNumber.orElse(0L));
-
-		List<LogicalTimestamp> missingPatches = gridDao.listMissingPatchIdsForClock(sessionId, List.of(currentClock),
-				1);
-
-		return missingPatches.isEmpty() ? Optional.of(currentClock) : Optional.empty();
+		return Optional.of(new LogicalTimestamp().setReplicaId(replicaId).setSequenceNumber(sequenceNumber.orElse(0L)));
 	}
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImpl.java
@@ -144,6 +144,7 @@ public class GridReplicaValidationManagerImpl implements GridReplicaValidationMa
 	void cleanupValidationResults(ValidationResults validationResults) {
 		validationResults.setValidatedOn(null);
 		validationResults.setSchema$id(null);
+		validationResults.setValidationException(null);
 	}
 
 	/**

--- a/services/workers/src/test/java/org/sagebionetworks/grid/workers/GridEventBrokerWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/grid/workers/GridEventBrokerWorkerIntegrationTest.java
@@ -52,11 +52,14 @@ import org.sagebionetworks.repo.model.grid.CreateReplicaRequest;
 import org.sagebionetworks.repo.model.grid.GridReplica;
 import org.sagebionetworks.repo.model.grid.GridSession;
 import org.sagebionetworks.repo.model.grid.patch.ConType;
+import org.sagebionetworks.repo.model.grid.patch.ConValue;
 import org.sagebionetworks.repo.model.grid.patch.LogicalTimestamp;
 import org.sagebionetworks.repo.model.grid.patch.Patch;
 import org.sagebionetworks.repo.model.grid.patch.compact.LogicalTimestampCompactSerializable;
 import org.sagebionetworks.repo.model.grid.patch.compact.PatchCompactSerializable;
 import org.sagebionetworks.repo.model.grid.patch.operation.NewConstant;
+import org.sagebionetworks.repo.model.grid.patch.operation.builder.InsertVectorBuilder;
+import org.sagebionetworks.repo.model.grid.patch.operation.builder.NewConstantBuilder;
 import org.sagebionetworks.repo.model.schema.CreateOrganizationRequest;
 import org.sagebionetworks.repo.model.schema.CreateSchemaRequest;
 import org.sagebionetworks.repo.model.schema.CreateSchemaResponse;
@@ -409,7 +412,7 @@ public class GridEventBrokerWorkerIntegrationTest {
 			}
 		}, incomingMessagesOne));
 
-		TimeUtils.waitFor(MAX_WAIT_MS, 1000L, () -> {
+		RowView row = TimeUtils.waitFor(MAX_WAIT_MS, 1000L, () -> {
 			System.out.println("Waiting for row validation results to change...");
 			Optional<GridHeader> header = gridViewManager.readHeader(session.getSessionId(), INTERNAL_REPLICA_ID);
 			if (header.isEmpty()) {
@@ -420,8 +423,36 @@ public class GridEventBrokerWorkerIntegrationTest {
 				return Pair.create(false, null);
 			}
 			return Pair.create(new ValidationResults().setIsValid(true).equals(rows.get(0).getRowValidationResults()),
-					null);
+					rows.get(0));
 		});
+
+		Patch updatePatch = new Patch()
+				.setPatchId(new LogicalTimestamp().setReplicaId(replicaOne.getReplicaId()).setSequenceNumber(25L));
+		LogicalTimestamp conId = updatePatch
+				.addNewOperation(new NewConstantBuilder().setValue(new ConValue(ConType.STRING, "wrong-type")));
+		updatePatch.addNewOperation(new InsertVectorBuilder().setVectorId(row.getRowObject().getData().getVectorId())
+				.setMap(Map.of(0, conId)));
+		JSONArray patchBody = PatchCompactSerializable.serialize(updatePatch);
+		wsOne.send(String.format("[1,102,\"patch\", %s]", patchBody.toString()));
+		// Wait for response complete: [5,102]
+		assertTrue(waitForMessage((a) -> a.optInt(0) == 5 && a.optInt(1) == 102, incomingMessagesOne));
+
+		RowView rowUpdated = TimeUtils.waitFor(MAX_WAIT_MS, 1000L, () -> {
+			System.out.println("Waiting for row validation results to change...");
+			Optional<GridHeader> header = gridViewManager.readHeader(session.getSessionId(), INTERNAL_REPLICA_ID);
+			if (header.isEmpty()) {
+				return Pair.create(false, null);
+			}
+			List<RowView> rows = gridViewManager.querySinglePage(header.get(), 100L, 0L);
+			if (rows.size() != 1) {
+				return Pair.create(false, null);
+			}
+			return Pair.create(new ValidationResults().setIsValid(false)
+					.setAllValidationMessages(List.of("#/anInt: expected type: Integer, found: String"))
+					.setValidationErrorMessage("expected type: Integer, found: String")
+					.equals(rows.get(0).getRowValidationResults()), rows.get(0));
+		});
+
 	}
 
 	/**


### PR DESCRIPTION
…ntClock(). Since it the entire clock was not provied to listMissingPatchIdsForClock(), patches from other replicas would always be returned even though they were already applied.  Also added an integration test to detect the bug