### PR TITLE
PLFM-9274: Cleanup temp tables after import

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImportDao.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImportDao.java
@@ -4,16 +4,15 @@ import java.util.Iterator;
 
 public interface GridCsvImportDao {
 	
-	String TEMP_TABLE_CSV_DATA = "TEMP_CSV_DATA";
-	String TEMP_TABLE_GRID_DATA = "TEMP_GRID_DATA";
+	void streamToCsvTempTable(String sessionId, DataStream dataIterator, ColumnMapping[] columnMapping);
 	
-	void streamToCsvTempTable(DataStream dataIterator, ColumnMapping[] columnMapping);
+	void streamToGridTempTable(String sessionId, DataStream dataIterator, ColumnMapping[] columnMapping);
 	
-	void streamToGridTempTable(DataStream dataIterator, ColumnMapping[] columnMapping);
+	Iterator<Object[]> getCsvTempTableIterator(String sessionId);
 	
-	Iterator<Object[]> getCsvTempTableIterator();
+	Iterator<Object[]> getGridTempTableIterator(String sessionId);
 	
-	Iterator<Object[]> getGridTempTableIterator();
+	Iterator<JoinedRow> getJoinedTempTableIterator(String sessionId, ColumnMapping[] columnMapping);
 	
-	Iterator<JoinedRow> getJoinedTempTableIterator(ColumnMapping[] columnMapping);
+	void dropTemporaryTables(String sessionId);
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImportDaoImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImportDaoImpl.java
@@ -9,6 +9,7 @@ import java.util.stream.IntStream;
 
 import org.json.JSONArray;
 import org.sagebionetworks.grid.db.GridTransaction;
+import org.sagebionetworks.repo.model.grid.GridUtils;
 import org.sagebionetworks.repo.model.grid.patch.LogicalTimestamp;
 import org.sagebionetworks.repo.model.grid.patch.compact.LogicalTimestampCompactSerializable;
 import org.sagebionetworks.repo.model.table.ColumnConstants;
@@ -20,7 +21,16 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public class GridCsvImportDaoImpl implements GridCsvImportDao {
-
+	
+	private static enum TempTableType {
+		CSV,
+		GRID;
+		
+		String tableName(String sessionId) {
+			return "T_" + name() + "_" + GridUtils.gridSessionIdAsLong(sessionId);
+		}
+	}
+	
 	private static final String COL_EXTRA = "EXTRA";
 
 	private static String getUpsertKeyColumnName(int index) {
@@ -37,31 +47,31 @@ public class GridCsvImportDaoImpl implements GridCsvImportDao {
 
 	@Override
 	@GridTransaction(readOnly = false)
-	public void streamToCsvTempTable(DataStream dataStream, ColumnMapping[] columnMapping) {
-		streamToTempTable(TEMP_TABLE_CSV_DATA, dataStream, columnMapping);
+	public void streamToCsvTempTable(String sessionId, DataStream dataStream, ColumnMapping[] columnMapping) {
+		streamToTempTable(TempTableType.CSV.tableName(sessionId), dataStream, columnMapping);
 	}
 
 	@Override
 	@GridTransaction(readOnly = false)
-	public void streamToGridTempTable(DataStream dataStream, ColumnMapping[] columnMapping) {
-		streamToTempTable(TEMP_TABLE_GRID_DATA, dataStream, columnMapping);
+	public void streamToGridTempTable(String sessionId, DataStream dataStream, ColumnMapping[] columnMapping) {
+		streamToTempTable(TempTableType.GRID.tableName(sessionId), dataStream, columnMapping);
 	}
 
 	@Override
 	@GridTransaction(readOnly = true)
-	public PaginationIterator<Object[]> getCsvTempTableIterator() {
-		return getTempTableIterator(TEMP_TABLE_CSV_DATA);
+	public PaginationIterator<Object[]> getCsvTempTableIterator(String sessionId) {
+		return getTempTableIterator(TempTableType.CSV.tableName(sessionId));
 	}
 
 	@Override
 	@GridTransaction(readOnly = true)
-	public PaginationIterator<Object[]> getGridTempTableIterator() {
-		return getTempTableIterator(TEMP_TABLE_GRID_DATA);
+	public PaginationIterator<Object[]> getGridTempTableIterator(String sessionId) {
+		return getTempTableIterator(TempTableType.GRID.tableName(sessionId));
 	}
 	
 	@Override
 	@GridTransaction(readOnly = true)
-	public PaginationIterator<JoinedRow> getJoinedTempTableIterator(ColumnMapping[] columnMapping) {
+	public PaginationIterator<JoinedRow> getJoinedTempTableIterator(String sessionId, ColumnMapping[] columnMapping) {
 		List<ColumnMapping> csvUpsertColumns = Arrays.stream(columnMapping).filter(ColumnMapping::isUpsertColumn).collect(Collectors.toList());
 
 		StringJoiner joinConditions = new StringJoiner(" AND ");
@@ -76,7 +86,7 @@ public class GridCsvImportDaoImpl implements GridCsvImportDao {
 		});
 		
 		String sql = String.format("SELECT C.*, G." + COL_EXTRA + " FROM " 
-				+ TEMP_TABLE_CSV_DATA + " C LEFT JOIN " + TEMP_TABLE_GRID_DATA + " G ON (%s) ORDER BY %s"
+				+ TempTableType.CSV.tableName(sessionId) + " C LEFT JOIN " + TempTableType.GRID.tableName(sessionId) + " G ON (%s) ORDER BY %s"
 				+ " LIMIT ? OFFSET ?", joinConditions.toString(), orderByColumns.toString());
 
 		return new PaginationIterator<>((limit, offset) -> jdbcTemplate.query(sql.toString(), (rs, rowNum) -> {
@@ -106,6 +116,14 @@ public class GridCsvImportDaoImpl implements GridCsvImportDao {
 
 			return new JoinedRow(csvData, gridRowVecId);
 		}, limit, offset), BATCH_SIZE);
+	}
+	
+	@Override
+	@GridTransaction(readOnly = false)
+	public void dropTemporaryTables(String sessionId) {
+		for (TempTableType type : TempTableType.values()) {
+			dropTemporaryTable(type.tableName(sessionId));
+		}
 	}
 
 	void streamToTempTable(String tableName, DataStream dataStream, ColumnMapping[] columnMapping) {
@@ -229,6 +247,10 @@ public class GridCsvImportDaoImpl implements GridCsvImportDao {
 		String sql = "CREATE TEMPORARY TABLE " + tableName + " (" + columnDefinitions.toString() + ")";
 
 		jdbcTemplate.update(sql);
+	}
+	
+	void dropTemporaryTable(String tableName) {
+		jdbcTemplate.update("DROP TEMPORARY TABLE IF EXISTS " + tableName);
 	}
 
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImporterImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImporterImpl.java
@@ -73,31 +73,36 @@ public class GridCsvImporterImpl implements GridCsvImporter {
 
 		ColumnMapping[] columnMapping;
 		
-		// First create a temporary table containing the CSV data
-		try (CSVReader csvReader = csvProvider.getCsvReader(user, request.getFileHandleId(), request.getCsvDescriptor())) {
+		try {
+			// First create a temporary table containing the CSV data
+			try (CSVReader csvReader = csvProvider.getCsvReader(user, request.getFileHandleId(), request.getCsvDescriptor())) {
+				
+				// We need to make sure that the schema is sorted according to the potential CSV header
+				validateHeader(csvReader, request.getSchema());
+				
+				// Computes the driving column mapping
+				columnMapping = getColumnMapping(upsertKey, request.getSchema(), gridHeader.getOrderedColumns());
+				
+				importDao.streamToCsvTempTable(gridSession.getSessionId(), new CsvDataStream(csvReader, columnMapping), columnMapping);
+			} catch(IllegalArgumentException e) {
+				throw e;
+			} catch (IOException ex) {
+				throw new IllegalStateException(ex);
+			}
 			
-			// We need to make sure that the schema is sorted according to the potential CSV header
-			validateHeader(csvReader, request.getSchema());
+			Iterator<RowView> gridDataIterator = gridViewManager.getQueryIterator(gridHeader, Collections.emptyList());
 			
-			// Computes the driving column mapping
-			columnMapping = getColumnMapping(upsertKey, request.getSchema(), gridHeader.getOrderedColumns());
+			// Now create a temporary table containing the grid data
+			importDao.streamToGridTempTable(gridSession.getSessionId(), new GridDataStream(gridDataIterator, columnMapping), columnMapping);
 			
-			importDao.streamToCsvTempTable(new CsvDataStream(csvReader, columnMapping), columnMapping);
-		} catch(IllegalArgumentException e) {
-			throw e;
-		} catch (IOException ex) {
-			throw new IllegalStateException(ex);
+			// Now join the two temporary tables to determine which rows are new and which rows are updates
+			Iterator<JoinedRow> joinResult = importDao.getJoinedTempTableIterator(gridSession.getSessionId(), columnMapping);
+			
+			return changePublisher.processJoinedRows(gridHeader, publisherConnInfo, joinResult, columnMapping);
+		
+		} finally {
+			importDao.dropTemporaryTables(gridSession.getSessionId());
 		}
-		
-		Iterator<RowView> gridDataIterator = gridViewManager.getQueryIterator(gridHeader, Collections.emptyList());
-		
-		// Now create a temporary table containing the grid data
-		importDao.streamToGridTempTable(new GridDataStream(gridDataIterator, columnMapping), columnMapping);
-		
-		// Now join the two temporary tables to determine which rows are new and which rows are updates
-		Iterator<JoinedRow> joinResult = importDao.getJoinedTempTableIterator(columnMapping);
-		
-		return changePublisher.processJoinedRows(gridHeader, publisherConnInfo, joinResult, columnMapping);
 	}
 	
 	void validateHeader(CSVReader reader, List<ColumnModel> schema) throws IOException {		

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImportDaoImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImportDaoImplTest.java
@@ -109,11 +109,11 @@ public class GridCsvImportDaoImplTest {
 		
 		DataStream gridDataStream = new GridDataStream(rowView, columnMapping);
 		
-		importDao.streamToGridTempTable(gridDataStream, columnMapping);
+		importDao.streamToGridTempTable(sessionId, gridDataStream, columnMapping);
 		
 		System.out.println("Grid import took: " + (System.currentTimeMillis() - start) + "ms");
 		
-		Iterator<Object[]> it = importDao.getGridTempTableIterator();
+		Iterator<Object[]> it = importDao.getGridTempTableIterator(sessionId);
 		
 		long rowId = 0;
 		Long rowVecId = 22L;
@@ -136,12 +136,12 @@ public class GridCsvImportDaoImplTest {
 		CsvDataStream csvDataStream = new CsvDataStream(reader, columnMapping);
 		
 		try (reader) {
-			importDao.streamToCsvTempTable(csvDataStream, columnMapping);
+			importDao.streamToCsvTempTable(sessionId, csvDataStream, columnMapping);
 		}
 
 		System.out.println("CSV import took: " + (System.currentTimeMillis() - start) + "ms");
 		
-		it = importDao.getCsvTempTableIterator();
+		it = importDao.getCsvTempTableIterator(sessionId);
 		rowId = 0;
 		
 		while (it.hasNext()) {
@@ -159,7 +159,7 @@ public class GridCsvImportDaoImplTest {
 	
 		start = System.currentTimeMillis();
 		
-		Iterator<JoinedRow> joinIt = importDao.getJoinedTempTableIterator(columnMapping);
+		Iterator<JoinedRow> joinIt = importDao.getJoinedTempTableIterator(sessionId, columnMapping);
 		
 		int notMatchedCount = 0;
 		
@@ -195,6 +195,8 @@ public class GridCsvImportDaoImplTest {
 		
 		// The CSV has only 50% of the rows in common with the grid
 		assertEquals(gridRowCount/2 + (csvRowCount - gridRowCount), notMatchedCount);
+		
+		importDao.dropTemporaryTables(sessionId);
 	}
 	
 	void writeGridData() throws IOException {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImporterImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImporterImplTest.java
@@ -266,6 +266,8 @@ public class GridCsvImporterImplTest {
 			importer.importCsv(user, request, mockCallback);
 		}).getMessage());
 		
+		verify(mockImportDao).dropTemporaryTables(sessionId);
+		
 		verifyNoMoreInteractions(mockImportDao);
 	}
 	
@@ -287,6 +289,8 @@ public class GridCsvImporterImplTest {
 			// Call under test
 			importer.importCsv(user, request, mockCallback);
 		}).getMessage());
+		
+		verify(mockImportDao).dropTemporaryTables(sessionId);
 		
 		verifyNoMoreInteractions(mockImportDao);
 	}
@@ -311,6 +315,8 @@ public class GridCsvImporterImplTest {
 			importer.importCsv(user, request, mockCallback);
 		}).getMessage());
 		
+		verify(mockImportDao).dropTemporaryTables(sessionId);
+		
 		verifyNoMoreInteractions(mockImportDao);
 	}
 	
@@ -328,6 +334,8 @@ public class GridCsvImporterImplTest {
 			// Call under test
 			importer.importCsv(user, request, mockCallback);
 		}).getMessage());
+		
+		verify(mockImportDao).dropTemporaryTables(sessionId);
 		
 		verifyNoMoreInteractions(mockImportDao);
 	}
@@ -351,6 +359,8 @@ public class GridCsvImporterImplTest {
 			importer.importCsv(user, request, mockCallback);
 		}).getMessage());
 		
+		verify(mockImportDao).dropTemporaryTables(sessionId);
+		
 		verifyNoMoreInteractions(mockImportDao);
 	}
 	
@@ -361,20 +371,20 @@ public class GridCsvImporterImplTest {
 		when(mockGridReplicaSupport.getRecordSetOrThrow(user, session)).thenReturn(recordSet);
 		when(mockCsvProvider.getCsvReader(user, request.getFileHandleId(), descriptor)).thenReturn(csvReader(csvContent));
 		when(mockGridViewManager.getQueryIterator(gridHeader, Collections.emptyList())).thenReturn(gridRows.iterator());
-		when(mockImportDao.getJoinedTempTableIterator(any())).thenReturn(joinedRows.iterator());
+		when(mockImportDao.getJoinedTempTableIterator(eq(sessionId), any())).thenReturn(joinedRows.iterator());
 		when(mockChangePublisher.processJoinedRows(eq(gridHeader), eq(connectionInfo), any(), any())).thenReturn(response);
 	}
 
 	private void verifyImportSequence(ColumnMapping[] expectedMapping) {
-		verify(mockImportDao).streamToCsvTempTable(streamCaptor.capture(), eq(expectedMapping));
+		verify(mockImportDao).streamToCsvTempTable(eq(sessionId), streamCaptor.capture(), eq(expectedMapping));
 		
 		assertTrue(streamCaptor.getValue() instanceof CsvDataStream);
 
-		verify(mockImportDao).streamToGridTempTable(streamCaptor.capture(), eq(expectedMapping));
+		verify(mockImportDao).streamToGridTempTable(eq(sessionId), streamCaptor.capture(), eq(expectedMapping));
 
 		assertTrue(streamCaptor.getValue() instanceof GridDataStream);
 		
-		verify(mockImportDao).getJoinedTempTableIterator(expectedMapping);
+		verify(mockImportDao).getJoinedTempTableIterator(sessionId, expectedMapping);
 	
 		verify(mockChangePublisher).processJoinedRows(eq(gridHeader), eq(connectionInfo), joinedRowCaptor.capture(), eq(expectedMapping));
 		
@@ -383,6 +393,8 @@ public class GridCsvImporterImplTest {
 		joinedRowCaptor.getValue().forEachRemaining(capturedJoinedRows::add);
 
 		assertEquals(joinedRows, capturedJoinedRows);
+		
+		verify(mockImportDao).dropTemporaryTables(sessionId);
 	}
 	
 	private CSVReader csvReader(String csvContent) {


### PR DESCRIPTION
Temporary tables are tied to a session, but they need to be cleaned up since we use a connection pool where a connection might be reused. I also tied the name of the temporary tables to the grid session for good measure.