### PR TITLE
PLFM-9355 - log agent invocation events & failures

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/AgentCloudwatchUtils.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/AgentCloudwatchUtils.java
@@ -5,11 +5,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.sagebionetworks.cloudwatch.ProfileData;
+import org.sagebionetworks.repo.manager.agent.handler.ReturnControlEvent;
 import org.sagebionetworks.repo.model.agent.GridAgentSessionContext;
 import org.sagebionetworks.repo.model.agent.SessionContext;
 import org.sagebionetworks.util.ValidateArgument;
-
-import software.amazon.awssdk.services.bedrockagentruntime.model.InvocationInputMember;
 
 class AgentCloudwatchUtils {
 
@@ -18,18 +17,24 @@ class AgentCloudwatchUtils {
         InvocationInputFailure,
     }
 
-    public static ProfileData generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchEventName eventName, String namespace, SessionContext context, InvocationInputMember member, Exception optionalException){
+    public static ProfileData generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchEventName eventName, String namespace, SessionContext context, ReturnControlEvent returnControlEvent, Exception optionalException) {
         ValidateArgument.required(eventName, "eventName");
-        ValidateArgument.required(member, "member");
 
-        ProfileData event = new ProfileData();
-        event.setNamespace(namespace);
-        event.setName(eventName.toString());
-        event.setValue(1.0);
-        event.setUnit("Count");
-        event.setTimestamp(new Date());
+        ProfileData cloudWatchEvent = new ProfileData();
+        cloudWatchEvent.setNamespace(namespace);
+        cloudWatchEvent.setName(eventName.toString());
+        cloudWatchEvent.setValue(1.0);
+        cloudWatchEvent.setUnit("Count");
+        cloudWatchEvent.setTimestamp(new Date());
 
         Map<String, String> dimensions = new HashMap<>();
+        if (returnControlEvent != null) {
+            dimensions.put("ActionGroup", returnControlEvent.getActionGroup());
+            dimensions.put("FunctionName", returnControlEvent.getFunction());
+            if (returnControlEvent.getParameters() != null) {
+                dimensions.put("Parameters", returnControlEvent.getParameters().toString());
+            }
+        }
         if (context != null) {
             dimensions.put("SessionContextType", context.getConcreteType());
             if (context instanceof GridAgentSessionContext) {
@@ -38,24 +43,15 @@ class AgentCloudwatchUtils {
                 dimensions.put("GridAgentReplicaId", String.valueOf(ctx.getAgentsReplicaId()));
             }
         }
-        if (member.functionInvocationInput() != null) {
-            dimensions.put("InvocationType", "Function");
-            dimensions.put("FunctionName", member.functionInvocationInput().function());
-        }
 
-        if (member.apiInvocationInput() != null) {
-            dimensions.put("InvocationType", "API");
-            dimensions.put("ApiPath", member.apiInvocationInput().apiPath());
-            dimensions.put("HttpMethod", member.apiInvocationInput().httpMethod());
-        }
 
         if (optionalException != null) {
             dimensions.put("ExceptionType", optionalException.getClass().getSimpleName());
             dimensions.put("ExceptionMessage", optionalException.getMessage());
         }
 
-        event.setDimension(dimensions);
+        cloudWatchEvent.setDimension(dimensions);
 
-        return event;
+        return cloudWatchEvent;
     }
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/AgentCloudwatchUtils.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/AgentCloudwatchUtils.java
@@ -1,0 +1,61 @@
+package org.sagebionetworks.repo.manager.agent;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.sagebionetworks.cloudwatch.ProfileData;
+import org.sagebionetworks.repo.model.agent.GridAgentSessionContext;
+import org.sagebionetworks.repo.model.agent.SessionContext;
+import org.sagebionetworks.util.ValidateArgument;
+
+import software.amazon.awssdk.services.bedrockagentruntime.model.InvocationInputMember;
+
+class AgentCloudwatchUtils {
+
+    public enum AgentCloudwatchEventName {
+        InvocationInput,
+        InvocationInputFailure,
+    }
+
+    public static ProfileData generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchEventName eventName, String namespace, SessionContext context, InvocationInputMember member, Exception optionalException){
+        ValidateArgument.required(eventName, "eventName");
+        ValidateArgument.required(member, "member");
+
+        ProfileData event = new ProfileData();
+        event.setNamespace(namespace);
+        event.setName(eventName.toString());
+        event.setValue(1.0);
+        event.setUnit("Count");
+        event.setTimestamp(new Date());
+
+        Map<String, String> dimensions = new HashMap<>();
+        if (context != null) {
+            dimensions.put("SessionContextType", context.getConcreteType());
+            if (context instanceof GridAgentSessionContext) {
+                GridAgentSessionContext ctx = (GridAgentSessionContext) context;
+                dimensions.put("GridSessionId", ctx.getGridSessionId());
+                dimensions.put("GridAgentReplicaId", String.valueOf(ctx.getAgentsReplicaId()));
+            }
+        }
+        if (member.functionInvocationInput() != null) {
+            dimensions.put("InvocationType", "Function");
+            dimensions.put("FunctionName", member.functionInvocationInput().function());
+        }
+
+        if (member.apiInvocationInput() != null) {
+            dimensions.put("InvocationType", "API");
+            dimensions.put("ApiPath", member.apiInvocationInput().apiPath());
+            dimensions.put("HttpMethod", member.apiInvocationInput().httpMethod());
+        }
+
+        if (optionalException != null) {
+            dimensions.put("ExceptionType", optionalException.getClass().getSimpleName());
+            dimensions.put("ExceptionMessage", optionalException.getMessage());
+        }
+
+        event.setDimension(dimensions);
+
+        return event;
+    }
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/AgentManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/AgentManagerImpl.java
@@ -11,6 +11,8 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 import org.sagebionetworks.LoggerProvider;
+import org.sagebionetworks.cloudwatch.Consumer;
+import org.sagebionetworks.cloudwatch.ProfileData;
 import org.sagebionetworks.repo.manager.agent.context.AgentContextValidator;
 import org.sagebionetworks.repo.manager.agent.handler.OpenApiReturnControlHandler;
 import org.sagebionetworks.repo.manager.agent.handler.ReturnControlEvent;
@@ -83,11 +85,13 @@ public class AgentManagerImpl implements AgentManager {
 	private final FeatureManager featureManager;
 	private final AgentContextValidator contextValidator;
 	private Logger logger;
+	private final Consumer cloudWatchConsumer;
 
 	@Autowired
 	public AgentManagerImpl(AgentDao agentDao, AgentClientProvider agentClientProvider,
 			Map<AgentSuffix, String> stackBedrockAgentIds, ReturnControlHandlerProvider handlerProvider, Clock clock,
-			AsynchronousJobStatusDAO statusDao, FeatureManager featureManager, AgentContextValidator contextValidator) {
+			AsynchronousJobStatusDAO statusDao, FeatureManager featureManager, AgentContextValidator contextValidator,
+			Consumer consumer) {
 		super();
 		this.agentDao = agentDao;
 		this.agentClientProvider = agentClientProvider;
@@ -104,6 +108,7 @@ public class AgentManagerImpl implements AgentManager {
 		this.handlerProvider = handlerProvider;
 		this.featureManager = featureManager;
 		this.contextValidator = contextValidator;
+		this.cloudWatchConsumer = consumer;
 	}
 
 	@Autowired
@@ -413,12 +418,24 @@ public class AgentManagerImpl implements AgentManager {
 	}
 
 	ReturnControlEvent fromInvocationInputMember(Long userId, SessionContext context, InvocationInputMember member) {
-		if (member.functionInvocationInput() != null) {
-			return fromFunctionInvocationInput(userId, member.functionInvocationInput());
-		} else if (member.apiInvocationInput() != null) {
-			return fromApiInvocationInput(userId, context, member.apiInvocationInput());
+		try {
+			logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, context, member, null);
+			if (member.functionInvocationInput() != null) {
+				return fromFunctionInvocationInput(userId, member.functionInvocationInput());
+			} else if (member.apiInvocationInput() != null) {
+				return fromApiInvocationInput(userId, context, member.apiInvocationInput());
+			}
+			throw new IllegalArgumentException("Expected either function or api invocation");
+		} catch (Exception e) {
+			// Add CloudWatch metric and rethrow
+			logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure, context, member, e);
+			throw e;
 		}
-		throw new IllegalArgumentException("Expected either function or api invocation");
+	}
+
+	void logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName eventName, SessionContext context, InvocationInputMember member, Exception optionalException) {
+		ProfileData event = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(eventName, this.getClass().getName(), context, member, optionalException);
+		cloudWatchConsumer.addProfileData(event);
 	}
 
 	ReturnControlEvent fromFunctionInvocationInput(Long userId, FunctionInvocationInput input) {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/AgentManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/AgentManagerImpl.java
@@ -392,8 +392,10 @@ public class AgentManagerImpl implements AgentManager {
 							accessLevel, AgentAccessLevel.WRITE_YOUR_PRIVATE_DATA));
 				}
 			}
