### PR TITLE
PLFM-9342

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImpl.java
@@ -136,6 +136,8 @@ public class GridReplicaValidationManagerImpl implements GridReplicaValidationMa
 
 			cleanupValidationResults(validationResults);
 
+			// Always apply the new validation results, even if the value did not change.
+			// The client uses the timestamp to determine if results are up-to-date with its local changes.
 			changes.add(createChange(row, validationResults));
 		}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImpl.java
@@ -136,9 +136,7 @@ public class GridReplicaValidationManagerImpl implements GridReplicaValidationMa
 
 			cleanupValidationResults(validationResults);
 
-			if (!validationResults.equals(row.getRowValidationResults())) {
-				changes.add(createChange(row, validationResults));
-			}
+			changes.add(createChange(row, validationResults));
 		}
 
 		return changes;

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImplTest.java
@@ -220,12 +220,14 @@ public class GridReplicaValidationManagerImplTest {
 	@Test
 	public void testValidateRows() {
 		when(mockJsonSchemaManager.getValidationSchema(schemaId)).thenReturn(jsonSchema);
-		rows.get(0).setRowObject(new RowObject().setData(new RowData().setRowJsonDocument(new JSONObject("{\"key\":\"value1\"}"))));
+		rows.get(0).setRowObject(new RowObject()
+				.setData(new RowData().setRowJsonDocument(new JSONObject("{\"key\":\"value1\"}"))));
 		// Sets an existing and equal validation result for the second row
 		rows.get(1).setRowObject(new RowObject()
 						.setData(new RowData().setRowJsonDocument(new JSONObject("{\"key\":\"value2\"}")))
 				.setMetadata(
 				new RowMetadata().setRowValidation(new RowValidation().setValidationResults(validationResult))));
+		IntendedChange intendedChange2 = new UpdateMetadataChange().setRowMetadataId(rows.get(1).getArrNodeId());
 
 		when(mockJsonSchemaValidationManager.validateBatch(jsonSchema,
 				List.of(new RowJsonSubject(rows.get(0)), new RowJsonSubject(rows.get(1)))))
@@ -233,14 +235,13 @@ public class GridReplicaValidationManagerImplTest {
 
 		doNothing().when(manager).cleanupValidationResults(validationResult);
 
-		// The change is created only for the first row that does not contain any
-		// validation result yet
 		doReturn(intendedChange).when(manager).createChange(rows.get(0), validationResult);
+		doReturn(intendedChange2).when(manager).createChange(rows.get(1), validationResult);
 
 		// call under test
 		List<IntendedChange> changes = manager.validateRows(gridHeader, schemaId, rows);
 
-		assertEquals(List.of(intendedChange), changes);
+		assertEquals(List.of(intendedChange, intendedChange2), changes);
 	}
 
 	@Test


### PR DESCRIPTION
Always update the validation result, even if it did not change. The clock of the validation result node can be used to determine if the validation result is up-to-date compared to the nodes in a row's data vector.