### PR TITLE
PLFM-9253

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,11 +15,7 @@ name: main
 
 on:
   push:
-    branches:
-      - '*'
-    tags:
-      - '[0-9]+'
-      - '[0-9]+\.[0-9]'
+    branches: ['*']
 
 # let only one copy of the workflow run at a time
 concurrency:
@@ -76,9 +72,9 @@ jobs:
             if [[ $branch == "develop" ]]; then
               GIT_COMMIT=${{ github.sha }}
               ARTIFACT_VERSION=$(date +%Y-%m-%d_%H-%M)"_"${GIT_COMMIT:0:7}
-            fi
-            if [[ ${GITHUB_REF:0:10} == "refs/tags/" ]]; then
-              ARTIFACT_VERSION="${GITHUB_REF#refs/tags/}"
+            #elif [[ $branch =~ "release-" ]]; then
+            elif [[ $branch =~ "PLFM-9253" ]]; then
+              ARTIFACT_VERSION=$(git describe --tags)
             fi
           fi
           if [[ $ARTIFACT_VERSION ]]; then

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,8 @@ on:
     branches:
       - '*'
     tags:
-      - '*'
+      - '[0-9]+'
+      - '[0-9]+\.[0-9]'
 
 # let only one copy of the workflow run at a time
 concurrency:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,7 +71,8 @@ jobs:
           echo "full_build=${{ vars.FULL_BUILD }}" >> $GITHUB_ENV
           echo "EXTRA_ARGS=${{ vars.EXTRA_ARGS }}" >> $GITHUB_ENV
           # for builds in Sage-Bionetworks repo', publish build artifacts
-          if [[ $GITHUB_REPOSITORY_OWNER == "Sage-Bionetworks" ]]; then
+          #if [[ $GITHUB_REPOSITORY_OWNER == "Sage-Bionetworks" ]]; then
+          if [[ "true" ]]; then
             if [[ $branch == "develop" ]]; then
               GIT_COMMIT=${{ github.sha }}
               ARTIFACT_VERSION=$(date +%Y-%m-%d_%H-%M)"_"${GIT_COMMIT:0:7}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,7 @@ on:
     branches:
       - '*'
     tags:
-      - '[0-9]+(\.[0-9])?'
+      - '*'
 
 # let only one copy of the workflow run at a time
 concurrency:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # Fetch all history for git commands to work correctly
 
       - name: Static Analysis
         uses: pre-commit/action@v3.0.0
@@ -74,7 +76,8 @@ jobs:
               ARTIFACT_VERSION=$(date +%Y-%m-%d_%H-%M)"_"${GIT_COMMIT:0:7}
             #elif [[ $branch =~ "release-" ]]; then
             elif [[ $branch =~ "PLFM-9253" ]]; then
-              ARTIFACT_VERSION=$(git describe --tags)
+              git fetch --tags
+              ARTIFACT_VERSION=$(git describe --tags --abbrev=0)
             fi
           fi
           if [[ $ARTIFACT_VERSION ]]; then

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,6 +16,7 @@ name: main
 on:
   push:
     branches: ['*']
+    tags: ['*']
 
 # let only one copy of the workflow run at a time
 concurrency:
@@ -42,13 +43,6 @@ jobs:
       - name: Static Analysis
         uses: pre-commit/action@v3.0.0
 
-      - name: Find latest tag
-        id: find_tag
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dry_run: true #setting to 'true' means no new version is created
-
       - run: |
           # get the 'user' parameter, either from the repo' env or repo' owner if not set
           if [ ${{ vars.USER }} ]; then
@@ -74,19 +68,28 @@ jobs:
           echo "full_build=${{ vars.FULL_BUILD }}" >> $GITHUB_ENV
           echo "EXTRA_ARGS=${{ vars.EXTRA_ARGS }}" >> $GITHUB_ENV
           # for builds in Sage-Bionetworks repo', publish build artifacts
-          if [[ $GITHUB_REPOSITORY_OWNER == "Sage-Bionetworks" ]]; then
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          # if [[ $GITHUB_REPOSITORY_OWNER == "Sage-Bionetworks" ]]; then
+          if [[ true ]]; then
             if [[ $branch == "develop" ]]; then
               GIT_COMMIT=${{ github.sha }}
               ARTIFACT_VERSION=$(date +%Y-%m-%d_%H-%M)"_"${GIT_COMMIT:0:7}
-            elif [[ $branch =~ "release-" ]]; then
-              ARTIFACT_VERSION=${{ steps.find_tag.outputs.previous_version }}
+            fi
+            if [[ $TAG_NAME ]]; then
+              ARTIFACT_VERSION=$TAG_NAME
             fi
           fi
           if [[ $ARTIFACT_VERSION ]]; then
-            echo Build will publish artifacts with version $ARTIFACT_VERSION
             echo "ARTIFACT_VERSION=$ARTIFACT_VERSION" >> $GITHUB_ENV
+          fi
+
+      - id: display-artifact-version
+        name: Display Artifact Version
+        run: |
+          if [[ $ARTIFACT_VERSION ]]; then
+            echo "Build will publish artifacts with version" $ARTIFACT_VERSION
           else
-            echo "Build will not publish artifacts"
+            echo "Artifacts will not be published for this build"
           fi
 
       - id: oidc

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,13 +69,11 @@ jobs:
           echo "full_build=${{ vars.FULL_BUILD }}" >> $GITHUB_ENV
           echo "EXTRA_ARGS=${{ vars.EXTRA_ARGS }}" >> $GITHUB_ENV
           # for builds in Sage-Bionetworks repo', publish build artifacts
