### PR TITLE
when the agent requests to filter rows based on the user's selection,…

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/handler/ReturnControlEvent.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/handler/ReturnControlEvent.java
@@ -79,21 +79,26 @@ public class ReturnControlEvent {
 		JSONObject object = new JSONObject();
 		try {
 			requestBodyParameters.forEach(p -> {
-				if ("object".equals(p.getType())) {
-					object.put(p.getName(), new JSONObject(p.getValue()));
-				} else if ("string".equals(p.getType())) {
-					object.put(p.getName(), p.getValue());
-				} else if ("integer".equals(p.getType())) {
-					object.put(p.getName(), p.getValue());
-				} else if ("array".equals(p.getType())) {
-					object.put(p.getName(), new JSONArray(p.getValue()));
-				} else {
-					throw new IllegalArgumentException("Unknown type: " + p.getType());
+				try {
+					if ("object".equals(p.getType())) {
+						object.put(p.getName(), new JSONObject(p.getValue()));
+					} else if ("string".equals(p.getType())) {
+						object.put(p.getName(), p.getValue());
+					} else if ("integer".equals(p.getType())) {
+						object.put(p.getName(), p.getValue());
+					} else if ("array".equals(p.getType())) {
+						object.put(p.getName(), new JSONArray(p.getValue()));
+					} else {
+						throw new IllegalArgumentException("Unknown type: " + p.getType());
+					}
+				} catch (JSONException e) {
+					throw new IllegalArgumentException("Failed to parse the JSON value for parameter '" 
+						+ p.getName() + "' with value: " + p.getValue() + ". Error: " + e.getMessage(), e);
 				}
 			});
 			return object.toString();
-		} catch (JSONException e) {
-			throw new IllegalArgumentException("Failed to parse the JSON request body: " + e.getMessage(), e);
+		} catch (IllegalArgumentException e) {
+			throw e;
 		}
 	}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/handler/grid/GridQueryRequestHandler.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/handler/grid/GridQueryRequestHandler.java
@@ -52,14 +52,14 @@ public class GridQueryRequestHandler implements OpenApiReturnControlHandler {
 				event.getRequestBody().get());
 		ValidateArgument.required(request.getQuery(), "request.query");
 		QueryElement element = new QueryElement(request.getQuery());
-		
+
 		GridAgentSessionContext context = event.getSessionContext(GridAgentSessionContext.class)
 				.orElseThrow(() -> new IllegalArgumentException("GridAgentSessionContext cannot be null"));
-		GridConnectionInfo connection = gridDao
-				.getSingletonConnection(context.getGridSessionId(), EventSource.INTERNAL)
+		GridConnectionInfo connection = gridDao.getSingletonConnection(context.getGridSessionId(), EventSource.INTERNAL)
 				.orElseThrow(() -> new IllegalArgumentException("Cannot get a grid connection."));
 
-		GridHeader header = viewManager.readHeader(context.getGridSessionId(), connection.getReplicaId())
+		GridHeader header = viewManager
+				.readHeader(context.getGridSessionId(), connection.getReplicaId(), context.getUsersReplicaId())
 				.orElseThrow(() -> new IllegalArgumentException("Grid session does not exist"));
 		QueryResult results = viewManager.querySinglePageAsQueryResult(header, element);
 		String json = JDOSecondaryPropertyUtils.createJSONFromObject(results);

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/model/RowView.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/model/RowView.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.repo.manager.grid.internal.replica.model;
 import java.util.Objects;
 
 import org.json.JSONArray;
+import org.sagebionetworks.repo.model.grid.CrdtId;
 import org.sagebionetworks.repo.model.grid.patch.LogicalTimestamp;
 import org.sagebionetworks.repo.model.schema.ValidationResults;
 
@@ -68,6 +69,10 @@ public class RowView {
 
 	public SynapseRow getSynapseRow() {
 		return rowObject != null ? rowObject.getSynapseRow() : null;
+	}
+	
+	public static CrdtId createCrdtIdFromLogical(LogicalTimestamp timestamp) {
+		return new CrdtId().setRep(timestamp.getReplicaId()).setSeq(timestamp.getSequenceNumber());
 	}
 
 	@Override

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/view/GridReplicaViewManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/view/GridReplicaViewManager.java
@@ -27,6 +27,16 @@ public interface GridReplicaViewManager {
 	Optional<GridHeader> readHeader(String gridSessionId, Long replicaId);
 
 	/**
+	 * Read the header for the given replica.
+	 * @param gridSessionId
+	 * @param replicaId      The ID of the internal replica to be queried.
+	 * @param usersReplicaId The ID of the user's replica, used to filter rows based
+	 *                       on the user's selection in their active replica.
+	 * @return
+	 */
+	Optional<GridHeader> readHeader(String gridSessionId, Long replicaId, Long usersReplicaId);
+
+	/**
 	 * Query for a single page of rows with all columns selected without a where
 	 * clause ('select * from grid123').
 	 * 
@@ -49,31 +59,33 @@ public interface GridReplicaViewManager {
 	 * @return
 	 */
 	List<RowView> querySinglePage(GridHeader header, List<FilterElement> filters, Long limit, Long offset);
-	
+
 	/**
 	 * Query for a single page of rows using the provided query.
+	 * 
 	 * @param header
 	 * @param query
 	 * @return
 	 */
 	List<RowView> querySinglePage(GridHeader header, QueryElement query);
-	
+
 	/**
 	 * Query for a single page with the results return as a query result.
+	 * 
 	 * @param header
 	 * @param query
 	 * @return
 	 */
 	QueryResult querySinglePageAsQueryResult(GridHeader header, QueryElement query);
-	
 
-
-    /**
-     * Returns an iterator that can be used to retrieve and stream through a grid session's query results.
-     * @param header
-     * @param filters
-     * @return
-     */
-    Iterator<RowView> getQueryIterator(GridHeader header, List<FilterElement> filters);
+	/**
+	 * Returns an iterator that can be used to retrieve and stream through a grid
+	 * session's query results.
+	 * 
+	 * @param header
+	 * @param filters
+	 * @return
+	 */
+	Iterator<RowView> getQueryIterator(GridHeader header, List<FilterElement> filters);
 
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/view/GridReplicaViewManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/view/GridReplicaViewManagerImpl.java
@@ -162,9 +162,14 @@ public class GridReplicaViewManagerImpl implements GridReplicaViewManager {
 		return new PaginationIterator<>(
 				(long limit, long offset) -> this.querySinglePage(header, filters, limit, offset), ROWS_PER_PAGE);
 	}
-
+	
 	@Override
 	public Optional<GridHeader> readHeader(String gridSessionId, Long replicaId) {
+		return readHeader(gridSessionId, replicaId, null);
+	}
+
+	@Override
+	public Optional<GridHeader> readHeader(String gridSessionId, Long replicaId, Long usersReplicaId) {
 		Optional<ObjectNode> rootOpt = gridIndexDao.getRootObject(gridSessionId, replicaId);
 		if (rootOpt.isEmpty()) {
 			return Optional.empty();
@@ -173,11 +178,11 @@ public class GridReplicaViewManagerImpl implements GridReplicaViewManager {
 		List<LogicalTimestamp> constantIds = new ArrayList<>();
 		LogicalTimestamp selectionId = root.getValue().get("selection");
 		LogicalTimestamp selectionConId = null;
-		if (selectionId != null) {
+		if (selectionId != null && usersReplicaId != null) {
 			List<ObjectNode> selections = gridIndexDao.getObjects(gridSessionId, replicaId, List.of(selectionId));
 			if (selections.size() == 1) {
 				ObjectNode selectionNode = selections.get(0);
-				selectionConId = selectionNode.getValue().get(replicaId.toString());
+				selectionConId = selectionNode.getValue().get(usersReplicaId.toString());
 				if(selectionConId != null) {
 					constantIds.add(selectionConId);
 				}
@@ -284,5 +289,7 @@ public class GridReplicaViewManagerImpl implements GridReplicaViewManager {
 		}
 		return obs;
 	}
+
+
 
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/handler/ReturnControlEventTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/handler/ReturnControlEventTest.java
@@ -74,7 +74,7 @@ public class ReturnControlEventTest {
 			event.getRequestBody();
 		}).getMessage();
 		assertEquals(
-				"Failed to parse the JSON request body: A JSONObject text must begin with '{' at 1 [character 2 line 1]",
+				"Failed to parse the JSON value for parameter 'three' with value: [123]. Error: A JSONObject text must begin with '{' at 1 [character 2 line 1]",
 				message);
 	}
 	

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/view/GridReplicaViewManagerImplAutowireTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/view/GridReplicaViewManagerImplAutowireTest.java
@@ -152,12 +152,13 @@ public class GridReplicaViewManagerImplAutowireTest {
 
 		// add a selection model to the gird
 		ReplicaSelectionModel selection = new ReplicaSelectionModel().setRowSelectAll(true).setColumnSelectAll(false);
-		Long maxSeq = setSelection(expected.getNodeId(), selection, replicaId);
+		Long otherReplica = 765L;
+		Long maxSeq = setSelection(expected.getNodeId(), selection, otherReplica);
 
 		expected.setReplicaSelectionModel(selection);
 		expected.setClockSequenceMaximum(maxSeq);
 		// call under test
-		assertEquals(Optional.of(expected), gridViewManager.readHeader(sessionId, replicaId));
+		assertEquals(Optional.of(expected), gridViewManager.readHeader(sessionId, replicaId, otherReplica));
 		
 		// set a different replica to be selected.
 		maxSeq = setSelection(expected.getNodeId(), selection, 333L);
@@ -769,8 +770,9 @@ public class GridReplicaViewManagerImplAutowireTest {
 		ReplicaSelectionModel selection = new ReplicaSelectionModel()
 				.setRowSelection(List.of(createCrdtIdFromLogical(allRows.get(1).getArrNodeId()),
 						createCrdtIdFromLogical(allRows.get(3).getArrNodeId())));
-		setSelection(header.getNodeId(), selection, replicaId);
-		header = gridViewManager.readHeader(sessionId, replicaId).get();
+		Long otherReplica = 987L;
+		setSelection(header.getNodeId(), selection, otherReplica);
+		header = gridViewManager.readHeader(sessionId, replicaId, otherReplica).get();
 
 		// call under test
 		assertEquals(List.of(allRows.get(1), allRows.get(3)),
@@ -785,8 +787,8 @@ public class GridReplicaViewManagerImplAutowireTest {
 								.setLimit(100L).setOffset(0L)));
 
 		selection = new ReplicaSelectionModel().setRowSelectAll(true);
-		setSelection(header.getNodeId(), selection, replicaId);
-		header = gridViewManager.readHeader(sessionId, replicaId).get();
+		setSelection(header.getNodeId(), selection, otherReplica);
+		header = gridViewManager.readHeader(sessionId, replicaId, otherReplica).get();
 
 		assertEquals(allRows,
 				gridViewManager.querySinglePage(header,

--- a/services/workers/src/test/java/org/sagebionetworks/AsynchronousJobWorkerHelper.java
+++ b/services/workers/src/test/java/org/sagebionetworks/AsynchronousJobWorkerHelper.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks;
 
+import org.java_websocket.WebSocket;
+import org.json.JSONArray;
 import org.sagebionetworks.AsynchronousJobWorkerHelperImpl.AsyncJobResponse;
 import org.sagebionetworks.repo.model.AsynchJobFailedException;
 import org.sagebionetworks.repo.model.UserInfo;
@@ -24,9 +26,12 @@ import org.sagebionetworks.repo.model.table.TableEntity;
 import org.sagebionetworks.repo.model.table.VirtualTable;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 public interface AsynchronousJobWorkerHelper {
 
@@ -307,5 +312,28 @@ public interface AsynchronousJobWorkerHelper {
 	 * @return
 	 */
 	Organization getOrCreateOrganization(Long userId, String name);
+
+	/**
+	 * Create a websocket connection that will post all received messages to the
+	 * passed queue.
+	 * 
+	 * @param presignedUrl
+	 * @param incomingMessages
+	 * @return
+	 * @throws URISyntaxException
+	 */
+	WebSocket createConnection(String presignedUrl, BlockingQueue<String> incomingMessages) throws URISyntaxException;
+
+	/**
+	 * Wait for the given message to appear on the queue.
+	 * 
+	 * @param code
+	 * @param key
+	 * @param incomingMessages
+	 * @return
+	 * @throws InterruptedException
+	 */
+	boolean waitForMessage(Predicate<JSONArray> handler, BlockingQueue<String> incomingMessages)
+			throws InterruptedException;
 
 }

--- a/services/workers/src/test/java/org/sagebionetworks/AsynchronousJobWorkerHelperImpl.java
+++ b/services/workers/src/test/java/org/sagebionetworks/AsynchronousJobWorkerHelperImpl.java
@@ -1,8 +1,33 @@
 package org.sagebionetworks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.java_websocket.WebSocket;
+import org.java_websocket.client.WebSocketClient;
+import org.json.JSONArray;
 import org.sagebionetworks.aws.SynapseS3Client;
 import org.sagebionetworks.repo.manager.EntityManager;
 import org.sagebionetworks.repo.manager.asynch.AsynchJobStatusManager;
@@ -68,23 +93,6 @@ import org.sagebionetworks.util.Pair;
 import org.sagebionetworks.util.TimeUtils;
 import org.sagebionetworks.util.ValidateArgument;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class AsynchronousJobWorkerHelperImpl implements AsynchronousJobWorkerHelper {
 
@@ -702,5 +710,91 @@ public class AsynchronousJobWorkerHelperImpl implements AsynchronousJobWorkerHel
 			return jsonSchemaService.createOrganization(userId,
 					new CreateOrganizationRequest().setOrganizationName(name));
 		}
+	}
+	
+	/**
+	 * Create a websocket connection that will post all received messages to the
+	 * passed queue.
+	 * 
+	 * @param presignedUrl
+	 * @param incomingMessages
+	 * @return
+	 * @throws URISyntaxException
+	 */
+	@Override
+	public WebSocket createConnection(String presignedUrl, BlockingQueue<String> incomingMessages)
+			throws URISyntaxException {
+		WebSocketImpl client = new WebSocketImpl(presignedUrl, incomingMessages);
+
+		try {
+			client.connectBlocking();
+		} catch (InterruptedException e) {
+			throw new RuntimeException("Failed to connect to WebSocket: " + presignedUrl, e);
+		}
+
+		return client;
+	}
+
+	public static class WebSocketImpl extends WebSocketClient {
+
+		private BlockingQueue<String> incomingMessages;
+
+		public WebSocketImpl(String url, BlockingQueue<String> incomingMessages) {
+			super(URI.create(url));
+			this.incomingMessages = incomingMessages;
+		}
+
+		@Override
+		public void onOpen(org.java_websocket.handshake.ServerHandshake handshakedata) {
+			LOG.info("WebSocket connection opened: {}, ", handshakedata.getHttpStatusMessage());
+		}
+
+		@Override
+		public void onClose(int code, String reason, boolean remote) {
+			LOG.info("WebSocket connection closed with code: {}, reason: {}", code, reason);
+		}
+
+		@Override
+		public void onError(Exception ex) {
+			LOG.error("WebSocket error: ", ex);
+		}
+
+		@Override
+		public void onMessage(String message) {
+			LOG.info("Message received: {}", message);
+			try {
+				incomingMessages.put(message);
+			} catch (InterruptedException e) {
+				this.close(4999);
+				throw new RuntimeException(e);
+			}
+		}
+
+	}
+	
+	/**
+	 * Wait for the given message to appear on the websocket queue.
+	 * 
+	 * @param code
+	 * @param key
+	 * @param incomingMessages
+	 * @return
+	 * @throws InterruptedException
+	 */
+	@Override
+	public boolean waitForMessage(Predicate<JSONArray> handler, BlockingQueue<String> incomingMessages)
+			throws InterruptedException {
+		String message = null;
+		do {
+			message = incomingMessages.poll(10, TimeUnit.SECONDS);
+			if (message == null) {
+				return false;
+			}
+			JSONArray array = new JSONArray(message);
+			if (handler.test(array)) {
+				return true;
+			}
+		} while (message != null);
+		return false;
 	}
 }

--- a/services/workers/src/test/java/org/sagebionetworks/agent/worker/GridAgentChatWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/agent/worker/GridAgentChatWorkerIntegrationTest.java
@@ -7,8 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.FileWriter;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
+import org.java_websocket.WebSocket;
+import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,12 +38,25 @@ import org.sagebionetworks.repo.model.agent.CreateAgentSessionRequest;
 import org.sagebionetworks.repo.model.agent.GridAgentSessionContext;
 import org.sagebionetworks.repo.model.entity.BindSchemaToEntityRequest;
 import org.sagebionetworks.repo.model.file.S3FileHandle;
+import org.sagebionetworks.repo.model.grid.CrdtId;
 import org.sagebionetworks.repo.model.grid.CreateGridPresignedUrlRequest;
 import org.sagebionetworks.repo.model.grid.CreateGridRequest;
 import org.sagebionetworks.repo.model.grid.CreateGridResponse;
 import org.sagebionetworks.repo.model.grid.CreateReplicaRequest;
 import org.sagebionetworks.repo.model.grid.GridReplica;
 import org.sagebionetworks.repo.model.grid.GridSession;
+import org.sagebionetworks.repo.model.grid.ReplicaSelectionModel;
+import org.sagebionetworks.repo.model.grid.message.JsonRxMessage;
+import org.sagebionetworks.repo.model.grid.message.JsonRxMessageType;
+import org.sagebionetworks.repo.model.grid.patch.ConType;
+import org.sagebionetworks.repo.model.grid.patch.ConValue;
+import org.sagebionetworks.repo.model.grid.patch.LogicalTimestamp;
+import org.sagebionetworks.repo.model.grid.patch.Patch;
+import org.sagebionetworks.repo.model.grid.patch.compact.PatchCompactSerializable;
+import org.sagebionetworks.repo.model.grid.patch.operation.builder.InsertObjectBuilder;
+import org.sagebionetworks.repo.model.grid.patch.operation.builder.NewConstantBuilder;
+import org.sagebionetworks.repo.model.grid.patch.operation.builder.NewObjectBuilder;
+import org.sagebionetworks.repo.model.jdo.JDOSecondaryPropertyUtils;
 import org.sagebionetworks.repo.model.schema.CreateSchemaRequest;
 import org.sagebionetworks.repo.model.schema.CreateSchemaResponse;
 import org.sagebionetworks.repo.model.schema.JsonSchema;
@@ -173,6 +191,8 @@ public class GridAgentChatWorkerIntegrationTest {
 						.setGridSessionId(gridSession.getSessionId()).setReplicaId(replicaOne.getReplicaId()))
 				.getPresignedUrl();
 		assertNotNull(urlOne);
+		BlockingQueue<String> incomingMessages = new LinkedBlockingQueue<>();
+		WebSocket websoceket = asynchronousJobWorkerHelper.createConnection(urlOne, incomingMessages);
 
 		GridAgentSessionContext context = new GridAgentSessionContext().setGridSessionId(replicaOne.getGridSessionId())
 				.setUsersReplicaId(replicaOne.getReplicaId());
@@ -208,6 +228,53 @@ public class GridAgentChatWorkerIntegrationTest {
 							assertTrue(response.getResponseText().toLowerCase().contains("4"));
 						}, MAX_WAIT_MS)
 				.getResponse();
+
+		// setup the user's selection.
+		GridHeader header = gridReplicaViewManager.readHeader(gridSession.getSessionId(), INTERNAL_REPLICA_ID).get();
+		List<RowView> rows = gridReplicaViewManager.querySinglePage(header, 100L, 0L);
+
+		JsonRxMessage message = createSetSelectionMessage(header,
+				new ReplicaSelectionModel()
+						.setRowSelection(List.of(RowView.createCrdtIdFromLogical(rows.get(2).getArrNodeId()))),
+				new LogicalTimestamp().setReplicaId(context.getUsersReplicaId()).setSequenceNumber(1L));
+		websoceket.send(message.toJson());
+		asynchronousJobWorkerHelper.waitForMessage((a) -> a.optInt(0) == 5 && a.optInt(1) == message.getId().get(),
+				incomingMessages);
+		TimeUtils.waitFor(MAX_WAIT_MS, 1000L, () -> {
+			ReplicaSelectionModel curSelection = gridReplicaViewManager
+					.readHeader(gridSession.getSessionId(), INTERNAL_REPLICA_ID, context.getUsersReplicaId()).get().getReplicaSelectionModel();
+			return Pair.create(curSelection != null, null);
+		});
+		
+		chatRequest = "I want to focus on my currently selected row.  Why is this row invalid?";
+		asynchronousJobWorkerHelper
+				.assertJobResponse(admin, new AgentChatRequest().setSessionId(agentSession.getSessionId())
+						.setChatText(chatRequest).setEnableTrace(true), (AgentChatResponse response) -> {
+							assertNotNull(response);
+							assertEquals(agentSession.getSessionId(), response.getSessionId());
+							assertNotNull(response.getResponseText());
+							System.out.println(response.getResponseText());
+							assertTrue(response.getResponseText().toLowerCase().contains("null"));
+							assertTrue(response.getResponseText().toLowerCase().contains("no id"));
+						}, MAX_WAIT_MS)
+				.getResponse();
+	}
+
+	public JsonRxMessage createSetSelectionMessage(GridHeader header, ReplicaSelectionModel selection,
+			LogicalTimestamp clock) {
+		LogicalTimestamp rootObjId = header.getNodeId();
+		Patch patch = new Patch();
+		patch.setPatchId(clock);
+		LogicalTimestamp selectionObj = patch.addNewOperation(new NewObjectBuilder());
+		JSONObject selectionJson = JDOSecondaryPropertyUtils.createJSONObjectForEntity(selection);
+		LogicalTimestamp conId = patch
+				.addNewOperation(new NewConstantBuilder().setValue(new ConValue(ConType.JSON_OBJECT, selectionJson)));
+		patch.addNewOperation(new InsertObjectBuilder().setObjectId(selectionObj)
+				.setMap(Map.of(clock.getReplicaId().toString(), conId)));
+		patch.addNewOperation(
+				new InsertObjectBuilder().setObjectId(rootObjId).setMap(Map.of("selection", selectionObj)));
+		return new JsonRxMessage(JsonRxMessageType.RequestData).setBody(PatchCompactSerializable.serialize(patch))
+				.setId(987).setMethod("patch");
 	}
 
 	/**

--- a/services/workers/src/test/java/org/sagebionetworks/grid/workers/GridEventBrokerWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/grid/workers/GridEventBrokerWorkerIntegrationTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -19,15 +18,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.http.entity.ContentType;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.java_websocket.WebSocket;
-import org.java_websocket.client.WebSocketClient;
 import org.json.JSONArray;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -113,8 +108,6 @@ import au.com.bytecode.opencsv.CSVReader;
 public class GridEventBrokerWorkerIntegrationTest {
 
 	private static final long INTERNAL_REPLICA_ID = 66534L;
-
-	private static final Logger LOG = LogManager.getLogger(GridEventBrokerWorkerIntegrationTest.class);
 
 	public static final long MAX_WAIT_MS = 120_000;
 
@@ -836,18 +829,7 @@ public class GridEventBrokerWorkerIntegrationTest {
 	 */
 	boolean waitForMessage(Predicate<JSONArray> handler, BlockingQueue<String> incomingMessages)
 			throws InterruptedException {
-		String message = null;
-		do {
-			message = incomingMessages.poll(10, TimeUnit.SECONDS);
-			if (message == null) {
-				return false;
-			}
-			JSONArray array = new JSONArray(message);
-			if (handler.test(array)) {
-				return true;
-			}
-		} while (message != null);
-		return false;
+		return asynchronousJobWorkerHelper.waitForMessage(handler, incomingMessages);
 	}
 
 	/**
@@ -861,52 +843,7 @@ public class GridEventBrokerWorkerIntegrationTest {
 	 */
 	public WebSocket createConnection(String presignedUrl, BlockingQueue<String> incomingMessages)
 			throws URISyntaxException {
-		WebSocketImpl client = new WebSocketImpl(presignedUrl, incomingMessages);
-
-		try {
-			client.connectBlocking();
-		} catch (InterruptedException e) {
-			throw new RuntimeException("Failed to connect to WebSocket: " + presignedUrl, e);
-		}
-
-		return client;
-	}
-
-	public static class WebSocketImpl extends WebSocketClient {
-
-		private BlockingQueue<String> incomingMessages;
-
-		public WebSocketImpl(String url, BlockingQueue<String> incomingMessages) {
-			super(URI.create(url));
-			this.incomingMessages = incomingMessages;
-		}
-
-		@Override
-		public void onOpen(org.java_websocket.handshake.ServerHandshake handshakedata) {
-			LOG.info("WebSocket connection opened: {}, ", handshakedata.getHttpStatusMessage());
-		}
-
-		@Override
-		public void onClose(int code, String reason, boolean remote) {
-			LOG.info("WebSocket connection closed with code: {}, reason: {}", code, reason);
-		}
-
-		@Override
-		public void onError(Exception ex) {
-			LOG.error("WebSocket error: ", ex);
-		}
-
-		@Override
-		public void onMessage(String message) {
-			LOG.info("Message received: {}", message);
-			try {
-				incomingMessages.put(message);
-			} catch (InterruptedException e) {
-				this.close(4999);
-				throw new RuntimeException(e);
-			}
-		}
-
+		return asynchronousJobWorkerHelper.createConnection(presignedUrl, incomingMessages);
 	}
 
 }


### PR DESCRIPTION
… the correct replicaID is used in the filter.  Also, when the agent provides invalid JSON requests, we now include the provided value in our error response to the agent.  This change seems to result in the agent correcting the problem after a single failure.