### PR TITLE
PLFM-8871

### DIFF
--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseAdminClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseAdminClient.java
@@ -3,7 +3,6 @@ package org.sagebionetworks.client;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.evaluation.model.SubmissionContributor;
 import org.sagebionetworks.reflection.model.PaginatedResults;
-import org.sagebionetworks.repo.model.BackfillCount;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.asynch.AsynchronousAdminRequestBody;
 import org.sagebionetworks.repo.model.asynch.AsynchronousJobStatus;
@@ -317,12 +316,5 @@ public interface SynapseAdminClient extends SynapseClient {
 	 * @throws SynapseException
 	 */
 	ProjectStorageLocationLimit setProjectStorageLocationLimit(ProjectStorageLocationLimit limit) throws SynapseException;
-	
-	/**
-	 * Create access control lists for legacy OAuth Clients which have none.
-	 * @return the number of new ACLs created
-	 * @throws SynapseException
-	 */
-	BackfillCount backfillOAuthClientACLs() throws SynapseException;
- 
+
 }

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseAdminClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseAdminClientImpl.java
@@ -7,7 +7,6 @@ import org.sagebionetworks.client.exceptions.SynapseClientException;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.evaluation.model.SubmissionContributor;
 import org.sagebionetworks.reflection.model.PaginatedResults;
-import org.sagebionetworks.repo.model.BackfillCount;
 import org.sagebionetworks.repo.model.IdList;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.asynch.AsynchronousAdminRequestBody;
@@ -29,7 +28,6 @@ import org.sagebionetworks.repo.model.migration.MigrationTypeCounts;
 import org.sagebionetworks.repo.model.migration.MigrationTypeList;
 import org.sagebionetworks.repo.model.migration.MigrationTypeNames;
 import org.sagebionetworks.repo.model.oauth.OAuthClient;
-import org.sagebionetworks.repo.model.quiz.PassingRecord;
 import org.sagebionetworks.repo.model.quiz.QuizResponse;
 import org.sagebionetworks.repo.model.status.StackStatus;
 import org.sagebionetworks.simpleHttpClient.SimpleHttpClientConfig;
@@ -413,11 +411,5 @@ public class SynapseAdminClientImpl extends SynapseClientImpl implements Synapse
 	@Override
 	public ProjectStorageLocationLimit setProjectStorageLocationLimit(ProjectStorageLocationLimit limit) throws SynapseException {
 		return putJSONEntity(getRepoEndpoint(), "/project/" + limit.getProjectId() + "/storage/limit", limit, ProjectStorageLocationLimit.class);
-	}
-	
-	@Override
-	public BackfillCount backfillOAuthClientACLs() throws SynapseException {
-		String uri = OAUTH_CLIENT + "/acl/backfill";
-		return postJSONEntity(getAuthEndpoint(), uri, null, BackfillCount.class);
 	}
 }

--- a/integration-test/src/test/java/org/sagebionetworks/ITOpenIDConnectTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITOpenIDConnectTest.java
@@ -31,7 +31,6 @@ import org.sagebionetworks.client.exceptions.SynapseForbiddenException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.client.exceptions.SynapseUnauthorizedException;
 import org.sagebionetworks.repo.model.AccessControlList;
-import org.sagebionetworks.repo.model.BackfillCount;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.auth.JSONWebTokenHelper;
 import org.sagebionetworks.repo.model.oauth.JsonWebKeySet;