-          #if [[ $GITHUB_REPOSITORY_OWNER == "Sage-Bionetworks" ]]; then
-          if [[ "true" ]]; then
+          if [[ $GITHUB_REPOSITORY_OWNER == "Sage-Bionetworks" ]]; then
             if [[ $branch == "develop" ]]; then
               GIT_COMMIT=${{ github.sha }}
               ARTIFACT_VERSION=$(date +%Y-%m-%d_%H-%M)"_"${GIT_COMMIT:0:7}
-            #elif [[ $branch =~ "release-" ]]; then
-            elif [[ $branch =~ "PLFM-9253" ]]; then
+            elif [[ $branch =~ "release-" ]]; then
               git fetch --tags
               ARTIFACT_VERSION=$(git describe --tags --abbrev=0)
             fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ name: main
 on:
   push:
     branches: ['*']
-    tags: ['*']
+    tags: ['[0-9]+(\.[0-9])?']
 
 # let only one copy of the workflow run at a time
 concurrency:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,15 +68,14 @@ jobs:
           echo "full_build=${{ vars.FULL_BUILD }}" >> $GITHUB_ENV
           echo "EXTRA_ARGS=${{ vars.EXTRA_ARGS }}" >> $GITHUB_ENV
           # for builds in Sage-Bionetworks repo', publish build artifacts
-          TAG_NAME="${GITHUB_REF#refs/tags/}"
           # if [[ $GITHUB_REPOSITORY_OWNER == "Sage-Bionetworks" ]]; then
           if [[ true ]]; then
             if [[ $branch == "develop" ]]; then
               GIT_COMMIT=${{ github.sha }}
               ARTIFACT_VERSION=$(date +%Y-%m-%d_%H-%M)"_"${GIT_COMMIT:0:7}
             fi
-            if [[ $TAG_NAME ]]; then
-              ARTIFACT_VERSION=$TAG_NAME
+            if [[ ${GITHUB_REF:0:10} == "refs/tags/" ]]; then
+              ARTIFACT_VERSION="${GITHUB_REF#refs/tags/}"
             fi
           fi
           if [[ $ARTIFACT_VERSION ]]; then

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,8 +71,7 @@ jobs:
           echo "full_build=${{ vars.FULL_BUILD }}" >> $GITHUB_ENV
           echo "EXTRA_ARGS=${{ vars.EXTRA_ARGS }}" >> $GITHUB_ENV
           # for builds in Sage-Bionetworks repo', publish build artifacts
-          # if [[ $GITHUB_REPOSITORY_OWNER == "Sage-Bionetworks" ]]; then
-          if [[ true ]]; then
+          if [[ $GITHUB_REPOSITORY_OWNER == "Sage-Bionetworks" ]]; then
             if [[ $branch == "develop" ]]; then
               GIT_COMMIT=${{ github.sha }}
               ARTIFACT_VERSION=$(date +%Y-%m-%d_%H-%M)"_"${GIT_COMMIT:0:7}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,8 +15,10 @@ name: main
 
 on:
   push:
-    branches: ['*']
-    tags: ['[0-9]+(\.[0-9])?']
+    branches:
+      - '*'
+    tags:
+      - '[0-9]+(\.[0-9])?'
 
 # let only one copy of the workflow run at a time
 concurrency:

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -79,7 +79,7 @@ if [ ${SETTINGS_XML} ]; then
   echo ${SETTINGS_XML} > ${m2_cache_parent_folder}/.m2/settings.xml
 fi
 
-if [ -n "${HOME_DIR_WITHIN_CONTAINER}" ]; then
+if [ -z ${HOME_DIR_WITHIN_CONTAINER+x} ]; then
   HOME_DIR_WITHIN_CONTAINER="/root"
 fi
 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -87,7 +87,7 @@ mysql -u${rds_user_name} -p${rds_password} -h ${org_sagebionetworks_repository_d
 mysql -u${rds_user_name} -p${rds_password} -h ${org_sagebionetworks_table_cluster_endpoint_0} -sN -e "DROP DATABASE ${db_name};CREATE DATABASE ${db_name};"
 
 # create build container and run build
-docker run --user "$(id -u):$(id -g)" -i --rm --name ${build_container_name} \
+docker run ${DOCKER_USER_OPTION} -i --rm --name ${build_container_name} \
 -m 5500M \
 -v ${m2_cache_parent_folder}/.m2:${HOME_DIR_WITHIN_CONTAINER}/.m2 \
 -v ${src_folder}:/repo \

--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -21,7 +21,8 @@ export src_folder=${HOME}/workspace/${JOB_NAME}
 BASEDIR=$(dirname "$0")
 
 export stack=dev
-export HOME_DIR_WITHIN_CONTAINER = "/tmp"
+export HOME_DIR_WITHIN_CONTAINER="/tmp"
+export DOCKER_USER_OPTION="--user \"$(id -u):$(id -g)\""
 
 ${BASEDIR}/before.sh
 ${BASEDIR}/docker_build.sh


### PR DESCRIPTION
This PR changes the build behavior:
- to build and push to Artifactory when a 'develop' or 'release-*' branch is pushed to the `Sage-Bionetworks` repo';
- to add an explicit step "Display Artifact Version" which shows the version, for convenience;
- to fix the problem with authenticating to Artifactory by (1) removing the unneeded Docker `--user` override for the CodePipeline build and, (2) correctly setting the home directory in the Docker container so that the `settings.xml` file is found. (Previously the dir was not being set.)