### PR TITLE
PLFM-9217

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManager.java
@@ -118,9 +118,11 @@ public interface MessageManager {
 	 *                            {@link AliasType#USER_EMAIL} falls back to the default notification
 	 *                            email of the user that owns the given alias. The principal id in the
 	 *                            alias must match the user id of the signed token
+	 * @param usernameOrEmail the handle used to identify the user.  If it is a valid email address for
+	 *                            the user, then the password reset email will be sent to this address.
 	 */
 	void sendNewPasswordResetEmail(String passwordResetPrefix, PasswordResetSignedToken passwordResetToken,
-			PrincipalAlias alias) throws NotFoundException;
+			PrincipalAlias alias, String usernameOrEmail) throws NotFoundException;
 
 	/**
 	 * Send an email confirming to user that their password has been changed

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/MessageManagerImpl.java
@@ -571,7 +571,7 @@ public class MessageManagerImpl implements MessageManager {
 	@Override
 	@WriteTransaction
 	public void sendNewPasswordResetEmail(String passwordResetUrlPrefix, PasswordResetSignedToken passwordResetToken,
-			PrincipalAlias alias) {
+			PrincipalAlias alias, String usernameOrEmail) {
 		ValidateArgument.required(passwordResetToken, "passwordResetToken");
 		ValidateArgument.required(passwordResetUrlPrefix, "passwordResetPrefix");
 		ValidateArgument.required(alias, "alias");
@@ -584,6 +584,12 @@ public class MessageManagerImpl implements MessageManager {
 
 		String resetUrl = getPasswordResetUrl(passwordResetUrlPrefix, passwordResetToken);
 		String email = getEmailForAlias(alias);
+
+		PrincipalAlias paForEmail = principalAliasDAO.findPrincipalWithAlias(usernameOrEmail, AliasType.USER_EMAIL);
+		if (paForEmail != null && paForEmail.getPrincipalId().equals(alias.getPrincipalId())) {
+			email = usernameOrEmail;
+		}
+
 		
 		if (emailQuarantineDao.isQuarantined(email)) {
 			logQuarantinedAddress("password reset email", email);

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImpl.java
@@ -142,7 +142,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 		try {
 			PrincipalAlias principalAlias = userManager.lookupUserByUsernameOrEmail(usernameOrEmail);
 			PasswordResetSignedToken passwordRestToken = authManager.createPasswordResetToken(principalAlias.getPrincipalId());
-			messageManager.sendNewPasswordResetEmail(passwordResetUrlPrefix, passwordRestToken, principalAlias);
+			messageManager.sendNewPasswordResetEmail(passwordResetUrlPrefix, passwordRestToken, principalAlias, usernameOrEmail);
 		} catch (NotFoundException e) {
 			// should not indicate that a email/user could not be found
 		}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/MessageManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/MessageManagerImplUnitTest.java
@@ -496,7 +496,7 @@ public class MessageManagerImplUnitTest {
 
 		String synapsePrefix = "https://synapse.org/";
 		String alternateEmailAddress = "baz@somewhere.org";
-		recipientEmailAlias.setPrincipalId(RECIPIENT_ID+100); // not a valid emails for
+		recipientEmailAlias.setPrincipalId(RECIPIENT_ID+100); // not a valid email for recipient
 		when(principalAliasDAO.findPrincipalWithAlias(alternateEmailAddress, AliasType.USER_EMAIL)).thenReturn(recipientEmailAlias);
 
 		// method under test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/MessageManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/MessageManagerImplUnitTest.java
@@ -386,7 +386,7 @@ public class MessageManagerImplUnitTest {
 
 		String synapsePrefix = "https://synapse.org/";
 
-		messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientUsernameAlias);
+		messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientUsernameAlias, recipientUsernameAlias.getAlias());
 		
 		ArgumentCaptor<SendRawEmailRequest> argument = ArgumentCaptor.forClass(SendRawEmailRequest.class);
 		verify(sesClient).sendRawEmail(argument.capture());
@@ -412,7 +412,7 @@ public class MessageManagerImplUnitTest {
 		String synapsePrefix = "https://synapse.org/";
 
 		Assertions.assertThrows(QuarantinedEmailException.class, ()-> {
-			messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientUsernameAlias);
+			messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientUsernameAlias, recipientUsernameAlias.getAlias());
 		});
 		
 		verify(mockEmailQuarantineDao).isQuarantined(RECIPIENT_EMAIL);
@@ -429,7 +429,7 @@ public class MessageManagerImplUnitTest {
 
 		String synapsePrefix = "https://synapse.org/";
 
-		messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientEmailAlias);
+		messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientEmailAlias, recipientEmailAlias.getAlias());
 
 		ArgumentCaptor<SendRawEmailRequest> argument = ArgumentCaptor.forClass(SendRawEmailRequest.class);
 		verify(sesClient).sendRawEmail(argument.capture());
@@ -456,10 +456,59 @@ public class MessageManagerImplUnitTest {
 		recipientEmailAlias.setType(AliasType.USER_EMAIL);
 
 		Assertions.assertThrows(IllegalArgumentException.class, ()-> {			
-			messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientEmailAlias);
+			messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientEmailAlias, recipientEmailAlias.getAlias());
 		});
 	}
+	
+	@Test
+	public void testSendNewPassowrdResetEmailWithAlternateEmailAddress() throws Exception {
+		when(principalAliasDAO.getUserName(RECIPIENT_ID)).thenReturn("bar");
+		when(notificationEmailDao.getNotificationEmailForPrincipal(RECIPIENT_ID)).thenReturn(RECIPIENT_EMAIL);		
+		when(userProfileManager.getUserProfile(RECIPIENT_ID.toString())).thenReturn(userProfileRecipient);
+		
+		PasswordResetSignedToken token = new PasswordResetSignedToken();
+		token.setUserId(Long.toString(RECIPIENT_ID));
 
+		String synapsePrefix = "https://synapse.org/";
+		String alternateEmailAddress = "baz@somewhere.org";
+		when(principalAliasDAO.findPrincipalWithAlias(alternateEmailAddress, AliasType.USER_EMAIL)).thenReturn(recipientEmailAlias);
+
+		// method under test
+		messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientUsernameAlias, alternateEmailAddress);
+		
+		ArgumentCaptor<SendRawEmailRequest> argument = ArgumentCaptor.forClass(SendRawEmailRequest.class);
+		verify(sesClient).sendRawEmail(argument.capture());
+		SendRawEmailRequest ser = argument.getValue();
+		assertEquals(1, ser.getDestinations().size());
+		assertEquals(alternateEmailAddress, ser.getDestinations().get(0));
+	}
+	
+
+
+	@Test
+	public void testSendNewPassowrdResetEmailWithWrongAlternateEmailAddress() throws Exception {
+		when(principalAliasDAO.getUserName(RECIPIENT_ID)).thenReturn("bar");
+		when(notificationEmailDao.getNotificationEmailForPrincipal(RECIPIENT_ID)).thenReturn(RECIPIENT_EMAIL);		
+		when(userProfileManager.getUserProfile(RECIPIENT_ID.toString())).thenReturn(userProfileRecipient);
+		
+		PasswordResetSignedToken token = new PasswordResetSignedToken();
+		token.setUserId(Long.toString(RECIPIENT_ID));
+
+		String synapsePrefix = "https://synapse.org/";
+		String alternateEmailAddress = "baz@somewhere.org";
+		recipientEmailAlias.setPrincipalId(RECIPIENT_ID+100); // not a valid emails for
+		when(principalAliasDAO.findPrincipalWithAlias(alternateEmailAddress, AliasType.USER_EMAIL)).thenReturn(recipientEmailAlias);
+
+		// method under test
+		messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientUsernameAlias, alternateEmailAddress);
+		
+		// email will go to primary email (RECIPIENT_EMAIL)
+		ArgumentCaptor<SendRawEmailRequest> argument = ArgumentCaptor.forClass(SendRawEmailRequest.class);
+		verify(sesClient).sendRawEmail(argument.capture());
+		SendRawEmailRequest ser = argument.getValue();
+		assertEquals(1, ser.getDestinations().size());
+		assertEquals(RECIPIENT_EMAIL, ser.getDestinations().get(0));
+	}
 
 	@Test
 	public void testSendNewPasswordResetEmail_DisallowedSnapsePrefix() throws Exception{
@@ -467,7 +516,7 @@ public class MessageManagerImplUnitTest {
 		token.setUserId(Long.toString(RECIPIENT_ID));
 		String synapsePrefix = "https://NOTsynapse.org/";
 		Assertions.assertThrows(IllegalArgumentException.class, ()-> {			
-			messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientUsernameAlias);
+			messageManager.sendNewPasswordResetEmail(synapsePrefix, token, recipientUsernameAlias, recipientUsernameAlias.getAlias());
 		});
 	}
 	

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
@@ -643,7 +643,7 @@ public class AuthenticationServiceImplTest {
 
 		verify(mockUserManager).lookupUserByUsernameOrEmail(email);
 		verify(mockAuthenticationManager).createPasswordResetToken(principalAlias.getPrincipalId());
-		verify(mockMessageManager).sendNewPasswordResetEmail(passwordResetUrlPrefix, token, principalAlias);
+		verify(mockMessageManager).sendNewPasswordResetEmail(passwordResetUrlPrefix, token, principalAlias, email);
 	}
 
 	@Test
@@ -658,7 +658,7 @@ public class AuthenticationServiceImplTest {
 		verify(mockUserManager).lookupUserByUsernameOrEmail(email);
 		//expect no errors to be throw but the token should never be generated and sent
 		verify(mockAuthenticationManager, never()).createPasswordResetToken(anyLong());
-		verify(mockMessageManager, never()).sendNewPasswordResetEmail(anyString(), any(), any());
+		verify(mockMessageManager, never()).sendNewPasswordResetEmail(anyString(), any(), any(), any());
 	}
 	
 	@Test
@@ -675,7 +675,7 @@ public class AuthenticationServiceImplTest {
 		
 		verify(mockUserManager).lookupUserByUsernameOrEmail(aliasEmail);
 		verify(mockAuthenticationManager).createPasswordResetToken(principalEmailAlias.getPrincipalId());
-		verify(mockMessageManager).sendNewPasswordResetEmail(passwordResetUrlPrefix, token, principalEmailAlias);	
+		verify(mockMessageManager).sendNewPasswordResetEmail(passwordResetUrlPrefix, token, principalEmailAlias, principalEmailAlias.getAlias());
 	}
 	
 	@Test


### PR DESCRIPTION
Allow a user to specify which of their registered email addresses a password reset email should go to.