### PR TITLE
PLFM-9408 - Fix submission filter

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/DBOSubmissionDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/DBOSubmissionDAOImpl.java
@@ -451,18 +451,24 @@ public class DBOSubmissionDAOImpl implements SubmissionDAO {
 			// Left join on the ACL table on the AR so that we can filter by "assigned acl" or not
 			+ " LEFT JOIN " + TABLE_ACCESS_CONTROL_LIST + " A ON S." + COL_DATA_ACCESS_SUBMISSION_ACCESS_REQUIREMENT_ID + " = A." + COL_ACL_OWNER_ID + " AND " +COL_ACL_OWNER_TYPE + "='" + ObjectType.ACCESS_REQUIREMENT.name() + "'";
 		
+		// Subquery to check if an ACL has REVIEW_SUBMISSIONS permission
+		String hasReviewSubmissionsPermission = "EXISTS (SELECT 1 FROM " + TABLE_RESOURCE_ACCESS + " RA"
+			+ " JOIN " + TABLE_RESOURCE_ACCESS_TYPE + " AT ON RA." + COL_RESOURCE_ACCESS_ID + " = AT." + COL_RESOURCE_ACCESS_TYPE_ID
+			+ " WHERE RA." + COL_RESOURCE_ACCESS_OWNER + " = A." + COL_ACL_ID
+			+ " AND AT." + COL_RESOURCE_ACCESS_TYPE_ELEMENT + " = '" + ACCESS_TYPE.REVIEW_SUBMISSIONS.name() + "')";
+
 		// This needs to go in the where clause as we are left joining on the ACL
 		switch (reviewerFilterType) {
 		case ALL:
 			// ACT can access everything, no need to filter on the ACL
 			break;
 		case ACT_ONLY:
-			// Only submissions that do not have any ACL assigned to the AR
-			additionalFilters.add("A." + COL_ACL_ID + " IS NULL");
+			// Only submissions where there is no ACL with REVIEW_SUBMISSIONS permission
+			additionalFilters.add("(A." + COL_ACL_ID + " IS NULL OR NOT " + hasReviewSubmissionsPermission + ")");
 			break;
 		case DELEGATED_ONLY:
-			// Only submissions that have at least on ACL assigned to the AR
-			additionalFilters.add("A." + COL_ACL_ID + " IS NOT NULL");
+			// Only submissions where there is an ACL with at least one REVIEW_SUBMISSIONS permission
+			additionalFilters.add(hasReviewSubmissionsPermission);
 		default:
 			break;
 		}

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/DBOSubmissionDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/DBOSubmissionDAOImpl.java
@@ -469,6 +469,7 @@ public class DBOSubmissionDAOImpl implements SubmissionDAO {
 		case DELEGATED_ONLY:
 			// Only submissions where there is an ACL with at least one REVIEW_SUBMISSIONS permission
 			additionalFilters.add(hasReviewSubmissionsPermission);
+			break;
 		default:
 			break;
 		}

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/DBOSubmissionDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/DBOSubmissionDAOImplTest.java
@@ -1200,18 +1200,116 @@ public class DBOSubmissionDAOImplTest {
 		
 		assertEquals(expected, result);
 	}
-	
+
+	@Test
+	public void testSearchSubmissionsWithACTOnlyAndExemptionEligibleAcl() {
+		// AR1 has an ACL with only EXEMPTION_ELIGIBLE (should be treated as ACT_ONLY)
+		addAclWithAccessTypes(accessRequirement.getId(), List.of(user1.getId()), Set.of(ACCESS_TYPE.EXEMPTION_ELIGIBLE));
+
+		String s1 = submissionDao.createSubmission(createSubmission(accessRequirement, researchProject, System.currentTimeMillis(), user1.getId())).getSubmissionId();
+		String s2 = submissionDao.createSubmission(createSubmission(accessRequirement2, researchProject, System.currentTimeMillis() + 1000, user2.getId())).getSubmissionId();
+
+		String accessorId = null;
+		String requirementId = null;
+		List<SubmissionSearchSort> sort = List.of(new SubmissionSearchSort().setField(SubmissionSortField.MODIFIED_ON));
+		SubmissionState state = null;
+		String reviewerId = null;
+		SubmissionReviewerFilterType reviewerFilterType = SubmissionReviewerFilterType.ACT_ONLY;
+		long limit = 10;
+		long offset = 0;
+
+		// Both submissions should be returned since AR1 only has EXEMPTION_ELIGIBLE (not REVIEW_SUBMISSIONS)
+		// and AR2 has no ACL at all
+		List<Submission> expected = List.of(
+			submissionDao.getSubmission(s1),
+			submissionDao.getSubmission(s2)
+		);
+
+		List<Submission> result = submissionDao.searchAllSubmissions(reviewerFilterType, sort, accessorId, requirementId, reviewerId, state, limit, offset);
+
+		assertEquals(expected, result);
+	}
+
+	@Test
+	public void testSearchSubmissionsWithDelegatedOnlyAndExemptionEligibleAcl() {
+		// AR1 has an ACL with only EXEMPTION_ELIGIBLE (should NOT be treated as DELEGATED_ONLY)
+		addAclWithAccessTypes(accessRequirement.getId(), List.of(user1.getId()), Set.of(ACCESS_TYPE.EXEMPTION_ELIGIBLE));
+		// AR2 has an ACL with REVIEW_SUBMISSIONS (should be treated as DELEGATED_ONLY)
+		addReviewers(accessRequirement2.getId(), List.of(user1.getId()));
+
+		String s1 = submissionDao.createSubmission(createSubmission(accessRequirement, researchProject, System.currentTimeMillis(), user1.getId())).getSubmissionId();
+		String s2 = submissionDao.createSubmission(createSubmission(accessRequirement2, researchProject, System.currentTimeMillis() + 1000, user2.getId())).getSubmissionId();
+
+		String accessorId = null;
+		String requirementId = null;
+		List<SubmissionSearchSort> sort = List.of(new SubmissionSearchSort().setField(SubmissionSortField.MODIFIED_ON));
+		SubmissionState state = null;
+		String reviewerId = null;
+		SubmissionReviewerFilterType reviewerFilterType = SubmissionReviewerFilterType.DELEGATED_ONLY;
+		long limit = 10;
+		long offset = 0;
+
+		// Only s2 should be returned since AR2 has REVIEW_SUBMISSIONS
+		// AR1 only has EXEMPTION_ELIGIBLE so s1 should NOT be included
+		List<Submission> expected = List.of(
+			submissionDao.getSubmission(s2)
+		);
+
+		List<Submission> result = submissionDao.searchAllSubmissions(reviewerFilterType, sort, accessorId, requirementId, reviewerId, state, limit, offset);
+
+		assertEquals(expected, result);
+	}
+
+	@Test
+	public void testSearchSubmissionsWithMixedPermissions() {
+		// AR1 has an ACL with both REVIEW_SUBMISSIONS and EXEMPTION_ELIGIBLE (should be treated as DELEGATED_ONLY)
+		addAclWithAccessTypes(accessRequirement.getId(), List.of(user1.getId()), Set.of(ACCESS_TYPE.REVIEW_SUBMISSIONS, ACCESS_TYPE.EXEMPTION_ELIGIBLE));
+
+		String s1 = submissionDao.createSubmission(createSubmission(accessRequirement, researchProject, System.currentTimeMillis(), user1.getId())).getSubmissionId();
+		String s2 = submissionDao.createSubmission(createSubmission(accessRequirement2, researchProject, System.currentTimeMillis() + 1000, user2.getId())).getSubmissionId();
+
+		String accessorId = null;
+		String requirementId = null;
+		List<SubmissionSearchSort> sort = List.of(new SubmissionSearchSort().setField(SubmissionSortField.MODIFIED_ON));
+		SubmissionState state = null;
+		String reviewerId = null;
+		long limit = 10;
+		long offset = 0;
+
+		// Test ACT_ONLY: should only return s2 (AR2 has no ACL)
+		List<Submission> expected = List.of(
+			submissionDao.getSubmission(s2)
+		);
+
+		List<Submission> result = submissionDao.searchAllSubmissions(SubmissionReviewerFilterType.ACT_ONLY, sort, accessorId, requirementId, reviewerId, state, limit, offset);
+
+		assertEquals(expected, result);
+
+		// Test DELEGATED_ONLY: should only return s1 (AR1 has REVIEW_SUBMISSIONS)
+		expected = List.of(
+			submissionDao.getSubmission(s1)
+		);
+
+		result = submissionDao.searchAllSubmissions(SubmissionReviewerFilterType.DELEGATED_ONLY, sort, accessorId, requirementId, reviewerId, state, limit, offset);
+
+		assertEquals(expected, result);
+	}
+
 	private void addReviewers(Long arId, List<String> reviewerIds) {
+		addAclWithAccessTypes(arId, reviewerIds, Set.of(ACCESS_TYPE.REVIEW_SUBMISSIONS));
+	}
+
+	private void addAclWithAccessTypes(Long arId, List<String> principalIds, Set<ACCESS_TYPE> accessTypes) {
 		AccessControlList acl = new AccessControlList()
 			.setId(arId.toString())
 			.setCreationDate(new Date())
 			.setCreatedBy(user1.getId())
 			.setModifiedBy(user1.getId())
 			.setModifiedOn(new Date())
-			.setResourceAccess(reviewerIds.stream().map(reviewerId -> 
-				new ResourceAccess().setAccessType(Set.of(ACCESS_TYPE.REVIEW_SUBMISSIONS)).setPrincipalId(Long.valueOf(reviewerId))
+			.setResourceAccess(principalIds.stream().map(principalId ->
+				new ResourceAccess().setAccessType(accessTypes).setPrincipalId(Long.valueOf(principalId))
 			).collect(Collectors.toSet()));
-		
+
 		aclDao.create(acl, ObjectType.ACCESS_REQUIREMENT);
 	}
 	


### PR DESCRIPTION
Fix an issue where submission filtering looked at the presence of an ACL instead of inspecting the ACL contents.