+			logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, event.getSessionContext(SessionContext.class).orElse(null), event, null);
 			return handler.handleEvent(event);
 		} catch (Exception e) {
+			logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure, event.getSessionContext(SessionContext.class).orElse(null), event, e);
 			logger.error("Return_control event execution failed. Will send the following message to the agent: '{}'",
 					e.getMessage());
 			// on failure provide the error message to the agent in JSON.
@@ -418,24 +420,17 @@ public class AgentManagerImpl implements AgentManager {
 	}
 
 	ReturnControlEvent fromInvocationInputMember(Long userId, SessionContext context, InvocationInputMember member) {
-		try {
-			logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, context, member, null);
-			if (member.functionInvocationInput() != null) {
-				return fromFunctionInvocationInput(userId, member.functionInvocationInput());
-			} else if (member.apiInvocationInput() != null) {
-				return fromApiInvocationInput(userId, context, member.apiInvocationInput());
-			}
-			throw new IllegalArgumentException("Expected either function or api invocation");
-		} catch (Exception e) {
-			// Add CloudWatch metric and rethrow
-			logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure, context, member, e);
-			throw e;
+		if (member.functionInvocationInput() != null) {
+			return fromFunctionInvocationInput(userId, member.functionInvocationInput());
+		} else if (member.apiInvocationInput() != null) {
+			return fromApiInvocationInput(userId, context, member.apiInvocationInput());
 		}
