### PR TITLE
PLFM-9269: Allow grid creation from another user record set

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/create/RecordSetCreateGridHandler.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/create/RecordSetCreateGridHandler.java
@@ -6,11 +6,13 @@ import java.util.List;
 import java.util.Optional;
 
 import org.sagebionetworks.repo.manager.EntityManager;
+import org.sagebionetworks.repo.manager.entity.EntityAuthorizationManager;
 import org.sagebionetworks.repo.manager.file.CsvFileHandleProvider;
 import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.manager.grid.PatchRowHandler;
 import org.sagebionetworks.repo.manager.grid.PatchStore;
 import org.sagebionetworks.repo.manager.table.UploadPreviewBuilder;
+import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.RecordSet;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.dao.asynch.AsyncJobProgressCallback;
@@ -36,13 +38,15 @@ public class RecordSetCreateGridHandler implements CreateGridHandler {
 	private final GridDao gridDao;
 	private final EntityManager entityManager;
 	private final FileHandleManager fileHandleManager;
+	private final EntityAuthorizationManager authorizationManager;
 	private final CsvFileHandleProvider csvProvider;
 
-	public RecordSetCreateGridHandler(GridDao gridDao, EntityManager entityManager, FileHandleManager fileHandleManager, CsvFileHandleProvider csvProvider) {
+	public RecordSetCreateGridHandler(GridDao gridDao, EntityManager entityManager, FileHandleManager fileHandleManager, EntityAuthorizationManager authorizationManager, CsvFileHandleProvider csvProvider) {
 		super();
 		this.gridDao = gridDao;
 		this.entityManager = entityManager;
 		this.fileHandleManager = fileHandleManager;
+		this.authorizationManager = authorizationManager;
 		this.csvProvider = csvProvider;
 	}
 
@@ -55,8 +59,12 @@ public class RecordSetCreateGridHandler implements CreateGridHandler {
 	public CreateGridHandlerResult createGrid(AsyncJobProgressCallback callback, UserInfo user, CreateGridRequest request,
 			PatchStore patchStore) {
 		String recordSetId = request.getRecordSetId();
+		
 		RecordSet recordSet = entityManager.getEntity(user, recordSetId, RecordSet.class);
-
+		
+		// Makes sure the user has download access
+		authorizationManager.hasAccess(user, recordSet.getId(), ACCESS_TYPE.DOWNLOAD).checkAuthorizationOrElseThrow();
+		
 		Optional<String> validationSchemaId = entityManager.findBoundSchema(recordSetId)
 				.map(binding -> binding.getJsonSchemaVersionInfo().get$id());
 
@@ -65,7 +73,8 @@ public class RecordSetCreateGridHandler implements CreateGridHandler {
 
 		GridReplica replica = gridDao.createReplica(user.getId(), session.getSessionId(), false, EventSource.INTERNAL);
 
-		FileHandle fileHandle = fileHandleManager.getRawFileHandle(user, recordSet.getDataFileHandleId());
+		// We already checked that the user has download access
+		FileHandle fileHandle = fileHandleManager.getRawFileHandleUnchecked(recordSet.getDataFileHandleId());
 
 		CsvTableDescriptor csvDescriptor = recordSet.getCsvDescriptor();
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporterImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporterImpl.java
@@ -72,6 +72,8 @@ public class GridRecordSetExporterImpl implements GridRecordSetExporter {
 		DownloadFromGridRequest request = new DownloadFromGridRequest()
 			.setSessionId(sessionId)
 			.setWriteHeader(true)
+			.setIncludeEtag(false)
+			.setIncludeRowIdAndRowVersion(false)
 			.setCsvTableDescriptor(csvDescriptor);
 		
 		DownloadFromGridResult result;

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/create/RecordSetCreateGridHandlerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/create/RecordSetCreateGridHandlerTest.java
@@ -30,12 +30,15 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.repo.manager.EntityManager;
+import org.sagebionetworks.repo.manager.entity.EntityAuthorizationManager;
 import org.sagebionetworks.repo.manager.file.CsvFileHandleProvider;
 import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.manager.grid.PatchRowHandler;
 import org.sagebionetworks.repo.manager.grid.PatchStore;
+import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.RecordSet;
 import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.model.auth.AuthorizationStatus;
 import org.sagebionetworks.repo.model.dao.asynch.AsyncJobProgressCallback;
 import org.sagebionetworks.repo.model.dbo.grid.CreateGridSession;
 import org.sagebionetworks.repo.model.dbo.grid.GridDao;
@@ -79,6 +82,9 @@ public class RecordSetCreateGridHandlerTest {
 
 	@Mock
 	private FileHandleManager mockFileHandleManager;
+	
+	@Mock
+	private EntityAuthorizationManager mockAuthorizationManager;
 	
 	@Mock
 	private CsvFileHandleProvider mockCsvProvider;
@@ -145,6 +151,7 @@ public class RecordSetCreateGridHandlerTest {
 	public void testBuildSessionFromRecordSet() throws IOException {
 		when(mockUser.getId()).thenReturn(userId);
 		when(mockEntityManager.getEntity(mockUser, recordSet.getId(), RecordSet.class)).thenReturn(recordSet);
+		when(mockAuthorizationManager.hasAccess(mockUser, recordSet.getId(), ACCESS_TYPE.DOWNLOAD)).thenReturn(AuthorizationStatus.authorized());
 		when(mockEntityManager.findBoundSchema(recordSet.getId())).thenReturn(Optional.of(
 				new JsonSchemaObjectBinding().setJsonSchemaVersionInfo(new JsonSchemaVersionInfo().set$id(schema$id))));
 
@@ -156,7 +163,7 @@ public class RecordSetCreateGridHandlerTest {
 
 		when(mockGridDao.createReplica(userId, gridSessionId, isAgent, EventSource.INTERNAL)).thenReturn(replica);
 
-		when(mockFileHandleManager.getRawFileHandle(mockUser, recordSet.getDataFileHandleId())).thenReturn(csvFile);
+		when(mockFileHandleManager.getRawFileHandleUnchecked(recordSet.getDataFileHandleId())).thenReturn(csvFile);
 
 		Long maxRowSize = (long) TableModelUtils.calculateMaxRowSize(csvSchema);
 
@@ -188,6 +195,7 @@ public class RecordSetCreateGridHandlerTest {
 	public void testBuildSessionFromRecordSetWithNoValidationSchema() throws IOException {
 		when(mockUser.getId()).thenReturn(userId);
 		when(mockEntityManager.getEntity(mockUser, recordSet.getId(), RecordSet.class)).thenReturn(recordSet);
+		when(mockAuthorizationManager.hasAccess(mockUser, recordSet.getId(), ACCESS_TYPE.DOWNLOAD)).thenReturn(AuthorizationStatus.authorized());
 		when(mockEntityManager.findBoundSchema(recordSet.getId())).thenReturn(Optional.empty());
 
 		gridSession = new GridSession().setSessionId(gridSessionId);
@@ -197,7 +205,7 @@ public class RecordSetCreateGridHandlerTest {
 
 		when(mockGridDao.createReplica(userId, gridSessionId, isAgent, EventSource.INTERNAL)).thenReturn(replica);
 
-		when(mockFileHandleManager.getRawFileHandle(mockUser, recordSet.getDataFileHandleId())).thenReturn(csvFile);
+		when(mockFileHandleManager.getRawFileHandleUnchecked(recordSet.getDataFileHandleId())).thenReturn(csvFile);
 
 		Long maxRowSize = (long) TableModelUtils.calculateMaxRowSize(csvSchema);
 
@@ -231,6 +239,7 @@ public class RecordSetCreateGridHandlerTest {
 
 		when(mockUser.getId()).thenReturn(userId);
 		when(mockEntityManager.getEntity(mockUser, recordSet.getId(), RecordSet.class)).thenReturn(recordSet);
+		when(mockAuthorizationManager.hasAccess(mockUser, recordSet.getId(), ACCESS_TYPE.DOWNLOAD)).thenReturn(AuthorizationStatus.authorized());
 		when(mockEntityManager.findBoundSchema(recordSet.getId())).thenReturn(Optional.empty());
 
 		gridSession = new GridSession().setSessionId(gridSessionId);
@@ -240,7 +249,7 @@ public class RecordSetCreateGridHandlerTest {
 
 		when(mockGridDao.createReplica(userId, gridSessionId, isAgent, EventSource.INTERNAL)).thenReturn(replica);
 
-		when(mockFileHandleManager.getRawFileHandle(mockUser, recordSet.getDataFileHandleId())).thenReturn(csvFile);
+		when(mockFileHandleManager.getRawFileHandleUnchecked(recordSet.getDataFileHandleId())).thenReturn(csvFile);
 
 		Long maxRowSize = (long) TableModelUtils.calculateMaxRowSize(csvSchema);
 
@@ -273,6 +282,7 @@ public class RecordSetCreateGridHandlerTest {
 	public void testBuildSessionFromRecordSetWithIOException() throws IOException {
 		when(mockUser.getId()).thenReturn(userId);
 		when(mockEntityManager.getEntity(mockUser, recordSet.getId(), RecordSet.class)).thenReturn(recordSet);
+		when(mockAuthorizationManager.hasAccess(mockUser, recordSet.getId(), ACCESS_TYPE.DOWNLOAD)).thenReturn(AuthorizationStatus.authorized());
 		when(mockEntityManager.findBoundSchema(recordSet.getId())).thenReturn(Optional.empty());
 
 		gridSession = new GridSession().setSessionId(gridSessionId);
@@ -282,7 +292,7 @@ public class RecordSetCreateGridHandlerTest {
 
 		when(mockGridDao.createReplica(userId, gridSessionId, isAgent, EventSource.INTERNAL)).thenReturn(replica);
 
-		when(mockFileHandleManager.getRawFileHandle(mockUser, recordSet.getDataFileHandleId())).thenReturn(csvFile);
+		when(mockFileHandleManager.getRawFileHandleUnchecked(recordSet.getDataFileHandleId())).thenReturn(csvFile);
 
 		IOException ioe = new IOException("nope");
 
@@ -313,6 +323,7 @@ public class RecordSetCreateGridHandlerTest {
 	public void testBuildSessionFromRecordSetWithEmptyCsvSchema() throws IOException {
 		when(mockUser.getId()).thenReturn(userId);
 		when(mockEntityManager.getEntity(mockUser, recordSet.getId(), RecordSet.class)).thenReturn(recordSet);
+		when(mockAuthorizationManager.hasAccess(mockUser, recordSet.getId(), ACCESS_TYPE.DOWNLOAD)).thenReturn(AuthorizationStatus.authorized());
 		when(mockEntityManager.findBoundSchema(recordSet.getId())).thenReturn(Optional.empty());
 
 		gridSession = new GridSession().setSessionId(gridSessionId);
@@ -322,7 +333,7 @@ public class RecordSetCreateGridHandlerTest {
 
 		when(mockGridDao.createReplica(userId, gridSessionId, isAgent, EventSource.INTERNAL)).thenReturn(replica);
 
-		when(mockFileHandleManager.getRawFileHandle(mockUser, recordSet.getDataFileHandleId())).thenReturn(csvFile);
+		when(mockFileHandleManager.getRawFileHandleUnchecked(recordSet.getDataFileHandleId())).thenReturn(csvFile);
 
 		csvSchema = Collections.emptyList();
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporterImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporterImplTest.java
@@ -100,6 +100,8 @@ public class GridRecordSetExporterImplTest {
 		DownloadFromGridRequest expectdDownloadRequest = new DownloadFromGridRequest()
 			.setSessionId(sessionId)
 			.setWriteHeader(true)
+			.setIncludeEtag(false)
+			.setIncludeRowIdAndRowVersion(false)
 			.setCsvTableDescriptor(csvDescriptor);
 		
 		when(mockCsvExporter.exportGridAsCsv(eq(user), eq(expectdDownloadRequest), eq(mockJobCallback), any(ValidationSummaryBuilder.class)))


### PR DESCRIPTION
Allows the creation of a grid from any record set that the user has download access to (since we need to read the content of the record set in order to instantiate the grid).