@@ -685,11 +684,5 @@ public class ITOpenIDConnectTest {
 
 		assertThrows(SynapseNotFoundException.class, () ->
 				synapse.getRefreshTokenMetadata(tokenId));	
-	}
-	
-	@Test
-	public void testBackfillService() throws Exception {
-		BackfillCount count = adminSynapse.backfillOAuthClientACLs();
-		assertEquals(0L, count.getCount());
 	}
 }

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/auth/OAuthClientDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/auth/OAuthClientDaoImpl.java
@@ -95,13 +95,6 @@ public class OAuthClientDaoImpl implements OAuthClientDao {
 			" ORDER BY oc."+COL_OAUTH_CLIENT_ID+
 			" LIMIT :"+LIMIT_PARAM_NAME+" OFFSET :"+OFFSET_PARAM_NAME+" ";
 	
-	private static final String CLIENT_WITHOUT_ACL_SQL_SELECT = "SELECT oc.*"+
-			" FROM "+TABLE_OAUTH_CLIENT+" oc "+
-			"LEFT OUTER JOIN "+TABLE_ACCESS_CONTROL_LIST+" acl "+
-			" ON oc."+COL_OAUTH_CLIENT_ID+"=acl."+COL_ACL_OWNER_ID+
-			" AND acl."+COL_ACL_OWNER_TYPE+"='OAUTH_CLIENT'"+
-			" WHERE acl."+COL_ACL_ID+" is null";
-	
 	private static final String CLIENT_SECRET_HASH_SQL_SELECT = "SELECT "+COL_OAUTH_CLIENT_SECRET_HASH+
 			" FROM "+TABLE_OAUTH_CLIENT
 			+ " WHERE "+COL_OAUTH_CLIENT_ID+" = ?";
@@ -366,16 +359,4 @@ public class OAuthClientDaoImpl implements OAuthClientDao {
 	private NotFoundException clientNotFoundException(String clientId) {
 		return new NotFoundException("The OAuth client (" + clientId + ") does not exist");
 	}
-	
-	@Override
-	public List<OAuthClient> listClientsWithoutACLs() {
-		List<DBOOAuthClient> dboList = jdbcTemplate.query(CLIENT_WITHOUT_ACL_SQL_SELECT, 
-				(new DBOOAuthClient()).getTableMapping());
-		List<OAuthClient> dtoList = new ArrayList<OAuthClient>();
-		for (DBOOAuthClient dbo : dboList) {
-			dtoList.add(clientDboToDto(dbo));
-		}
-		return dtoList;
-	}
-	
 }

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/auth/OAuthClientDaoImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/auth/OAuthClientDaoImplTest.java
@@ -641,27 +641,5 @@ public class OAuthClientDaoImplTest {
 		assertEquals(0, results.getResults().size());
 		assertNull(results.getNextPageToken());
 	}
-	
-	@Test
-	public void testListClientsWithoutACLs() throws Exception {
-		// create two clients, create one acl
-		Long creatorId = BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId();
-		String clientWithACL = createSectorIdentifierAndClient(SECTOR_IDENTIFIER, 
-				creatorId, CLIENT_NAME);
-		String clientWithoutACL = createSectorIdentifierAndClient(SECOND_SECTOR_IDENTIFIER, 
-				creatorId, "some other client");
-		aclDAO.delete(clientWithoutACL, ObjectType.OAUTH_CLIENT);
-		
-		// method under test
-		List<OAuthClient> clients = oauthClientDao.listClientsWithoutACLs();
-		
-		// should return just the client not having an ACL
-		assertEquals(1, clients.size());
-		
-		OAuthClient actual = clients.get(0);
-		
-		assertEquals(clientWithoutACL, actual.getClient_id());
-		assertEquals(creatorId.toString(), actual.getCreatedBy());
-	}
 
 }

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/BackfillCount.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/BackfillCount.json
@@ -1,8 +1,0 @@
-{
-	"description": "Number of OAuth Client ACLs that have been backfilled.",
-	"properties": {
-		"count": {
-			"type": "integer"
-		}
-	}
-}

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/auth/OAuthClientDao.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/auth/OAuthClientDao.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.repo.model.auth;
 