+		throw new IllegalArgumentException("Expected either function or api invocation");
 	}
 
-	void logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName eventName, SessionContext context, InvocationInputMember member, Exception optionalException) {
-		ProfileData event = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(eventName, this.getClass().getName(), context, member, optionalException);
-		cloudWatchConsumer.addProfileData(event);
+	void logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName eventName, SessionContext sessionContext, ReturnControlEvent event, Exception optionalException) {
+		ProfileData cloudWatchEvent = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(eventName, this.getClass().getName(), sessionContext, event, optionalException);
+		cloudWatchConsumer.addProfileData(cloudWatchEvent);
 	}
 
 	ReturnControlEvent fromFunctionInvocationInput(Long userId, FunctionInvocationInput input) {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentCloudwatchUtilsTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentCloudwatchUtilsTest.java
@@ -1,72 +1,79 @@
 package org.sagebionetworks.repo.manager.agent;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sagebionetworks.cloudwatch.ProfileData;
+import org.sagebionetworks.repo.manager.agent.handler.ReturnControlEvent;
+import org.sagebionetworks.repo.manager.agent.parameter.Parameter;
 import org.sagebionetworks.repo.model.agent.GridAgentSessionContext;
+import org.sagebionetworks.repo.model.agent.SessionContext;
 
-import software.amazon.awssdk.services.bedrockagentruntime.model.ApiInvocationInput;
 import software.amazon.awssdk.services.bedrockagentruntime.model.FunctionInvocationInput;
 import software.amazon.awssdk.services.bedrockagentruntime.model.InvocationInputMember;
 
 class AgentCloudwatchUtilsTest {
+    SessionContext context;
+    String namespace;
+    String actionGroup;
+    String functionName;
+    List<Parameter> parameters;
+    ReturnControlEvent returnControlEvent;
+    Exception exception;
+
+    @BeforeEach
+    public void before() {
+        context = null;
+        namespace = "ns";
+        actionGroup = "testActionGroup";
+        functionName = "testFunction";
+        returnControlEvent = new ReturnControlEvent(123L, actionGroup, functionName, parameters);
+        exception = null;
+    }
 
     @Test
     public void testNullEventName() {
-        InvocationInputMember member = InvocationInputMember.builder().build();
-
-        assertThrows(IllegalArgumentException.class, () -> AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(null, "ns", null, member, null));
+        assertThrows(IllegalArgumentException.class, () -> AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(null, namespace, context, returnControlEvent, exception));
     }
 
     @Test
-    public void testNullInvocationInputMember() {
-        assertThrows(IllegalArgumentException.class, () -> AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, "ns", null, null, null));
-    }
+    public void testWithParameters() {
+        parameters = List.of(new Parameter("param1", "string", "value1"), new Parameter("param2", "number", "42"));
+        returnControlEvent = new ReturnControlEvent(123L, actionGroup, functionName, parameters);
 
-    @Test
-    public void testFunctionInvocation() {
-        FunctionInvocationInput fin = FunctionInvocationInput.builder().actionGroup("action").function("myFunction").build();
-        InvocationInputMember member = InvocationInputMember.builder().functionInvocationInput(fin).build();
-
-        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, "myNamespace", null, member, null);
+        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, namespace, context, returnControlEvent, exception);
         assertNotNull(pd);
-        assertEquals("myNamespace", pd.getNamespace());
+        assertEquals(namespace, pd.getNamespace());
         assertEquals(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput.toString(), pd.getName());
         assertEquals(1.0, pd.getValue());
         assertEquals("Count", pd.getUnit());
         assertNotNull(pd.getTimestamp());
-
         Map<String, String> dims = pd.getDimension();
-        assertNotNull(dims);
-        assertEquals("Function", dims.get("InvocationType"));
-        assertEquals("myFunction", dims.get("FunctionName"));
-        assertFalse(dims.containsKey("ApiPath"));
-        assertFalse(dims.containsKey("HttpMethod"));
-        assertFalse(dims.containsKey("ExceptionType"));
+        assertEquals(actionGroup, dims.get("ActionGroup"));
+        assertEquals(functionName, dims.get("FunctionName"));
+        assertEquals(parameters.toString(), dims.get("Parameters"));
     }
 
     @Test
