### PR TITLE
PLFM-9357 - Grid CSV import supports arrays

### DIFF
--- a/lib/lib-table-cluster/src/main/java/org/sagebionetworks/table/cluster/utils/CSVUtils.java
+++ b/lib/lib-table-cluster/src/main/java/org/sagebionetworks/table/cluster/utils/CSVUtils.java
@@ -1,8 +1,9 @@
 package org.sagebionetworks.table.cluster.utils;
 
 import java.io.Reader;
-import java.io.Writer;
 
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.sagebionetworks.repo.model.table.ColumnConstants;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
@@ -10,7 +11,6 @@ import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
 import org.sagebionetworks.repo.model.table.UploadToTablePreviewRequest;
 
 import au.com.bytecode.opencsv.CSVReader;
-import au.com.bytecode.opencsv.CSVWriter;
 import au.com.bytecode.opencsv.Constants;
 
 public class CSVUtils {
@@ -19,7 +19,7 @@ public class CSVUtils {
 	/**
 	 * When searching for a type this setups the order we check for.  Not all types are included.
 	 */
-	private static final ColumnType[] typesToCheck = new ColumnType[]{ColumnType.BOOLEAN, ColumnType.INTEGER, ColumnType.DOUBLE, ColumnType.DATE, ColumnType.ENTITYID, ColumnType.STRING, ColumnType.MEDIUMTEXT, ColumnType.LARGETEXT};
+	private static final ColumnType[] typesToCheck = new ColumnType[]{ColumnType.STRING_LIST, ColumnType.BOOLEAN, ColumnType.INTEGER, ColumnType.DOUBLE, ColumnType.DATE, ColumnType.ENTITYID, ColumnType.STRING, ColumnType.MEDIUMTEXT, ColumnType.LARGETEXT};
 
 	/**
 	 * Create CSVReader with the correct parameters using the provided parameters or default values.
@@ -107,6 +107,16 @@ public class CSVUtils {
 		}
 	}
 	
+	public static long getMaxLengthOfStringListItems(JSONArray list) throws JSONException {
+		long maxLength = 0;
+		for (int i = 0; i < list.length(); i++) {
+			String element = list.getString(i);
+			if (element != null) {
+				maxLength = Math.max(maxLength, element.length());
+			}
+		}
+		return maxLength;
+	}
 
 	/**
 	 * Check if the given value is compatible with the given columnType.
@@ -122,8 +132,10 @@ public class CSVUtils {
 			return currentType;
 		}
 		long currentMaxSize = 0;
+		long currentMaxListLength = 0;
 		if(currentType != null){
 			currentMaxSize = currentType.getMaximumSize();
+			currentMaxListLength = currentType.getMaximumListLength() == null ? 0 : currentType.getMaximumListLength();
 		}
 		// The current type determines where lookup starts.
 		int startIndex = findIndexOf(currentType);
@@ -131,7 +143,21 @@ public class CSVUtils {
 		for(int i=startIndex; i<typesToCheck.length; i++){
 			ColumnModel cm = new ColumnModel();
 			cm.setColumnType(typesToCheck[i]);
-			long maxSize = Math.max(value.length(), currentMaxSize);
+			long size = value.length();
+			if (ColumnType.STRING_LIST.equals(typesToCheck[i])) {
+				try {
+					// get the largest length of a single item in the array
+					size = getMaxLengthOfStringListItems(new JSONArray(value));
+
+					// assign the maximumListLength
+					long maxListLength = Math.max(value.split(",").length, currentMaxListLength);
+					cm.setMaximumListLength(maxListLength);
+				} catch (JSONException e) {
+					// Not a string list
+					continue;
+				}
+			}
+			long maxSize = Math.max(size, currentMaxSize);
 			cm.setMaximumSize(maxSize);
 			try {
 				TableModelUtils.validateValue(value, cm);

--- a/lib/lib-table-cluster/src/test/java/org/sagebionetworks/table/cluster/utils/CSVUtilsTest.java
+++ b/lib/lib-table-cluster/src/test/java/org/sagebionetworks/table/cluster/utils/CSVUtilsTest.java
@@ -73,6 +73,19 @@ public class CSVUtilsTest {
 	}
 
 	@Test
+	public void testCheckTypeStringList() {
+		String in = "[\"abcdef\", \"ghi\"]";
+		ColumnModel cm = CSVUtils.checkType(in, null);
+		assertNotNull(cm);
+		assertEquals(ColumnType.STRING_LIST, cm.getColumnType());
+		assertEquals(6L, cm.getMaximumSize());
+		assertEquals(2L, cm.getMaximumListLength());
+		// Should yield the same type
+		ColumnModel back = CSVUtils.checkType(in, cm);
+		assertEquals(cm, back);
+	}
+
+	@Test
 	public void testCheckTypeBoolean() {
 		String in = "true";
 		ColumnModel cm = CSVUtils.checkType(in, null);

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/handler/grid/LiteralSetValueProcessor.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/handler/grid/LiteralSetValueProcessor.java
@@ -20,7 +20,7 @@ public class LiteralSetValueProcessor implements SetValueProcessor<LiteralSetVal
 		if (rawSetValue.isNull("value")) {
 			return Optional.of(new ConValue(ConType.NULL, null));
 		}
-		return Optional.of(new ConValue(ConType.fromValue(sv.getValue()), sv.getValue()));
+		return Optional.of(new ConValue(ConType.fromValue(rawSetValue.get("value")), rawSetValue.get("value")));
 	}
 
 	@Override

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridReplicaCsvExporterImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridReplicaCsvExporterImpl.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import org.json.JSONObject;
 import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.manager.file.LocalFileUploadRequest;
 import org.sagebionetworks.repo.manager.grid.GridManager;
@@ -140,7 +141,7 @@ public class GridReplicaCsvExporterImpl implements GridReplicaCsvExporter {
                 }
 
                 rowView.getCells().stream()
-                        .map(v -> v == null ? null : v.getValue() == null ? null : v.getValue().toString())
+                        .map(v -> v == null ? null : v.getValue() == null || JSONObject.NULL.equals(v.getValue()) ? null : v.getValue().toString())
                         .forEach(csvRow::add);
 
                 writer.writeNext(csvRow.toArray(new String[0]));

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/table/UploadPreviewBuilder.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/table/UploadPreviewBuilder.java
@@ -214,8 +214,8 @@ public class UploadPreviewBuilder {
 				schema[i].setColumnType(ColumnType.STRING);
 				schema[i].setMaximumSize(ColumnConstants.DEFAULT_STRING_SIZE);
 			}
-			// Only STRINGS should keep the max size
-			if(!ColumnType.STRING.equals(schema[i].getColumnType())){
+			// Only STRING and STRING_LIST should keep the max size
+			if(!ColumnType.STRING.equals(schema[i].getColumnType()) && !ColumnType.STRING_LIST.equals(schema[i].getColumnType())) {
 				schema[i].setMaximumSize(null);
 			}
 			/*

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/handler/grid/LiteralSetValueProcessorTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/handler/grid/LiteralSetValueProcessorTest.java
@@ -1,7 +1,9 @@
 package org.sagebionetworks.repo.manager.agent.handler.grid;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,7 +24,7 @@ public class LiteralSetValueProcessorTest {
 	}
 
 	@Test
-	public void testCreateConValueWithJSONArray() {
+	public void testCreateConValueWithString() {
 		LiteralSetValue sv = new LiteralSetValue().setColumnName("a").setValue("a string");
 		JSONObject svRaw = new JSONObject("{\"columnName\":\"a\", \"value\":\"a string\"}");
 
@@ -32,6 +34,43 @@ public class LiteralSetValueProcessorTest {
 		assertEquals(ConType.STRING, result.getType());
 		assertEquals("a string", result.getValue());
 	}
+
+	@Test
+	public void testCreateConValueWithNumber() {
+		LiteralSetValue sv = new LiteralSetValue().setColumnName("a").setValue(2L);
+		JSONObject svRaw = new JSONObject("{\"columnName\":\"a\", \"value\": 2 }");
+
+		// call under test
+		ConValue result = handler.createConValue(row, sv, svRaw).get();
+
+		assertEquals(ConType.LONG, result.getType());
+		assertEquals(2L, result.getValue());
+	}
+
+	@Test
+	public void testCreateConValueWithJSONObject() {
+		LiteralSetValue sv = new LiteralSetValue().setColumnName("a").setValue("{\"foo\":\"bar\"}");
+		JSONObject svRaw = new JSONObject("{\"columnName\":\"a\", \"value\": {\"foo\":\"bar\"}}");
+
+		// call under test
+		ConValue result = handler.createConValue(row, sv, svRaw).get();
+
+		assertEquals(ConType.JSON_OBJECT, result.getType());
+		assertTrue(new JSONObject("{\"foo\":\"bar\"}").similar(result.getValue()));
+	}
+
+	@Test
+	public void testCreateConValueWithJSONArray() {
+		LiteralSetValue sv = new LiteralSetValue().setColumnName("a").setValue("[\"a string\"]");
+		JSONObject svRaw = new JSONObject("{\"columnName\":\"a\", \"value\":[\"a string\"]}");
+
+		// call under test
+		ConValue result = handler.createConValue(row, sv, svRaw).get();
+
+		assertEquals(ConType.JSON_ARRAY, result.getType());
+		assertTrue(new JSONArray("[\"a string\"]").similar(result.getValue()));
+	}
+
 
 	@Test
 	public void testCreateConValueWithNull() {

--- a/services/workers/src/test/java/org/sagebionetworks/agent/worker/GridAgentChatWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/agent/worker/GridAgentChatWorkerIntegrationTest.java
@@ -131,33 +131,41 @@ public class GridAgentChatWorkerIntegrationTest {
 		admin = userManager.getUserInfo(BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId());
 	}
 
-	void setGrid() throws IOException, Exception, AssertionError, AsynchJobFailedException {
+	/**
+	 * Helper to create a grid session from CSV rows and bind the provided schema.
+	 * This consolidates duplicated setup code so tests can call with different
+	 * datasets and schemas.
+	 *
+	 * @param csvHeader                the CSV header columns (first line)
+	 * @param csvRows                  the CSV data rows (each row is a String[] matching header length)
+	 * @param schemaPath            classpath path to the JSON schema
+	 * @param shortName             short name used when creating the schema id
+	 * @param expectedTotalRows     expected total row count to wait for
+	 * @param expectedInvalidRows   expected invalid row count to wait for
+	 */
+	void createGridSessionFromCsv(String[] csvHeader, List<String[]> csvRows, String schemaPath, String shortName, int expectedTotalRows, int expectedInvalidRows) throws Exception {
 		File temp = File.createTempFile("GridScaleIntegrationTest", ".csv", null);
 
 		csvDescriptor = new CsvTableDescriptor().setIsFirstLineHeader(true);
 		try (CSVWriter writer = new CSVWriterProviderImpl().createWriter(new FileWriter(temp), csvDescriptor)) {
-			writer.writeNext(new String[] { "a", "b" });
-			writer.writeNext(new String[] { "1", "one" });
-			writer.writeNext(new String[] { "2" });
-			writer.writeNext(new String[] { null, "no id" });
-			writer.writeNext(new String[] { "3", "true" });
-			writer.writeNext(new String[] { "98", "ninety eight" });
-			writer.writeNext(new String[] { "99" });
-			writer.writeNext(new String[] { "101" });
-			writer.writeNext(new String[] { "102", "one hundred two" });
-			writer.writeNext(new String[] { "103", "3.41" });
+			writer.writeNext(csvHeader);
+			for (String[] r : csvRows) {
+				writer.writeNext(r);
+			}
 		}
 
-		S3FileHandle fh = fileHandleManager.uploadLocalFile(new LocalFileUploadRequest().withFileToUpload(temp)
-				.withContentType("text/csv").withFileName(temp.getName()).withUserId(admin.getId().toString()));
+		S3FileHandle fh = fileHandleManager
+				.uploadLocalFile(new LocalFileUploadRequest().withFileToUpload(temp).withContentType("text/csv")
+						.withFileName(temp.getName()).withUserId(admin.getId().toString()));
 		temp.delete();
 
 		project = entityService.createEntity(admin.getId(), new Project().setName("GridScaleIntegrationTest"), null);
 
+		// use the first column as the upsert key
 		recordSet = entityService.createEntity(admin.getId(), new RecordSet().setName("aRecordSet")
-				.setParentId(project.getId()).setDataFileHandleId(fh.getId()).setUpsertKey(List.of("a")), null);
+				.setParentId(project.getId()).setDataFileHandleId(fh.getId()).setUpsertKey(List.of(csvHeader[0])), null);
 
-		schema$id = createJsonSchema("schema/ConditionalRequirement.json", "conditionalrequirement");
+		schema$id = createJsonSchema(schemaPath, shortName);
 
 		entityService.bindSchemaToEntity(admin.getId(),
 				new BindSchemaToEntityRequest().setEntityId(recordSet.getId()).setSchema$id(schema$id));
@@ -184,7 +192,7 @@ public class GridAgentChatWorkerIntegrationTest {
 					.filter(r -> r.getRowValidationResults() != null && !r.getRowValidationResults().getIsValid())
 					.count();
 			System.out.println("invalid count: " + invalidRows);
-			if (rows.size() != 9 || invalidRows != 2) {
+			if (rows.size() != expectedTotalRows || invalidRows != expectedInvalidRows) {
 				return Pair.create(false, null);
 			}
 			return Pair.create(true, header.get());
@@ -193,7 +201,25 @@ public class GridAgentChatWorkerIntegrationTest {
 
 	@Test
 	public void testViewWithSchemaAndAgentChat() throws Exception {
-		setGrid();
+		createGridSessionFromCsv(
+				new String[] { "a", "b" },
+				List.of(
+						new String[] { "1", "one" },
+						new String[] { "2" },
+						new String[] { null, "no id" },
+						new String[] { "3", "true" },
+						new String[] { "98", "ninety eight" },
+						new String[] { "99" },
+						new String[] { "101" },
+						new String[] { "102", "one hundred two" },
+						new String[] { "103", "3.41" }
+				),
+				"schema/ConditionalRequirement.json",
+				"conditionalrequirement",
+				9,
+				2
+		);
+
 		// Create replica One
 		GridReplica replicaOne = gridService
 				.createReplica(admin.getId(), new CreateReplicaRequest().setGridSessionId(gridSession.getSessionId()))
@@ -394,68 +420,24 @@ public class GridAgentChatWorkerIntegrationTest {
 				return Pair.create(false, null);
 			}
 		});
-
-	}
-
-	void setupGridRegex() throws IOException, Exception, AssertionError, AsynchJobFailedException {
-		File temp = File.createTempFile("GridScaleIntegrationTest", ".csv", null);
-
-		csvDescriptor = new CsvTableDescriptor().setIsFirstLineHeader(true);
-		try (CSVWriter writer = new CSVWriterProviderImpl().createWriter(new FileWriter(temp), csvDescriptor)) {
-			writer.writeNext(new String[] { "firstName", "lastName", "phone", "formattedName", "cleanPhone" });
-			writer.writeNext(new String[] { "John", "Smith", "(555) 123-4567", "Smith, John", "555-123-4567" });
-			writer.writeNext(new String[] { "Alice", "Johnson", "(555) 987-6543", null, null });
-			writer.writeNext(new String[] { "Bob", "Williams", "(555) 456-7890", null, null });
-			writer.writeNext(new String[] { "Carol", "Davis", "(555) 321-0987", null, null });
-			writer.writeNext(new String[] { "David", "Miller", "(555) 789-0123", null, null });
-		}
-
-		S3FileHandle fh = fileHandleManager.uploadLocalFile(new LocalFileUploadRequest().withFileToUpload(temp)
-				.withContentType("text/csv").withFileName(temp.getName()).withUserId(admin.getId().toString()));
-		temp.delete();
-
-		project = entityService.createEntity(admin.getId(), new Project().setName("GridScaleIntegrationTest"), null);
-
-		recordSet = entityService.createEntity(admin.getId(), new RecordSet().setName("aRecordSet")
-				.setParentId(project.getId()).setDataFileHandleId(fh.getId()).setUpsertKey(List.of("a")), null);
-
-		schema$id = createJsonSchema("schema/PathSchema.json", "pathschema");
-
-		entityService.bindSchemaToEntity(admin.getId(),
-				new BindSchemaToEntityRequest().setEntityId(recordSet.getId()).setSchema$id(schema$id));
-
-		gridSession = asynchronousJobWorkerHelper.assertJobResponse(admin,
-				new CreateGridRequest().setRecordSetId(recordSet.getId()), (CreateGridResponse response) -> {
-					assertNotNull(response);
-					assertNotNull(response.getGridSession());
-				}, MAX_WAIT_MS).getResponse().getGridSession();
-		assertNotNull(gridSession);
-		assertEquals(recordSet.getId(), gridSession.getSourceEntityId());
-		assertEquals(schema$id, gridSession.getGridJsonSchema$Id());
-
-		TimeUtils.waitFor(MAX_WAIT_MS, 2000L, () -> {
-			System.out.println("Waiting for row validation results to change...");
-			Optional<GridHeader> header = gridReplicaViewManager.readHeader(gridSession.getSessionId(),
-					INTERNAL_REPLICA_ID);
-			if (header.isEmpty()) {
-				return Pair.create(false, null);
-			}
-			List<RowView> rows = gridReplicaViewManager.querySinglePage(header.get(), 100L, 0L);
-			System.out.println("row count: " + rows.size());
-			int invalidRows = (int) rows.stream()
-					.filter(r -> r.getRowValidationResults() != null && !r.getRowValidationResults().getIsValid())
-					.count();
-			System.out.println("invalid count: " + invalidRows);
-			if (rows.size() != 5 || invalidRows != 4) {
-				return Pair.create(false, null);
-			}
-			return Pair.create(true, header.get());
-		});
 	}
 
 	@Test
-	public void testRegularExpression() throws IOException, AssertionError, AsynchJobFailedException, Exception {
-		setupGridRegex();
+	public void testRegularExpression() throws AssertionError, Exception {
+		createGridSessionFromCsv(
+				new String[] { "firstName", "lastName", "phone", "formattedName", "cleanPhone" },
+				List.of(
+						new String[] { "John", "Smith", "(555) 123-4567", "Smith, John", "555-123-4567" },
+						new String[] { "Alice", "Johnson", "(555) 987-6543", null, null },
+						new String[] { "Bob", "Williams", "(555) 456-7890", null, null },
+						new String[] { "Carol", "Davis", "(555) 321-0987", null, null },
+						new String[] { "David", "Miller", "(555) 789-0123", null, null }
+				),
+				"schema/PathSchema.json",
+				"pathschema",
+				5,
+				4
+		);
 
 		// Create replica One
 		GridReplica replicaOne = gridService
@@ -528,6 +510,81 @@ public class GridAgentChatWorkerIntegrationTest {
 		});
 	}
 
+	@Test
+	public void testArrays() throws Exception {
+		createGridSessionFromCsv(
+				new String[] { "arrayColumn", },
+				List.of(
+						new String[] { "abc", },
+						new String[] { "def" },
+						new String[] { "ghi" },
+						new String[] { "jkl" }
+				),
+				"schema/ArrayProperty.json",
+				"arrayproperty",
+				4,
+				4
+		);
+
+		GridReplica replicaOne = gridService
+				.createReplica(admin.getId(), new CreateReplicaRequest().setGridSessionId(gridSession.getSessionId()))
+				.getReplica();
+
+		String urlOne = gridService
+				.createPresignedUrl(admin.getId(), new CreateGridPresignedUrlRequest()
+						.setGridSessionId(gridSession.getSessionId()).setReplicaId(replicaOne.getReplicaId()))
+				.getPresignedUrl();
+		assertNotNull(urlOne);
+		BlockingQueue<String> incomingMessages = new LinkedBlockingQueue<>();
+		asynchronousJobWorkerHelper.createConnection(urlOne, incomingMessages);
+
+		GridAgentSessionContext context = new GridAgentSessionContext().setGridSessionId(replicaOne.getGridSessionId())
+				.setUsersReplicaId(replicaOne.getReplicaId());
+		AgentSession agentSession = agentService.createSession(admin.getId(), new CreateAgentSessionRequest()
+				.setSessionContext(context).setAgentAccessLevel(AgentAccessLevel.WRITE_YOUR_PRIVATE_DATA));
+		assertNotNull(agentSession);
+		assertEquals(context, agentSession.getSessionContext());
+		assertNotNull(context.getAgentsReplicaId());
+
+		String chatRequest = "Set the arrayColumn column to be \"abc\", \"xyz\" for all rows in the grid";
+		AgentChatResponse acr = asynchronousJobWorkerHelper
+				.assertJobResponse(admin, new AgentChatRequest().setSessionId(agentSession.getSessionId())
+						.setChatText(chatRequest).setEnableTrace(true), (AgentChatResponse response) -> {
+					assertNotNull(response);
+					assertEquals(agentSession.getSessionId(), response.getSessionId());
+					assertNotNull(response.getResponseText());
+					System.out.println(response.getResponseText());
+				}, MAX_WAIT_MS)
+				.getResponse();
+		// the agent is likely to ask if it should proceed....
+		if (acr.getResponseText().contains("?")) {
+			chatRequest = "You may proceed with making the change.";
+			acr = asynchronousJobWorkerHelper
+					.assertJobResponse(admin, new AgentChatRequest().setSessionId(agentSession.getSessionId())
+							.setChatText(chatRequest).setEnableTrace(true), (AgentChatResponse response) -> {
+						assertNotNull(response);
+						assertEquals(agentSession.getSessionId(), response.getSessionId());
+						assertNotNull(response.getResponseText());
+						System.out.println(response.getResponseText());
+					}, MAX_WAIT_MS)
+					.getResponse();
+		}
+
+		TimeUtils.waitFor(MAX_WAIT_MS, 2000L, () -> {
+			System.out.println("Waiting for agent's changes to appear...");
+			GridHeader h = gridReplicaViewManager
+					.readHeader(gridSession.getSessionId(), INTERNAL_REPLICA_ID, context.getUsersReplicaId()).get();
+			QueryResult qr = gridReplicaViewManager.querySinglePageAsQueryResult(h,
+					new QueryElement().setWhere(List.of(new CellValueFilterElement().setColumnName("arrayColumn")
+							.setOperator(CellValueOperatorElement.EQUALS).setValue(List.of("abc", "xyz")))));
+			if (qr.getRows().size() == 4L) {
+				return Pair.create(true, null);
+			} else {
+				return Pair.create(false, null);
+			}
+		});
+	}
+
 	public JsonRxMessage createSetSelectionMessage(GridHeader header, ReplicaSelectionModel selection,
 			LogicalTimestamp clock) {
 		LogicalTimestamp rootObjId = header.getNodeId();
@@ -565,5 +622,6 @@ public class GridAgentChatWorkerIntegrationTest {
 					assertNotNull(response.getNewVersionInfo().get$id());
 				}, MAX_WAIT_MS).getResponse().getNewVersionInfo().get$id();
 	}
+
 
 }

--- a/services/workers/src/test/java/org/sagebionetworks/grid/workers/GridEventBrokerWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/grid/workers/GridEventBrokerWorkerIntegrationTest.java
@@ -558,10 +558,10 @@ public class GridEventBrokerWorkerIntegrationTest {
 		Project project = entityService.createEntity(admin.getId(), new Project().setName("RecordSet Test"), null);
 
 		String csvContent =
-			"integer_column,string_column,double_column,boolean_column" + System.lineSeparator() +
-			"1,test_1,1.1,true" 										+ System.lineSeparator() +
-			"2,test_2,,true" 											+ System.lineSeparator() +
-			"3,test_3,3.3,false";
+			"integer_column,string_column,double_column,boolean_column,array_column"+ System.lineSeparator() +
+			"1,test_1,1.1,true,[]" 													+ System.lineSeparator() +
+			"2,test_2,,true," 														+ System.lineSeparator() +
+			"3,test_3,3.3,false,\"[\\\"foo\\\",\\\"bar\\\"]\"";
 
 		S3FileHandle fileHandle = fileHandleManager.createFileFromByteArray(admin.getId().toString(), new Date(), csvContent.getBytes(StandardCharsets.UTF_8), "recordset.csv", ContentType.create("text/csv"), null);
 
@@ -575,7 +575,8 @@ public class GridEventBrokerWorkerIntegrationTest {
 			"integer_column", new JsonSchema().setType(Type.integer),
 			"string_column", new JsonSchema().setType(Type.string),
 			"double_column", new JsonSchema().setType(Type.number),
-			"boolean_column", new JsonSchema().setType(Type._boolean)
+			"boolean_column", new JsonSchema().setType(Type._boolean),
+			"array_column", new JsonSchema().setType(Type.array).setItems(new JsonSchema().setType(Type.string))
 		), List.of("double_column")).getNewVersionInfo().get$id();
 
 		entityService.bindSchemaToEntity(admin.getId(),
@@ -622,7 +623,7 @@ public class GridEventBrokerWorkerIntegrationTest {
 		);
 
 		assertEquals(
-			List.of("integer_column", "string_column", "double_column", "boolean_column"),
+			List.of("integer_column", "string_column", "double_column", "boolean_column", "array_column"),
 			header.getOrderedColumns().stream().map(Column::getName).collect(Collectors.toList())
 		);
 
@@ -642,9 +643,9 @@ public class GridEventBrokerWorkerIntegrationTest {
 
 		assertEquals(
 			List.of(
-				"{\"integer_column\":1,\"string_column\":\"test_1\",\"double_column\":1.1,\"boolean_column\":true}",
+				"{\"integer_column\":1,\"string_column\":\"test_1\",\"double_column\":1.1,\"boolean_column\":true,\"array_column\":[]}",
 				"{\"integer_column\":2,\"string_column\":\"test_2\",\"double_column\":null,\"boolean_column\":true}",
-				"{\"integer_column\":3,\"string_column\":\"test_3\",\"double_column\":3.3,\"boolean_column\":false}"
+				"{\"integer_column\":3,\"string_column\":\"test_3\",\"double_column\":3.3,\"boolean_column\":false,\"array_column\":[\"foo\",\"bar\"]}"
 			),
 			rowsView.stream().map(r -> r.getRowObject().getData().getRowJsonDocument().toString()).collect(Collectors.toList())
 		);
@@ -704,9 +705,9 @@ public class GridEventBrokerWorkerIntegrationTest {
 
 		assertEquals(
 			List.of(
-				"{\"integer_column\":1,\"string_column\":\"test_1\",\"double_column\":1.1,\"boolean_column\":true}",
+				"{\"integer_column\":1,\"string_column\":\"test_1\",\"double_column\":1.1,\"boolean_column\":true,\"array_column\":[]}",
 				"{\"integer_column\":2,\"string_column\":\"test_2\",\"double_column\":2.2,\"boolean_column\":true}",
-				"{\"integer_column\":3,\"string_column\":\"test_3\",\"double_column\":3.3,\"boolean_column\":false}"
+				"{\"integer_column\":3,\"string_column\":\"test_3\",\"double_column\":3.3,\"boolean_column\":false,\"array_column\":[\"foo\",\"bar\"]}"
 			),
 			rowsView.stream().map(r -> r.getRowObject().getData().getRowJsonDocument().toString()).collect(Collectors.toList())
 		);
@@ -732,13 +733,13 @@ public class GridEventBrokerWorkerIntegrationTest {
 
 		// Now update the record set from a CSV file
 		String csvContents =
-			"integer_column,string_column,double_column,boolean_column" + System.lineSeparator() +
-			"1,test_1_updated,1.1,false" 								+ System.lineSeparator() + // update
+			"integer_column,string_column,double_column,boolean_column,array_column" + System.lineSeparator() +
+			"1,test_1_updated,1.1,false,\"[\\\"abc\\\",\\\"def\\\"]\""	+ System.lineSeparator() + // update
 																								   // Skip line 2
-			"3,test_3_updated,3.3,true" 								+ System.lineSeparator() + // update
-			"4,test_4_created,4.4,true"									+ System.lineSeparator() + // new row
-			"5,test_5_created,5.5,true"									+ System.lineSeparator() + // new row
-			"6,test_6_created,6.6,false";														   // new row
+			"3,test_3_updated,3.3,true,\"[]\"" 							+ System.lineSeparator() + // update
+			"4,test_4_created,4.4,true,\"[\\\"ghi\\\",\\\"123\\\"]\""	+ System.lineSeparator() + // new row
+			"5,test_5_created,5.5,true,"							+ System.lineSeparator() + // new row
+			"6,test_6_created,6.6,false,\"[\\\"456\\\",\\\"xyz\\\"]\"";							   // new row
 
 		S3FileHandle upsertFileHandle = fileHandleManager.createFileFromByteArray(admin.getId().toString(), new Date(), csvContents.getBytes(StandardCharsets.UTF_8), "recordset_upsert.csv", ContentType.create("text/csv"), null);
 
@@ -750,7 +751,8 @@ public class GridEventBrokerWorkerIntegrationTest {
 				new ColumnModel().setName("integer_column").setColumnType(ColumnType.INTEGER),
 				new ColumnModel().setName("string_column").setColumnType(ColumnType.STRING),
 				new ColumnModel().setName("double_column").setColumnType(ColumnType.DOUBLE),
-				new ColumnModel().setName("boolean_column").setColumnType(ColumnType.BOOLEAN)
+				new ColumnModel().setName("boolean_column").setColumnType(ColumnType.BOOLEAN),
+				new ColumnModel().setName("array_column").setColumnType(ColumnType.STRING_LIST)
 			));
 
 		asynchronousJobWorkerHelper.assertJobResponse(admin, csvImportRequest, (GridCsvImportResponse response) -> {
@@ -776,15 +778,30 @@ public class GridEventBrokerWorkerIntegrationTest {
 
 		assertEquals(
 			List.of(
-				"{\"integer_column\":1,\"string_column\":\"test_1_updated\",\"double_column\":1.1,\"boolean_column\":false}",
+				"{\"integer_column\":1,\"string_column\":\"test_1_updated\",\"double_column\":1.1,\"boolean_column\":false,\"array_column\":[\"abc\",\"def\"]}",
 				"{\"integer_column\":2,\"string_column\":\"test_2\"," +    "\"double_column\":2.2,\"boolean_column\":true}",
-				"{\"integer_column\":3,\"string_column\":\"test_3_updated\",\"double_column\":3.3,\"boolean_column\":true}",
-				"{\"integer_column\":4,\"string_column\":\"test_4_created\",\"double_column\":4.4,\"boolean_column\":true}",
-				"{\"integer_column\":5,\"string_column\":\"test_5_created\",\"double_column\":5.5,\"boolean_column\":true}",
-				"{\"integer_column\":6,\"string_column\":\"test_6_created\",\"double_column\":6.6,\"boolean_column\":false}"
+				"{\"integer_column\":3,\"string_column\":\"test_3_updated\",\"double_column\":3.3,\"boolean_column\":true,\"array_column\":[]}",
+				"{\"integer_column\":4,\"string_column\":\"test_4_created\",\"double_column\":4.4,\"boolean_column\":true,\"array_column\":[\"ghi\",\"123\"]}",
+				"{\"integer_column\":5,\"string_column\":\"test_5_created\",\"double_column\":5.5,\"boolean_column\":true,\"array_column\":null}",
+				"{\"integer_column\":6,\"string_column\":\"test_6_created\",\"double_column\":6.6,\"boolean_column\":false,\"array_column\":[\"456\",\"xyz\"]}"
 			),
 			rowsView.stream().map(r -> r.getRowObject().getData().getRowJsonDocument().toString()).collect(Collectors.toList())
 		);
+
+		DownloadFromGridRequest csvDownloadRequest = new DownloadFromGridRequest()
+				.setSessionId(session.getSessionId())
+				.setIncludeRowIdAndRowVersion(false)
+				.setIncludeEtag(false);
+		List<String[]> downloadedCsvContents = createAndDownloadCsvFromGrid(csvDownloadRequest);
+
+		assertEquals(7, downloadedCsvContents.size());
+		assertArrayEquals(new String[] { "integer_column",	"string_column",	"double_column",	"boolean_column",	"array_column" 		}, downloadedCsvContents.get(0));
+		assertArrayEquals(new String[] { "1",			 	"test_1_updated",	"1.1",				"false", 			"[\"abc\",\"def\"]",}, downloadedCsvContents.get(1));
+		assertArrayEquals(new String[] { "2",			 	"test_2",			"2.2",				"true", 			null,  				}, downloadedCsvContents.get(2));
+		assertArrayEquals(new String[] { "3",			 	"test_3_updated",	"3.3",				"true", 			"[]",  				}, downloadedCsvContents.get(3));
+		assertArrayEquals(new String[] { "4",			 	"test_4_created",	"4.4",				"true", 			"[\"ghi\",\"123\"]",}, downloadedCsvContents.get(4));
+		assertArrayEquals(new String[] { "5",			 	"test_5_created",	"5.5",				"true", 			null, 	 			}, downloadedCsvContents.get(5));
+		assertArrayEquals(new String[] { "6",			 	"test_6_created",	"6.6",				"false", 			"[\"456\",\"xyz\"]",}, downloadedCsvContents.get(6));
 	}
 
 	List<String[]> createAndDownloadCsvFromGrid(DownloadFromGridRequest request)

--- a/services/workers/src/test/resources/schema/ArrayProperty.json
+++ b/services/workers/src/test/resources/schema/ArrayProperty.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"properties": {
+		"arrayColumn": {
+			"type": "array",
+			"description": "An array of strings",
+			"items": {
+				"type": "string"
+			}
+		}
+	},
+	"required": [
+		"arrayColumn"
+	]
+}


### PR DESCRIPTION
Update CSVUtils and UploadPreviewBuilder to support identifying string arrays, which ensures that string array data is properly identified and imported into the grid.

Also update the GridReplicaCsvExporter to write both `null` and `undefined` as `null`, `null` and `"null"`.


(Probably need to extend this to also handle other array types)