### PR TITLE
PLFM-9207

### DIFF
--- a/lib/models/pom.xml
+++ b/lib/models/pom.xml
@@ -120,6 +120,11 @@
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-jackson</artifactId>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcpkix-jdk18on</artifactId>
+		</dependency>
 
 	</dependencies>
 

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/auth/JSONWebTokenHelper.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/auth/JSONWebTokenHelper.java
@@ -9,6 +9,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
 
+import org.bouncycastle.util.BigIntegers;
 import org.sagebionetworks.repo.model.oauth.JsonWebKey;
 import org.sagebionetworks.repo.model.oauth.JsonWebKeyRSA;
 import org.sagebionetworks.repo.model.oauth.JsonWebKeySet;
@@ -24,6 +25,7 @@ import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.SecurityException;
+
 
 public class JSONWebTokenHelper {
 	public static final String RSA = "RSA";
@@ -91,7 +93,7 @@ public class JSONWebTokenHelper {
 	
 	private static BigInteger base64URLEncodedToBigInteger(String s) {
 		byte[] bytes = Base64.getUrlDecoder().decode(s);
-		return new BigInteger(bytes);
+		return BigIntegers.fromUnsignedByteArray(bytes);
 	}
 
 	public static RSAPublicKey getRSAPublicKeyForJsonWebKeyRSA(JsonWebKeyRSA jwkRsa) {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/KeyPairUtil.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/KeyPairUtil.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.commons.codec.binary.Base32;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.BigIntegers;
 import org.sagebionetworks.repo.model.oauth.JsonWebKey;
 import org.sagebionetworks.repo.model.oauth.JsonWebKeyRSA;
 import org.sagebionetworks.repo.model.oauth.JsonWebKeySet;
@@ -112,9 +113,13 @@ public class KeyPairUtil {
 			throw new RuntimeException(e);
 		}
 	}
+	// make sure the representation is unsigned (i.e. no leading zero byte)
+	static byte[] bigIntToBytes(BigInteger i) {
+		return BigIntegers.asUnsignedByteArray(i);
+	}
 
-	private static String bigIntToBase64URLEncoded(BigInteger i) {
-		return Base64.getUrlEncoder().withoutPadding().encodeToString(i.toByteArray());
+	static String bytesToBase64URLEncoded(byte[] b) {
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(b);
 	}
 
 	public static JsonWebKeySet getJSONWebKeySetForPEMEncodedRsaKeys(List<String> pemEncodedKeyPairs) {
@@ -132,8 +137,8 @@ public class KeyPairUtil {
 			rsaKey.setUse(KEY_USE_SIGNATURE);
 			rsaKey.setKid(kid);
 			// these are specific to the RSA algorithm
-			rsaKey.setE(bigIntToBase64URLEncoded(rsaPublicKey.getPublicExponent()));
-			rsaKey.setN(bigIntToBase64URLEncoded(rsaPublicKey.getModulus()));
+			rsaKey.setE(bytesToBase64URLEncoded(bigIntToBytes(rsaPublicKey.getPublicExponent())));
+			rsaKey.setN(bytesToBase64URLEncoded(bigIntToBytes(rsaPublicKey.getModulus())));
 			publicKeys.add(rsaKey);
 		}
 		return jsonWebKeySet;

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/KeyPairUtilTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/KeyPairUtilTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -83,10 +84,13 @@ public class KeyPairUtilTest {
 	
 	@Test
 	public void testGetRSAKeyPairFromPEM() throws Exception {
-		// just make sure we can extract a private/public key pair
+		// make sure we can extract a private/public key pair
 		KeyPair keyPair = KeyPairUtil.getRSAKeyPairFromPrivateKey(DEV_OIDC_SIGNATURE_RSA_PRIVATE_KEY_PEM);
 		assertNotNull(keyPair.getPrivate());
-		assertNotNull(keyPair.getPublic());
+		RSAPublicKey publicKey = (RSAPublicKey)keyPair.getPublic();
+		assertNotNull(publicKey);
+		// make sure modulus is 256 bytes
+		assertEquals(256, KeyPairUtil.bigIntToBytes(publicKey.getModulus()).length);
 	}
 
 	@Test


### PR DESCRIPTION
Aridhia uses Azure B2C as an OAuth client and found that the client fails when the 'modulus' part of the Synapse public key is padding with a leading zero.  This PR corrects the problem by encoding the BigInteger as an 'unsigned' integer, which ensures it's always the correct 256 bytes.