-    public void testApiInvocation() {
-        ApiInvocationInput api = ApiInvocationInput.builder().actionGroup("ag").apiPath("/v1/resource").httpMethod("GET").build();
-        InvocationInputMember member = InvocationInputMember.builder().apiInvocationInput(api).build();
+    public void testNullParameters() {
+        parameters = null;
 
-        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, "nsApi", null, member, null);
+        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, namespace, context, returnControlEvent, exception);
         Map<String, String> dims = pd.getDimension();
-        assertEquals("API", dims.get("InvocationType"));
-        assertEquals("/v1/resource", dims.get("ApiPath"));
-        assertEquals("GET", dims.get("HttpMethod"));
+        assertEquals(null, dims.get("Parameters"));
     }
+
 
     @Test
     public void testInvocationInputException() {
-        FunctionInvocationInput fin = FunctionInvocationInput.builder().actionGroup("action").function("gridFn").build();
-        InvocationInputMember member = InvocationInputMember.builder().functionInvocationInput(fin).build();
-
-        Exception ex = new RuntimeException("something bad");
-        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure, "gridNs", null, member, ex);
+        exception = new RuntimeException("something bad");
+        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure, namespace, context, returnControlEvent, exception);
 
         Map<String, String> dims = pd.getDimension();
         assertEquals("RuntimeException", dims.get("ExceptionType"));
