### PR TITLE
PLFM-9092 only run build on pushes, not PRs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,8 +13,6 @@
 name: main
 
 on:
-  pull_request:
-    branches: ['*']
   push:
     branches: ['*']
 


### PR DESCRIPTION
OIDC auth' fails on PRs.   Moreover the Synapse team today does not run builds upon PR generation.  So let's remove this condition from the workflow trigger.