-import java.util.List;
 import java.util.Set;
 
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
@@ -125,12 +124,4 @@ public interface OAuthClientDao {
 	 * @return a paginated list of clients which have been granted refresh token(s) for the given user.
 	 */
 	OAuthClientAuthorizationHistoryList getAuthorizedClientHistory(String userId, String nextPageToken, Long maxLeaseLengthInDays);
-	
-	/** 
-	 * List the legacy OAuth clients which lack ACLs.
-	 * Since there are only about 200 client, and since this is temporary code,
-	 * we do not paginate.
-	 * @return the IDs of OAuth Clients which lack an ACL
-	 */
-	List<OAuthClient> listClientsWithoutACLs();
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/oauth/OAuthClientManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/oauth/OAuthClientManager.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.repo.manager.oauth;
 
 import org.sagebionetworks.repo.model.AccessControlList;
-import org.sagebionetworks.repo.model.BackfillCount;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.oauth.OAuthClient;
@@ -112,12 +111,4 @@ public interface OAuthClientManager {
 	 * @return true iff the credentials are valid
 	 */
 	boolean validateClientCredentials(OAuthClientIdAndSecret idAndSecret);
-	
-	/**
-	 * Create ACLs for legacy OAuthClients which have none.
-	 * Can only be invoked by a Synapse admin'.
-	 * @param userInfo
-	 * @return the number of ACLs created
-	 */
-	BackfillCount backfillAccessControlLists(UserInfo userInfo);
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/oauth/OAuthClientManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/oauth/OAuthClientManagerImpl.java
@@ -26,13 +26,11 @@ import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.AccessControlListDAO;
 import org.sagebionetworks.repo.model.AuthorizationUtils;
-import org.sagebionetworks.repo.model.BackfillCount;
 import org.sagebionetworks.repo.model.ConflictingUpdateException;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.ResourceAccess;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
-import org.sagebionetworks.repo.model.auth.AuthorizationStatus;
 import org.sagebionetworks.repo.model.auth.OAuthClientDao;
 import org.sagebionetworks.repo.model.auth.SectorIdentifier;
 import org.sagebionetworks.repo.model.dbo.dao.AccessControlListUtils;
@@ -450,21 +448,4 @@ public class OAuthClientManagerImpl implements OAuthClientManager {
 			return false;
 		}
 	}
-	
-	@WriteTransaction
-	@Override
-	public BackfillCount backfillAccessControlLists(UserInfo userInfo) {
-		if (!userInfo.isAdmin()) {
-			throw new UnauthorizedException("Only an administrator can backfill OAuth client ACLs.");
-		}
-		List<OAuthClient> clients = oauthClientDao.listClientsWithoutACLs();
-		for (OAuthClient client: clients) {
-			AccessControlList acl = createAccessControlList(Long.parseLong(client.getCreatedBy()), client.getClient_id());
-			aclDAO.create(acl, ObjectType.OAUTH_CLIENT);
-		}
-		BackfillCount result = new BackfillCount();
-		result.setCount((long)clients.size());
-		return result;
-	}
-
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/OpenIDConnectService.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/OpenIDConnectService.java
@@ -1,7 +1,6 @@
 package org.sagebionetworks.repo.service.auth;
 
 import org.sagebionetworks.repo.model.AccessControlList;
-import org.sagebionetworks.repo.model.BackfillCount;
 import org.sagebionetworks.repo.model.oauth.JsonWebKeySet;
 import org.sagebionetworks.repo.model.oauth.OAuthAuthorizationResponse;
 import org.sagebionetworks.repo.model.oauth.OAuthClient;
@@ -174,6 +173,4 @@ public interface OpenIDConnectService {
 	OAuthRefreshTokenInformation getRefreshTokenMetadataAsUser(Long userId, String tokenId);
 
 	OAuthRefreshTokenInformation getRefreshTokenMetadataAsClient(String verifiedClientId, String tokenId);
-	
-	BackfillCount backfillOauthClientACLs(Long userId);
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/OpenIDConnectServiceImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/OpenIDConnectServiceImpl.java
@@ -11,7 +11,6 @@ import org.sagebionetworks.repo.manager.oauth.OAuthRefreshTokenManager;
 import org.sagebionetworks.repo.manager.oauth.OIDCTokenManager;
 import org.sagebionetworks.repo.manager.oauth.OpenIDConnectManager;
 import org.sagebionetworks.repo.model.AccessControlList;
-import org.sagebionetworks.repo.model.BackfillCount;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.oauth.JsonWebKeySet;
 import org.sagebionetworks.repo.model.oauth.OAuthAuthorizationResponse;
@@ -259,13 +258,6 @@ public class OpenIDConnectServiceImpl implements OpenIDConnectService {
 	@Override
 	public OAuthRefreshTokenInformation getRefreshTokenMetadataAsClient(String verifiedClientId, String tokenId) {
 		return oauthRefreshTokenManager.getRefreshTokenMetadata(verifiedClientId, tokenId);
-	}
-	
-	
-	@Override
-	public BackfillCount backfillOauthClientACLs(Long userId) {
-		UserInfo userInfo = userManager.getUserInfo(userId);
-		return oauthClientManager.backfillAccessControlLists(userInfo);
 	}
 
 }

--- a/services/repository/src/main/java/org/sagebionetworks/auth/controller/OpenIDConnectController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/controller/OpenIDConnectController.java
@@ -9,7 +9,6 @@ import org.sagebionetworks.auth.HttpAuthUtil;
 import org.sagebionetworks.repo.manager.oauth.OAuthClientNotVerifiedException;
 import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
-import org.sagebionetworks.repo.model.BackfillCount;
 import org.sagebionetworks.repo.model.oauth.JsonWebKeySet;
 import org.sagebionetworks.repo.model.oauth.OAuthAuthorizationResponse;
 import org.sagebionetworks.repo.model.oauth.OAuthClient;
@@ -597,19 +596,4 @@ public class OpenIDConnectController {
 			@RequestBody OAuthTokenRevocationRequest revokeRequest) throws NotFoundException {
 		serviceProvider.getOpenIDConnectService().revokeToken(verifiedClientId, revokeRequest);
 	}
-
-	/**
-	 * Backfill OAuth client ACLs.  This service can only be called by a Synapse administrator.
-	 * @param userId
-	 * @return
-	 * @throws NotFoundException
-	 */
-	@RequiredScope({modify})
-	@ResponseStatus(HttpStatus.CREATED)
-	@RequestMapping(value = UrlHelpers.OAUTH_2_CLIENT_ACL_BACKFILL, method = RequestMethod.POST)
-	public @ResponseBody BackfillCount backfillOauthClientACLs(
-			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM) Long userId) throws NotFoundException {
-		return serviceProvider.getOpenIDConnectService().backfillOauthClientACLs(userId);
-	}
-
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
@@ -1232,7 +1232,6 @@ public class UrlHelpers {
 	public static final String OAUTH_2_CLIENT = AUTH_OAUTH_2+"/client";
 	public static final String OAUTH_2_CLIENT_ACL = OAUTH_2_CLIENT+"/{id}/acl";
 	public static final String OAUTH_2_CLIENT_ID_ACL = OAUTH_2_CLIENT+"/{id}/acl";
-	public static final String OAUTH_2_CLIENT_ACL_BACKFILL =  OAUTH_2_CLIENT+"/acl/backfill";
 	
 	public static final String OAUTH_2_CLIENT_ID = OAUTH_2_CLIENT+ID;
 	public static final String OAUTH_2_CLIENT_ID_VERIFICATION_PRECHECK = OAUTH_2_CLIENT+ID+"/verificationPrecheck";


### PR DESCRIPTION
This PR removes the one-time use code for backfilling OAuth client ACLs. All new OAuth clients will have ACLs created when the client is created.