@@ -80,10 +87,12 @@ class AgentCloudwatchUtilsTest {
         gridContext.setGridSessionId("grid-123");
         gridContext.setAgentsReplicaId(42L);
 
+        context = gridContext;
+
         FunctionInvocationInput fin = FunctionInvocationInput.builder().actionGroup("action").function("gridFn").build();
         InvocationInputMember member = InvocationInputMember.builder().functionInvocationInput(fin).build();
 
-        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, "gridNs", gridContext, member, null);
+        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, namespace, context, returnControlEvent, exception);
 
         Map<String, String> dims = pd.getDimension();
         assertEquals("org.sagebionetworks.repo.model.agent.GridAgentSessionContext", dims.get("SessionContextType"));

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentCloudwatchUtilsTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentCloudwatchUtilsTest.java
@@ -1,0 +1,94 @@
+package org.sagebionetworks.repo.manager.agent;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.sagebionetworks.cloudwatch.ProfileData;
+import org.sagebionetworks.repo.model.agent.GridAgentSessionContext;
+
+import software.amazon.awssdk.services.bedrockagentruntime.model.ApiInvocationInput;
+import software.amazon.awssdk.services.bedrockagentruntime.model.FunctionInvocationInput;
+import software.amazon.awssdk.services.bedrockagentruntime.model.InvocationInputMember;
+
+class AgentCloudwatchUtilsTest {
+
+    @Test
+    public void testNullEventName() {
+        InvocationInputMember member = InvocationInputMember.builder().build();
+
+        assertThrows(IllegalArgumentException.class, () -> AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(null, "ns", null, member, null));
+    }
+
+    @Test
+    public void testNullInvocationInputMember() {
+        assertThrows(IllegalArgumentException.class, () -> AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, "ns", null, null, null));
+    }
+
+    @Test
+    public void testFunctionInvocation() {
+        FunctionInvocationInput fin = FunctionInvocationInput.builder().actionGroup("action").function("myFunction").build();
+        InvocationInputMember member = InvocationInputMember.builder().functionInvocationInput(fin).build();
+
+        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, "myNamespace", null, member, null);
+        assertNotNull(pd);
+        assertEquals("myNamespace", pd.getNamespace());
+        assertEquals(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput.toString(), pd.getName());
+        assertEquals(1.0, pd.getValue());
+        assertEquals("Count", pd.getUnit());
+        assertNotNull(pd.getTimestamp());
+
+        Map<String, String> dims = pd.getDimension();
+        assertNotNull(dims);
+        assertEquals("Function", dims.get("InvocationType"));
+        assertEquals("myFunction", dims.get("FunctionName"));
+        assertFalse(dims.containsKey("ApiPath"));
+        assertFalse(dims.containsKey("HttpMethod"));
+        assertFalse(dims.containsKey("ExceptionType"));
+    }
+
+    @Test
+    public void testApiInvocation() {
+        ApiInvocationInput api = ApiInvocationInput.builder().actionGroup("ag").apiPath("/v1/resource").httpMethod("GET").build();
+        InvocationInputMember member = InvocationInputMember.builder().apiInvocationInput(api).build();
+
+        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, "nsApi", null, member, null);
+        Map<String, String> dims = pd.getDimension();
+        assertEquals("API", dims.get("InvocationType"));
+        assertEquals("/v1/resource", dims.get("ApiPath"));
+        assertEquals("GET", dims.get("HttpMethod"));
+    }
+
+    @Test
+    public void testInvocationInputException() {
+        FunctionInvocationInput fin = FunctionInvocationInput.builder().actionGroup("action").function("gridFn").build();
+        InvocationInputMember member = InvocationInputMember.builder().functionInvocationInput(fin).build();
+
+        Exception ex = new RuntimeException("something bad");
+        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure, "gridNs", null, member, ex);
+
+        Map<String, String> dims = pd.getDimension();
+        assertEquals("RuntimeException", dims.get("ExceptionType"));
+        assertEquals("something bad", dims.get("ExceptionMessage"));
+
+    }
+
+    @Test
+    public void testGridContext() {
+        GridAgentSessionContext gridContext = new GridAgentSessionContext();
+        gridContext.setGridSessionId("grid-123");
+        gridContext.setAgentsReplicaId(42L);
+
+        FunctionInvocationInput fin = FunctionInvocationInput.builder().actionGroup("action").function("gridFn").build();
+        InvocationInputMember member = InvocationInputMember.builder().functionInvocationInput(fin).build();
+
+        ProfileData pd = AgentCloudwatchUtils.generateCloudwatchProfileDataForInvocationInput(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, "gridNs", gridContext, member, null);
+
+        Map<String, String> dims = pd.getDimension();
+        assertEquals("org.sagebionetworks.repo.model.agent.GridAgentSessionContext", dims.get("SessionContextType"));
+        assertEquals("grid-123", dims.get("GridSessionId"));
+        assertEquals("42", dims.get("GridAgentReplicaId"));
+    }
+
+}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentManagerImplUnitTest.java
@@ -32,6 +32,8 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.reactivestreams.Subscription;
 import org.sagebionetworks.LoggerProvider;
