### PR TITLE
Fix bug in OpenAPI spec - Curation Task definition

### DIFF
--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/CurationTaskController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/CurationTaskController.java
@@ -102,7 +102,7 @@ public class CurationTaskController {
     public @ResponseBody
     CurationTask updateCurationTask(
             @RequestParam(value = AuthorizationConstants.USER_ID_PARAM) Long userId,
-            @RequestBody CurationTask curationTask) throws DatastoreException, UnauthorizedException, NotFoundException, InvalidModelException, IOException {
+            @PathVariable Long taskId, @RequestBody CurationTask curationTask) throws DatastoreException, UnauthorizedException, NotFoundException, InvalidModelException, IOException {
         return service.updateCurationTask(userId, curationTask);
     }
 


### PR DESCRIPTION
All path variables must be in the controller method signature, even if unused