+import org.sagebionetworks.cloudwatch.Consumer;
+import org.sagebionetworks.cloudwatch.ProfileData;
 import org.sagebionetworks.repo.manager.agent.AgentManagerImpl.AgentResponse;
 import org.sagebionetworks.repo.manager.agent.context.AgentContextValidator;
 import org.sagebionetworks.repo.manager.agent.handler.HttpCode;
@@ -145,6 +147,9 @@ public class AgentManagerImplUnitTest {
 	@Mock
 	private AgentContextValidator mockContextValidator;
 
+	@Mock
+	private Consumer mockCloudwatchConsumer;
+
 	private AgentManagerImpl manager;
 
 	private String stackBedrockAgentId;
@@ -213,7 +218,7 @@ public class AgentManagerImplUnitTest {
 				stackBedrockGridAgentId);
 
 		manager = Mockito.spy(new AgentManagerImpl(mockAgentDao, mockAgentClientProvider, idMap,
-				mockReturnControlHandlerProvider, mockClock, mockStatusDao, mockFeatureManager, mockContextValidator));
+				mockReturnControlHandlerProvider, mockClock, mockStatusDao, mockFeatureManager, mockContextValidator, mockCloudwatchConsumer));
 
 		when(mockLoggerProvider.getLogger(AgentManagerImpl.class.getName())).thenReturn(mockLogger);
 		manager.setLoggerProvider(mockLoggerProvider);
@@ -1382,6 +1387,8 @@ public class AgentManagerImplUnitTest {
 		ReturnControlEvent event = manager.fromInvocationInputMember(adminId,null, member);
 		ReturnControlEvent expected = new ReturnControlEvent(adminId, actionGroup, functionOne, params);
 		assertEquals(expected, event);
+
+		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, null, member, null);
 	}
 
 	@Test
@@ -1395,16 +1402,30 @@ public class AgentManagerImplUnitTest {
 		ReturnControlEvent event = manager.fromInvocationInputMember(adminId,null, member);
 		ReturnControlEvent expected = new ReturnControlEvent(adminId, actionGroup, "GET /foo/one/{id}", params);
 		assertEquals(expected, event);
+
+		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, null, member, null);
 	}
 
 	@Test
-	public void testFromInvocationInputMemberWithUnknowtype() {
+	public void testFromInvocationInputMemberWithUnknownType() {
 		InvocationInputMember member = InvocationInputMember.builder().build();
-		String message = assertThrows(IllegalArgumentException.class, () -> {
+		Exception e = assertThrows(IllegalArgumentException.class, () -> {
 			// call under test
 			manager.fromInvocationInputMember(adminId,null, member);
-		}).getMessage();
-		assertEquals("Expected either function or api invocation", message);
+		});
+		assertEquals("Expected either function or api invocation", e.getMessage());
+
+		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, null, member, null);
+		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure, null, member, e);
+	}
+
+	@Test
+	public void testLogInvocationEventToCloudWatch() {
+		InvocationInputMember member = createInvocationInputMember(actionGroup, functionOne);
+		GridAgentSessionContext ctx = new GridAgentSessionContext();
+		// call under test
+		manager.logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, ctx, member, null);
+		verify(mockCloudwatchConsumer).addProfileData(any(ProfileData.class));
 	}
 
 	@Test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentManagerImplUnitTest.java
@@ -4,9 +4,11 @@ import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -1033,6 +1035,8 @@ public class AgentManagerImplUnitTest {
 		// call under test
 		String result = manager.handleEvent(level, mockReturnControlHandlerOne, returnControlEventOne);
 		assertEquals("one", result);
+		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, null, returnControlEventOne, null);
+		verify(manager, never()).logInvocationEventToCloudWatch(eq(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure), any(), any(), any());
 	}
 
 	@ParameterizedTest
@@ -1046,6 +1050,9 @@ public class AgentManagerImplUnitTest {
 		// call under test
 		String result = manager.handleEvent(level, mockReturnControlHandlerOne, returnControlEventOne);
 		assertEquals("one", result);
+
+		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, null, returnControlEventOne, null);
+		verify(manager, never()).logInvocationEventToCloudWatch(eq(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure), any(), any(), any());
 	}
 
 	@ParameterizedTest
@@ -1063,6 +1070,8 @@ public class AgentManagerImplUnitTest {
 		verify(mockLogger).error(
 				"Return_control event execution failed. Will send the following message to the agent: '{}'",
 				expectedMessage);
+
+		verify(manager).logInvocationEventToCloudWatch(eq(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure), eq(null), eq(returnControlEventOne), any(UnauthorizedException.class));
 	}
 
 	@ParameterizedTest
@@ -1075,6 +1084,7 @@ public class AgentManagerImplUnitTest {
 		String result = manager.handleEvent(level, mockReturnControlHandlerOne, returnControlEventOne);
 		assertEquals("{\"errorMessage\":\"The feature to allow agents to write to Synapse is currently disabled.\"}",
 				result);
+		verify(manager).logInvocationEventToCloudWatch(eq(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure), eq(null), eq(returnControlEventOne), any(UnsupportedOperationException.class));
 	}
 
 	@ParameterizedTest
@@ -1091,6 +1101,9 @@ public class AgentManagerImplUnitTest {
 		verify(mockLogger).error(
 				"Return_control event execution failed. Will send the following message to the agent: '{}'",
 				e.getMessage());
+
+		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, null, returnControlEventOne, null);
+		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure, null, returnControlEventOne, e);
 	}
 
 	@Test
@@ -1387,8 +1400,6 @@ public class AgentManagerImplUnitTest {
 		ReturnControlEvent event = manager.fromInvocationInputMember(adminId,null, member);
 		ReturnControlEvent expected = new ReturnControlEvent(adminId, actionGroup, functionOne, params);
 		assertEquals(expected, event);
-
-		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, null, member, null);
 	}
 
 	@Test
@@ -1402,8 +1413,6 @@ public class AgentManagerImplUnitTest {
 		ReturnControlEvent event = manager.fromInvocationInputMember(adminId,null, member);
 		ReturnControlEvent expected = new ReturnControlEvent(adminId, actionGroup, "GET /foo/one/{id}", params);
 		assertEquals(expected, event);
-
-		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, null, member, null);
 	}
 
 	@Test
@@ -1414,17 +1423,13 @@ public class AgentManagerImplUnitTest {
 			manager.fromInvocationInputMember(adminId,null, member);
 		});
 		assertEquals("Expected either function or api invocation", e.getMessage());
-
-		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, null, member, null);
-		verify(manager).logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInputFailure, null, member, e);
 	}
 
 	@Test
 	public void testLogInvocationEventToCloudWatch() {
-		InvocationInputMember member = createInvocationInputMember(actionGroup, functionOne);
 		GridAgentSessionContext ctx = new GridAgentSessionContext();
 		// call under test
-		manager.logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, ctx, member, null);
+		manager.logInvocationEventToCloudWatch(AgentCloudwatchUtils.AgentCloudwatchEventName.InvocationInput, ctx, returnControlEventApi, null);
 		verify(mockCloudwatchConsumer).addProfileData(any(ProfileData.class));
 	}
 


### PR DESCRIPTION
In PLFM-9355, we discovered that when invoking functions, the agent submits JSON, but deeply nested objects are mangled by Bedrock such that they become unparseable.

As a workaround, we will ask the agent to encode these nested objects as strings, which Bedrock will not transform, and our JSON parsing library incidentally permits and transforms to the un-escaped string object.

With this change, we can validate the effectiveness of our workaround by tracking frequency of this type of exception.