### PR TITLE
PLFM-9324

### DIFF
--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -4632,10 +4632,10 @@ public interface SynapseClient extends BaseClient {
     
     RealmIdList listRealmIds() throws SynapseException ;
     
-    Realm getRealm() throws SynapseException;
-    
     Realm getRealm(String id) throws SynapseException ;
     
     RealmPrincipal getRealmPrincipals(String id) throws SynapseException ;
+    
+    RealmPrincipal getRealmPrincipals() throws SynapseException;
 }
 

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -4632,6 +4632,8 @@ public interface SynapseClient extends BaseClient {
     
     RealmIdList listRealmIds() throws SynapseException ;
     
+    Realm getRealm() throws SynapseException;
+    
     Realm getRealm(String id) throws SynapseException ;
     
     RealmPrincipal getRealmPrincipals(String id) throws SynapseException ;

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
@@ -755,6 +755,7 @@ public class SynapseClientImpl extends BaseClientImpl implements SynapseClient {
 	public static final String FILE_HANDLE_RESTORE = FILE_HANDLE + "/restore";
 	
 	protected static final String REALM = "/realm";
+	protected static final String PRINCIPALS = "/principals";
 	
 
 	/**
@@ -6577,17 +6578,17 @@ public class SynapseClientImpl extends BaseClientImpl implements SynapseClient {
 	}
 
 	@Override
-	public Realm getRealm() throws SynapseException {
-	       return getJSONEntity(getRepoEndpoint(), REALM, Realm.class);
-	}
-
-	@Override
 	public Realm getRealm(String id) throws SynapseException {
 	       return getJSONEntity(getRepoEndpoint(), REALM+"/"+id, Realm.class);
 	}
 
 	@Override
 	public RealmPrincipal getRealmPrincipals(String id) throws SynapseException {
-	       return getJSONEntity(getRepoEndpoint(), REALM+"/"+id+"/principals", RealmPrincipal.class);
+	       return getJSONEntity(getRepoEndpoint(), REALM+"/"+id+PRINCIPALS, RealmPrincipal.class);
+	}
+	
+	@Override
+	public RealmPrincipal getRealmPrincipals() throws SynapseException {
+		return getJSONEntity(getRepoEndpoint(), REALM+PRINCIPALS, RealmPrincipal.class);
 	}
 }

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
@@ -6577,6 +6577,11 @@ public class SynapseClientImpl extends BaseClientImpl implements SynapseClient {
 	}
 
 	@Override
+	public Realm getRealm() throws SynapseException {
+	       return getJSONEntity(getRepoEndpoint(), REALM, Realm.class);
+	}
+
+	@Override
 	public Realm getRealm(String id) throws SynapseException {
 	       return getJSONEntity(getRepoEndpoint(), REALM+"/"+id, Realm.class);
 	}

--- a/integration-test/src/test/java/org/sagebionetworks/ITRealm.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITRealm.java
@@ -1,14 +1,17 @@
 package org.sagebionetworks;
 
-import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sagebionetworks.client.SynapseAdminClient;
 import org.sagebionetworks.client.SynapseClient;
-import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.repo.model.auth.IdentityProvider;
 import org.sagebionetworks.repo.model.auth.OAuthIdentityProvider;
 import org.sagebionetworks.repo.model.auth.Realm;
@@ -29,9 +32,15 @@ public class ITRealm {
     private static final String NAME = "test-realm";
     private static final List<IdentityProvider> IDPS = 
     		List.of(new OAuthIdentityProvider().setProvider(OAuthProvider.ARCUS_BIOSCIENCES));
+    
+    // parameters for a new user, created inside the realm
+    private static final String USER_NAME_IN_REALM = UUID.randomUUID().toString();
+    private static final String PASSWORD_IN_REALM = "password"+UUID.randomUUID().toString();
+    private static final String EMNAIL_IN_REALM = UUID.randomUUID().toString() + "@sagebase.org";
+
 
 	@Test
-	public void testRoundTrip() throws SynapseException {
+	public void testRoundTrip() throws Exception {
 		// create realm
 		Realm realm = new Realm();
 		realm.setName(NAME);
@@ -56,10 +65,17 @@ public class ITRealm {
 		assertNotNull(principals.getPublicGroup());
 		assertNotNull(principals.getAdministrativeGroup());
 		
-		// can also determine the realm's principals from the user, inferring the realm through their access token:
-		RealmPrincipal principals2 = synapse.getRealmPrincipals();
-		assertEquals(principals, principals2);
-		
+		Long userIdInRealm = null;
+		try {
+			SynapseClientImpl synapseClientInNewRealm = new SynapseClientImpl();
+			userIdInRealm = SynapseClientHelper.createUser(adminSynapse, synapseClientInNewRealm,
+					USER_NAME_IN_REALM, PASSWORD_IN_REALM, EMNAIL_IN_REALM, true, false, IDPS.get(0));
+			// can also determine the realm's principals from the user, inferring the realm through their access token:
+			RealmPrincipal principals2 = synapseClientInNewRealm.getRealmPrincipals();
+			assertEquals(principals, principals2);
+		} finally {
+			adminSynapse.deleteUser(userIdInRealm);
+		}
 		// delete realm
 		adminSynapse.deleteRealm(id);
 	}

--- a/integration-test/src/test/java/org/sagebionetworks/ITRealm.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITRealm.java
@@ -48,10 +48,6 @@ public class ITRealm {
 		Realm retrieved = synapse.getRealm(id);
 		assertEquals(created, retrieved);
 		
-		// can also determine the realm from the user, thrpugh the access token:
-		retrieved = synapse.getRealm();
-		assertEquals(created, retrieved);
-		
 		// get realm principals
 		RealmPrincipal principals = synapse.getRealmPrincipals(id);
 		assertEquals(id, principals.getRealmId());
@@ -59,6 +55,10 @@ public class ITRealm {
 		assertNotNull(principals.getAuthenticatedUsers());
 		assertNotNull(principals.getPublicGroup());
 		assertNotNull(principals.getAdministrativeGroup());
+		
+		// can also determine the realm's principals from the user, inferring the realm through their access token:
+		RealmPrincipal principals2 = synapse.getRealmPrincipals();
+		assertEquals(principals, principals2);
 		
 		// delete realm
 		adminSynapse.deleteRealm(id);

--- a/integration-test/src/test/java/org/sagebionetworks/ITRealm.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITRealm.java
@@ -46,7 +46,10 @@ public class ITRealm {
 		
 		// get realm by id
 		Realm retrieved = synapse.getRealm(id);
+		assertEquals(created, retrieved);
 		
+		// can also determine the realm from the user, thrpugh the access token:
+		retrieved = synapse.getRealm();
 		assertEquals(created, retrieved);
 		
 		// get realm principals

--- a/integration-test/src/test/java/org/sagebionetworks/ITRealm.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITRealm.java
@@ -7,11 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sagebionetworks.client.SynapseAdminClient;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.SynapseClientImpl;
+import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.auth.IdentityProvider;
 import org.sagebionetworks.repo.model.auth.OAuthIdentityProvider;
 import org.sagebionetworks.repo.model.auth.Realm;
@@ -36,6 +38,20 @@ public class ITRealm {
     private static final String USER_NAME_IN_REALM = UUID.randomUUID().toString();
     private static final String PASSWORD_IN_REALM = "password"+UUID.randomUUID().toString();
     private static final String EMNAIL_IN_REALM = UUID.randomUUID().toString() + "@sagebase.org";
+    
+    private Realm realmToDelete;
+    
+    
+    @AfterEach
+    public void after() throws Exception {
+    	try {
+    		if (realmToDelete!=null) {
+    			adminSynapse.deleteRealm(realmToDelete.getId());
+    		}
+    	} catch (Exception e) {
+    		// fall through
+    	}
+    }
 
 
 	@Test
@@ -47,6 +63,7 @@ public class ITRealm {
 		Realm created = adminSynapse.createRealm(realm);
 		String id = created.getId();
 		assertNotNull(id);
+		realmToDelete=realm;
 		
 		// list realms
 		List<String> realms = synapse.listRealmIds().getRealms();
@@ -64,17 +81,14 @@ public class ITRealm {
 		assertNotNull(principals.getPublicGroup());
 		assertNotNull(principals.getAdministrativeGroup());
 		
-		Long userIdInRealm = null;
-		try {
-			SynapseClientImpl synapseClientInNewRealm = new SynapseClientImpl();
-			userIdInRealm = SynapseClientHelper.createUser(adminSynapse, synapseClientInNewRealm,
-					USER_NAME_IN_REALM, PASSWORD_IN_REALM, EMNAIL_IN_REALM, true, false, IDPS.get(0));
-			// can also determine the realm's principals from the user, inferring the realm through their access token:
-			RealmPrincipal principals2 = synapseClientInNewRealm.getRealmPrincipals();
-			assertEquals(principals, principals2);
-		} finally {
-			adminSynapse.deleteUser(userIdInRealm);
-		}
+		// can also determine the realm's principals from the user, inferring the realm through their access token:
+		principals = synapse.getRealmPrincipals();
+		assertEquals("0", principals.getRealmId()); // default realm
+		assertNotNull(principals.getAnonymousUser());
+		assertNotNull(principals.getAuthenticatedUsers());
+		assertNotNull(principals.getPublicGroup());
+		assertNotNull(principals.getAdministrativeGroup());
+		
 		// delete realm
 		adminSynapse.deleteRealm(id);
 	}

--- a/integration-test/src/test/java/org/sagebionetworks/ITRealm.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITRealm.java
@@ -20,7 +20,6 @@ import org.sagebionetworks.repo.model.oauth.OAuthProvider;
 
 @ExtendWith(ITTestExtension.class)
 public class ITRealm {
-
 	private SynapseClient synapse;
 	private SynapseAdminClient adminSynapse;
 

--- a/integration-test/src/test/java/org/sagebionetworks/SynapseClientHelper.java
+++ b/integration-test/src/test/java/org/sagebionetworks/SynapseClientHelper.java
@@ -1,17 +1,15 @@
 package org.sagebionetworks;
 
-import java.util.UUID;
-
 import org.sagebionetworks.client.SynapseAdminClient;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseException;
-import org.sagebionetworks.repo.model.auth.IdentityProvider;
 import org.sagebionetworks.repo.model.auth.JSONWebTokenHelper;
 import org.sagebionetworks.repo.model.auth.LoginResponse;
 import org.sagebionetworks.repo.model.auth.NewIntegrationTestUser;
-import org.sagebionetworks.repo.model.auth.SynapseIdentityProvider;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
+
+import java.util.UUID;
 
 /**
  * Holds helpers for setting up integration tests
@@ -49,12 +47,7 @@ public class SynapseClientHelper {
 	
 	public static Long createUser(SynapseAdminClient client, SynapseClient newUserClient, 
 			String username, String password, String email, boolean acceptsTermsOfUse, boolean validateUser) throws SynapseException, JSONObjectAdapterException {
-		return createUser(client, newUserClient, username, password, email, acceptsTermsOfUse, validateUser, new SynapseIdentityProvider());
-	}
-	
-	public static Long createUser(SynapseAdminClient client, SynapseClient newUserClient, 
-					String username, String password, String email, boolean acceptsTermsOfUse, boolean validateUser, IdentityProvider identityProvider) throws SynapseException, JSONObjectAdapterException {
-				if (newUserClient == null) {
+		if (newUserClient == null) {
 			newUserClient = new SynapseClientImpl();
 		}
 		setEndpoints(newUserClient);
@@ -65,7 +58,6 @@ public class SynapseClientHelper {
 		nu.setUsername(username);
 		nu.setPassword(password);
 		nu.setValidatedUser(validateUser);
-		nu.setIdentityProvider(identityProvider);
 		LoginResponse loginResponse = client.createIntegrationTestUser(nu);
 		
 		String accessTokenSubject = JSONWebTokenHelper.getSubjectFromJWTAccessToken(loginResponse.getAccessToken());

--- a/integration-test/src/test/java/org/sagebionetworks/SynapseClientHelper.java
+++ b/integration-test/src/test/java/org/sagebionetworks/SynapseClientHelper.java
@@ -1,15 +1,17 @@
 package org.sagebionetworks;
 
+import java.util.UUID;
+
 import org.sagebionetworks.client.SynapseAdminClient;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.repo.model.auth.IdentityProvider;
 import org.sagebionetworks.repo.model.auth.JSONWebTokenHelper;
 import org.sagebionetworks.repo.model.auth.LoginResponse;
 import org.sagebionetworks.repo.model.auth.NewIntegrationTestUser;
+import org.sagebionetworks.repo.model.auth.SynapseIdentityProvider;
 import org.sagebionetworks.schema.adapter.JSONObjectAdapterException;
-
-import java.util.UUID;
 
 /**
  * Holds helpers for setting up integration tests
@@ -42,11 +44,11 @@ public class SynapseClientHelper {
 	}
 	
 	public static Long createUser(SynapseAdminClient client, SynapseClient newUserClient, String username, String password, boolean acceptsTermsOfUse, boolean validateUser) throws SynapseException, JSONObjectAdapterException {
-		return createUser(client, newUserClient, username, password, UUID.randomUUID().toString() + "@sagebase.org", acceptsTermsOfUse, validateUser);
+		return createUser(client, newUserClient, username, password, UUID.randomUUID().toString() + "@sagebase.org", acceptsTermsOfUse, validateUser, new SynapseIdentityProvider());
 	}
 	
 	public static Long createUser(SynapseAdminClient client, SynapseClient newUserClient, 
-			String username, String password, String email, boolean acceptsTermsOfUse, boolean validateUser) throws SynapseException, JSONObjectAdapterException {
+			String username, String password, String email, boolean acceptsTermsOfUse, boolean validateUser, IdentityProvider identityProvider) throws SynapseException, JSONObjectAdapterException {
 		if (newUserClient == null) {
 			newUserClient = new SynapseClientImpl();
 		}
@@ -58,6 +60,7 @@ public class SynapseClientHelper {
 		nu.setUsername(username);
 		nu.setPassword(password);
 		nu.setValidatedUser(validateUser);
+		nu.setIdentityProvider(identityProvider);
 		LoginResponse loginResponse = client.createIntegrationTestUser(nu);
 		
 		String accessTokenSubject = JSONWebTokenHelper.getSubjectFromJWTAccessToken(loginResponse.getAccessToken());

--- a/integration-test/src/test/java/org/sagebionetworks/SynapseClientHelper.java
+++ b/integration-test/src/test/java/org/sagebionetworks/SynapseClientHelper.java
@@ -44,12 +44,17 @@ public class SynapseClientHelper {
 	}
 	
 	public static Long createUser(SynapseAdminClient client, SynapseClient newUserClient, String username, String password, boolean acceptsTermsOfUse, boolean validateUser) throws SynapseException, JSONObjectAdapterException {
-		return createUser(client, newUserClient, username, password, UUID.randomUUID().toString() + "@sagebase.org", acceptsTermsOfUse, validateUser, new SynapseIdentityProvider());
+		return createUser(client, newUserClient, username, password, UUID.randomUUID().toString() + "@sagebase.org", acceptsTermsOfUse, validateUser);
 	}
 	
 	public static Long createUser(SynapseAdminClient client, SynapseClient newUserClient, 
-			String username, String password, String email, boolean acceptsTermsOfUse, boolean validateUser, IdentityProvider identityProvider) throws SynapseException, JSONObjectAdapterException {
-		if (newUserClient == null) {
+			String username, String password, String email, boolean acceptsTermsOfUse, boolean validateUser) throws SynapseException, JSONObjectAdapterException {
+		return createUser(client, newUserClient, username, password, email, acceptsTermsOfUse, validateUser, new SynapseIdentityProvider());
+	}
+	
+	public static Long createUser(SynapseAdminClient client, SynapseClient newUserClient, 
+					String username, String password, String email, boolean acceptsTermsOfUse, boolean validateUser, IdentityProvider identityProvider) throws SynapseException, JSONObjectAdapterException {
+				if (newUserClient == null) {
 			newUserClient = new SynapseClientImpl();
 		}
 		setEndpoints(newUserClient);

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/auth/RealmDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/auth/RealmDaoImpl.java
@@ -39,6 +39,7 @@ import org.sagebionetworks.repo.model.oauth.OAuthProvider;
 import org.sagebionetworks.repo.transactions.WriteTransaction;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -71,6 +72,9 @@ public class RealmDaoImpl implements RealmDao {
 	
 	private static final String REALM_IDP_SQL = "SELECT * FROM "+TABLE_REALM_IDP+" WHERE "+COL_REALM_IDP_REALM_ID+" = ?";
 	
+	private static final String REALM_FOR_IDP_SQL = "SELECT "+COL_REALM_IDP_REALM_ID+" FROM "+TABLE_REALM_IDP+
+			" WHERE "+COL_REALM_IDP_PROVIDER+" = ?";
+	
 	private static final String REALM_PRINCIPAL_SQL = "SELECT * FROM "+TABLE_REALM_PRINCIPAL+" WHERE "+COL_REALM_PRINCIPAL_REALM_ID+" = ?";
 	
 	private static final String SELECT_ALL_IDS_SQL = "SELECT "+COL_REALM_ID+" FROM "+TABLE_REALM;
@@ -101,19 +105,23 @@ public class RealmDaoImpl implements RealmDao {
 		return result;
 	}
 	
+	static String identityProviderName(IdentityProvider idp) {
+		if (idp instanceof SynapseIdentityProvider) {
+			return SYNAPSE_IDENTITY_PROVIDER;
+		} else if (idp instanceof OAuthIdentityProvider) {
+			return ((OAuthIdentityProvider)idp).getProvider().name();
+		} else {
+			throw new IllegalArgumentException("Unexpected type "+idp.getClass().getName());
+		}
+	}
+	
 	static List<DBORealmIdentityProvider> copyRealmToRealmIdps(Realm realm) {
 		List<DBORealmIdentityProvider> result = new ArrayList<DBORealmIdentityProvider>();
 		if (realm.getIdentityProvider()!=null) {
 			for (IdentityProvider idp : realm.getIdentityProvider()) {
 				DBORealmIdentityProvider realmIdp = new DBORealmIdentityProvider();
 				realmIdp.setRealmId(stringToLong(realm.getId()));
-				if (idp instanceof SynapseIdentityProvider) {
-					realmIdp.setIdentityProvider(SYNAPSE_IDENTITY_PROVIDER);
-				} else if (idp instanceof OAuthIdentityProvider) {
-					realmIdp.setIdentityProvider(((OAuthIdentityProvider)idp).getProvider().name());
-				} else {
-					throw new IllegalArgumentException("Unexpected type "+idp.getClass().getName());
-				}
+				realmIdp.setIdentityProvider(identityProviderName(idp));
 				result.add(realmIdp);
 			}
 		}
@@ -246,6 +254,15 @@ public class RealmDaoImpl implements RealmDao {
 		copyRealmPrincipalsToRealm(principals, result);
 		result.setRealmId(id);
 		return result;
+	}
+	
+	@Override
+	public Optional<String> getRealmIdForIdentityProvider(IdentityProvider identityProvider) {
+		try {
+			return Optional.of(jdbcTemplate.queryForObject(REALM_FOR_IDP_SQL, String.class, identityProviderName(identityProvider)));
+		} catch (EmptyResultDataAccessException e) {
+			return Optional.empty();
+		}
 	}
 
 	@Override

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/auth/RealmDaoImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/auth/RealmDaoImplTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -113,6 +114,10 @@ class RealmDaoImplTest {
 
 	@Test
 	void testRoundtrip() {
+		// method under test
+		Optional<String> realmIdForProvider = realmDao.getRealmIdForIdentityProvider(IDP_LIST.get(0));
+		assertTrue(realmIdForProvider.isEmpty());
+		
 		// create a realm
 		Realm realm = new Realm();
 		realm.setName(NAME); 
@@ -134,6 +139,10 @@ class RealmDaoImplTest {
 		// method under test
 		Realm retrievedRealm = realmDao.getRealm(id);
 		assertEquals(created, retrievedRealm);
+		
+		// method under test
+		realmIdForProvider= realmDao.getRealmIdForIdentityProvider(IDP_LIST.get(0));
+		assertEquals(id, realmIdForProvider.get());
 	
 		RealmPrincipal realmPrincipal = new RealmPrincipal();
 		realmPrincipal.setRealmId(id);

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -119,10 +120,10 @@ public class DBOAccessControlListDAOImplTest {
 		
 		UserGroup ug = new UserGroup();
 		ug.setIsIndividual(true);
-		ug.setRealmId(AuthorizationConstants.DEFAULT_REALM_ID);
+		ug.setRealmId(DEFAULT_REALM_ID);
 		Long userId = userGroupDAO.create(ug);
 		boolean isAdmin = false;
-		userInfo = new UserInfo(isAdmin, userId);
+		userInfo = new UserInfo(isAdmin, userId, DEFAULT_REALM_ID);
 		userInfo.setGroups(Sets.newHashSet(userId, groupOneId, groupTwoId));
 
 		// Create an ACL for this node
@@ -672,8 +673,8 @@ public class DBOAccessControlListDAOImplTest {
 		Node visibleToOne = nodeDAO.createNewNode(NodeTestUtils.createNewFolder("visibleToOne", createdById, modifiedById, node.getId()));
 		Node visibleToTwo = nodeDAO.createNewNode(NodeTestUtils.createNewFolder("visibleToTwo", createdById, modifiedById, node.getId()));
 		
-		UserInfo userOne = new UserInfo(false, group.getId());
-		UserInfo userTwo = new UserInfo(false, group2.getId());
+		UserInfo userOne = new UserInfo(false, group.getId(), DEFAULT_REALM_ID);
+		UserInfo userTwo = new UserInfo(false, group2.getId(), DEFAULT_REALM_ID);
 		
 		AccessControlList acl1 = AccessControlListUtil.createACLToGrantEntityAdminAccess(visibleToOne.getId(), userOne, new Date());
 		createAcl(acl1, ObjectType.ENTITY);
@@ -713,8 +714,8 @@ public class DBOAccessControlListDAOImplTest {
 		Node visibleToOne = nodeDAO.createNewNode(NodeTestUtils.createNewFolder("visibleToOne", createdById, modifiedById, node.getId()));
 		Node visibleToTwo = nodeDAO.createNewNode(NodeTestUtils.createNewFolder("visibleToTwo", createdById, modifiedById, node.getId()));
 
-		UserInfo userOne = new UserInfo(false, group.getId());
-		UserInfo userTwo = new UserInfo(false, group2.getId());
+		UserInfo userOne = new UserInfo(false, group.getId(), DEFAULT_REALM_ID);
+		UserInfo userTwo = new UserInfo(false, group2.getId(), DEFAULT_REALM_ID);
 		
 		AccessControlList acl1 = AccessControlListUtil.createACLToGrantEntityAdminAccess(visibleToOne.getId(), userOne, new Date());
 		createAcl(acl1, ObjectType.ENTITY);
@@ -760,7 +761,7 @@ public class DBOAccessControlListDAOImplTest {
 		
 		Node node2 = nodeDAO.createNewNode(NodeTestUtils.createNewFolder("node2", createdById, modifiedById, node.getId()));
 		
-		AccessControlList acl2 = AccessControlListUtil.createACLToGrantEntityAdminAccess(node2.getId(), new UserInfo(false, group2.getId()), new Date());
+		AccessControlList acl2 = AccessControlListUtil.createACLToGrantEntityAdminAccess(node2.getId(), new UserInfo(false, group2.getId(), DEFAULT_REALM_ID), new Date());
 		acl2.getResourceAccess().add(new ResourceAccess().setPrincipalId(Long.valueOf(group.getId())).setAccessType(Set.of(ACCESS_TYPE.READ)));
 		createAcl(acl2, ObjectType.ENTITY);
 		

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplTest.java
@@ -673,8 +673,8 @@ public class DBOAccessControlListDAOImplTest {
 		Node visibleToOne = nodeDAO.createNewNode(NodeTestUtils.createNewFolder("visibleToOne", createdById, modifiedById, node.getId()));
 		Node visibleToTwo = nodeDAO.createNewNode(NodeTestUtils.createNewFolder("visibleToTwo", createdById, modifiedById, node.getId()));
 		
-		UserInfo userOne = new UserInfo(false, group.getId(), DEFAULT_REALM_ID);
-		UserInfo userTwo = new UserInfo(false, group2.getId(), DEFAULT_REALM_ID);
+		UserInfo userOne = new UserInfo(false, Long.parseLong(group.getId()), DEFAULT_REALM_ID);
+		UserInfo userTwo = new UserInfo(false, Long.parseLong(group2.getId()), DEFAULT_REALM_ID);
 		
 		AccessControlList acl1 = AccessControlListUtil.createACLToGrantEntityAdminAccess(visibleToOne.getId(), userOne, new Date());
 		createAcl(acl1, ObjectType.ENTITY);
@@ -714,8 +714,8 @@ public class DBOAccessControlListDAOImplTest {
 		Node visibleToOne = nodeDAO.createNewNode(NodeTestUtils.createNewFolder("visibleToOne", createdById, modifiedById, node.getId()));
 		Node visibleToTwo = nodeDAO.createNewNode(NodeTestUtils.createNewFolder("visibleToTwo", createdById, modifiedById, node.getId()));
 
-		UserInfo userOne = new UserInfo(false, group.getId(), DEFAULT_REALM_ID);
-		UserInfo userTwo = new UserInfo(false, group2.getId(), DEFAULT_REALM_ID);
+		UserInfo userOne = new UserInfo(false, Long.parseLong(group.getId()), DEFAULT_REALM_ID);
+		UserInfo userTwo = new UserInfo(false, Long.parseLong(group2.getId()), DEFAULT_REALM_ID);
 		
 		AccessControlList acl1 = AccessControlListUtil.createACLToGrantEntityAdminAccess(visibleToOne.getId(), userOne, new Date());
 		createAcl(acl1, ObjectType.ENTITY);
@@ -761,7 +761,7 @@ public class DBOAccessControlListDAOImplTest {
 		
 		Node node2 = nodeDAO.createNewNode(NodeTestUtils.createNewFolder("node2", createdById, modifiedById, node.getId()));
 		
-		AccessControlList acl2 = AccessControlListUtil.createACLToGrantEntityAdminAccess(node2.getId(), new UserInfo(false, group2.getId(), DEFAULT_REALM_ID), new Date());
+		AccessControlList acl2 = AccessControlListUtil.createACLToGrantEntityAdminAccess(node2.getId(), new UserInfo(false, Long.parseLong(group2.getId()), DEFAULT_REALM_ID), new Date());
 		acl2.getResourceAccess().add(new ResourceAccess().setPrincipalId(Long.valueOf(group.getId())).setAccessType(Set.of(ACCESS_TYPE.READ)));
 		createAcl(acl2, ObjectType.ENTITY);
 		

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/auth/NewIntegrationTestUser.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/auth/NewIntegrationTestUser.json
@@ -21,6 +21,10 @@
 		"validatedUser": {
 			"type": "boolean",
 			"description": "True if a verification approved states should be added for the user"
+		},
+		"identityProvider": {
+			"$ref": "org.sagebionetworks.repo.model.auth.IdentityProvider",
+			"description": "Identity provider used to infer the user's realm."
 		}
 	}
 }

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/RealmDao.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/RealmDao.java
@@ -30,7 +30,11 @@ public interface RealmDao {
 	 */
 	public Realm getRealm(String id);
 	
-	
+	/**
+	 * 
+	 * @param identityProvider
+	 * @return the ID of realm associated with the given identity provider, or null if there is none
+	 */
 	public Optional<String> getRealmIdForIdentityProvider(IdentityProvider identityProvider);
 	
 	/**

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/RealmDao.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/RealmDao.java
@@ -1,5 +1,8 @@
 package org.sagebionetworks.repo.model;
 
+import java.util.Optional;
+
+import org.sagebionetworks.repo.model.auth.IdentityProvider;
 import org.sagebionetworks.repo.model.auth.Realm;
 import org.sagebionetworks.repo.model.auth.RealmIdList;
 import org.sagebionetworks.repo.model.auth.RealmPrincipal;
@@ -26,6 +29,9 @@ public interface RealmDao {
 	 * @return
 	 */
 	public Realm getRealm(String id);
+	
+	
+	public Optional<String> getRealmIdForIdentityProvider(IdentityProvider identityProvider);
 	
 	/**
 	 * 

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/UserInfo.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/UserInfo.java
@@ -35,11 +35,6 @@ public class UserInfo {
 		this(isAdmin, id, null);
 	}
 	
-	@Deprecated
-	public UserInfo(boolean isAdmin, String id, String realmId){
-		this(isAdmin, Long.parseLong(id), realmId);
-	}
-	
 	/**
 	 * Helper to create a UserInfo
 	 * @param isAdmin

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/UserInfo.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/UserInfo.java
@@ -50,6 +50,7 @@ public class UserInfo {
 		this.id = id;
 		this.groups = new LinkedHashSet<Long>();
 		this.groups.add(this.id);
+		this.realmId=realmId;
 	}
 
 	public Set<Long> getGroups() {

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/UserInfo.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/UserInfo.java
@@ -170,8 +170,8 @@ public class UserInfo {
 
 	@Override
 	public String toString() {
-		return "UserInfo [groups=" + groups + ", isAdmin=" + isAdmin + ", id=" + id + ", creationDate=" + creationDate
-				+ ", hasTwoFactorAuthEnabled=" + hasTwoFactorAuthEnabled
+		return "UserInfo [groups=" + groups + ", isAdmin=" + isAdmin + ", id=" + id + ", realmId=" + realmId
+				+ ", creationDate=" + creationDate + ", hasTwoFactorAuthEnabled=" + hasTwoFactorAuthEnabled
 				+ ", context=" + context + "]";
 	}
 	

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/UserInfo.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/UserInfo.java
@@ -2,7 +2,6 @@ package org.sagebionetworks.repo.model;
 
 import java.util.Date;
 import java.util.LinkedHashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import org.sagebionetworks.repo.model.auth.CallersContext;
@@ -19,17 +18,26 @@ public class UserInfo {
 	
 	private final boolean isAdmin;
 	private Long id;
+	private String realmId;
 	private Date creationDate;
 	private boolean hasTwoFactorAuthEnabled;
 	private CallersContext context;
 
+	// Note: this is only used in unit tests
+	@Deprecated
 	public UserInfo(boolean isAdmin) {
 		this.isAdmin = isAdmin;
 	}
 	
+	// Note: this is only used in unit tests
 	@Deprecated
-	public UserInfo(boolean isAdmin, String id){
-		this(isAdmin, Long.parseLong(id));
+	public UserInfo(boolean isAdmin, Long id){
+		this(isAdmin, id, null);
+	}
+	
+	@Deprecated
+	public UserInfo(boolean isAdmin, String id, String realmId){
+		this(isAdmin, Long.parseLong(id), realmId);
 	}
 	
 	/**
@@ -37,7 +45,7 @@ public class UserInfo {
 	 * @param isAdmin
 	 * @param id
 	 */
-	public UserInfo(boolean isAdmin, Long id){
+	public UserInfo(boolean isAdmin, Long id, String realmId){
 		this.isAdmin = isAdmin;
 		this.id = id;
 		this.groups = new LinkedHashSet<Long>();
@@ -58,6 +66,14 @@ public class UserInfo {
 	public static void validateUserInfo(UserInfo info) throws UserNotFoundException {
 
 		if (info == null) throw new IllegalArgumentException("UserInfo cannot be null");
+	}
+
+	public String getRealmId() {
+		return realmId;
+	}
+
+	public void setRealmId(String realmId) {
+		this.realmId = realmId;
 	}
 
 	public Long getId() {
@@ -98,7 +114,16 @@ public class UserInfo {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(context, creationDate, groups, hasTwoFactorAuthEnabled, id, isAdmin);
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((context == null) ? 0 : context.hashCode());
+		result = prime * result + ((creationDate == null) ? 0 : creationDate.hashCode());
+		result = prime * result + ((groups == null) ? 0 : groups.hashCode());
+		result = prime * result + (hasTwoFactorAuthEnabled ? 1231 : 1237);
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + (isAdmin ? 1231 : 1237);
+		result = prime * result + ((realmId == null) ? 0 : realmId.hashCode());
+		return result;
 	}
 
 	@Override
@@ -110,10 +135,36 @@ public class UserInfo {
 		if (getClass() != obj.getClass())
 			return false;
 		UserInfo other = (UserInfo) obj;
-		return Objects.equals(context, other.context)
-				&& Objects.equals(creationDate, other.creationDate) && Objects.equals(groups, other.groups)
-				&& hasTwoFactorAuthEnabled == other.hasTwoFactorAuthEnabled && Objects.equals(id, other.id)
-				&& isAdmin == other.isAdmin;
+		if (context == null) {
+			if (other.context != null)
+				return false;
+		} else if (!context.equals(other.context))
+			return false;
+		if (creationDate == null) {
+			if (other.creationDate != null)
+				return false;
+		} else if (!creationDate.equals(other.creationDate))
+			return false;
+		if (groups == null) {
+			if (other.groups != null)
+				return false;
+		} else if (!groups.equals(other.groups))
+			return false;
+		if (hasTwoFactorAuthEnabled != other.hasTwoFactorAuthEnabled)
+			return false;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (isAdmin != other.isAdmin)
+			return false;
+		if (realmId == null) {
+			if (other.realmId != null)
+				return false;
+		} else if (!realmId.equals(other.realmId))
+			return false;
+		return true;
 	}
 
 	@Override

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NotificationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/NotificationManagerImpl.java
@@ -15,6 +15,7 @@ import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.file.FileHandle;
 import org.sagebionetworks.util.ValidateArgument;
 import org.springframework.beans.factory.annotation.Autowired;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 public class NotificationManagerImpl implements NotificationManager {
 
@@ -89,7 +90,8 @@ public class NotificationManagerImpl implements NotificationManager {
 			.withIncludeProfileSettingLink(false)
 			.withIncludeUnsubscribeLink(false)
 			.withIgnoreNotificationSettings(true)
-			.withSender(new UserInfo(true, AuthorizationConstants.BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId()))
+			.withSender(new UserInfo(true, AuthorizationConstants.BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId(),
+					DEFAULT_REALM_ID))
 			.withRecipients(Collections.singleton(user.getId().toString()))
 			.withTemplateFile(template)
 			.withSubject(subject)

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserInfoHelper.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserInfoHelper.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.repo.manager;
 
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -18,8 +20,7 @@ public class UserInfoHelper {
 	}
 	
 	public static UserInfo createAnonymousUserInfo() {
-		UserInfo result = new UserInfo(false);
-		result.setId(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId());
+		UserInfo result = new UserInfo(false, BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId(), DEFAULT_REALM_ID);
 		
 		Set<Long> groups = new HashSet<Long>();
 		// Everyone belongs to their own group and to Public

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserManagerImpl.java
@@ -15,6 +15,7 @@ import org.sagebionetworks.repo.model.AuthorizationUtils;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.GroupMembersDAO;
 import org.sagebionetworks.repo.model.NameConflictException;
+import org.sagebionetworks.repo.model.RealmDao;
 import org.sagebionetworks.repo.model.SessionIdThreadLocal;
 import org.sagebionetworks.repo.model.TeamConstants;
 import org.sagebionetworks.repo.model.UnauthorizedException;
@@ -25,7 +26,9 @@ import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.UserProfileDAO;
 import org.sagebionetworks.repo.model.auth.AuthenticationDAO;
 import org.sagebionetworks.repo.model.auth.CallersContext;
+import org.sagebionetworks.repo.model.auth.IdentityProvider;
 import org.sagebionetworks.repo.model.auth.NewUser;
+import org.sagebionetworks.repo.model.auth.OAuthIdentityProvider;
 import org.sagebionetworks.repo.model.dao.NotificationEmailDAO;
 import org.sagebionetworks.repo.model.dbo.DBOBasicDao;
 import org.sagebionetworks.repo.model.dbo.auth.UserStatusDao;
@@ -38,7 +41,6 @@ import org.sagebionetworks.repo.model.principal.PrincipalAlias;
 import org.sagebionetworks.repo.model.principal.PrincipalAliasDAO;
 import org.sagebionetworks.repo.transactions.WriteTransaction;
 import org.sagebionetworks.repo.web.NotFoundException;
-import org.sagebionetworks.securitytools.HMACUtils;
 import org.sagebionetworks.securitytools.PBKDF2Utils;
 import org.sagebionetworks.util.ValidateArgument;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +57,7 @@ public class UserManagerImpl implements UserManager {
 	private final NotificationEmailDAO notificationEmailDao;
 	private final PrincipalOIDCBindingDao principalOidcBindingDao;
 	private final UserStatusDao userStatusDao;
+	private final RealmDao realmDao;
 	
 	/**
 	 * Testing purposes only
@@ -67,7 +70,7 @@ public class UserManagerImpl implements UserManager {
 	public UserManagerImpl(UserGroupDAO userGroupDAO, UserProfileDAO userProfileDAO, GroupMembersDAO groupMembersDAO,
 			AuthenticationDAO authDAO, PrincipalAliasDAO principalAliasDAO, NotificationEmailDAO notificationEmailDao,
 			PrincipalOIDCBindingDao principalOIDCBindingDao,
-			DBOBasicDao basicDAO, UserStatusDao userStatusDao) {
+			DBOBasicDao basicDAO, UserStatusDao userStatusDao, RealmDao realmDao) {
 		super();
 		this.userGroupDAO = userGroupDAO;
 		this.userProfileDAO = userProfileDAO;
@@ -78,6 +81,7 @@ public class UserManagerImpl implements UserManager {
 		this.principalOidcBindingDao = principalOIDCBindingDao;
 		this.userStatusDao = userStatusDao;
 		this.basicDAO = basicDAO;
+		this.realmDao=realmDao;
 	}
 
 	@Override
@@ -95,11 +99,18 @@ public class UserManagerImpl implements UserManager {
 		if (alias != null) {
 			throw new NameConflictException("User '" + user.getUserName() + "' already exists");
 		}
+		String realmId=AuthorizationConstants.DEFAULT_REALM_ID;
 		// Make sure that the subject for an oauth provider is not bound yet
 		if (user.getOauthProvider() != null) {
 			lookupOidcBindingBySubject(user.getOauthProvider(), user.getSubject()).ifPresent((principalId)-> {
 				throw new NameConflictException("The provided '" + user.getOauthProvider() +"' account is already registered with Synapse");
 			});
+			IdentityProvider identityProvider = new OAuthIdentityProvider().setProvider(user.getOauthProvider());
+			Optional<String> optionalRealmId=realmDao.getRealmIdForIdentityProvider(identityProvider);
+			if (optionalRealmId.isEmpty()) {
+				throw new IllegalArgumentException("There is no security realm associated with "+user.getOauthProvider().name());
+			}
+			realmId=optionalRealmId.get();
 		}
 		
 		Date createdOn = new Date();
@@ -107,8 +118,7 @@ public class UserManagerImpl implements UserManager {
 		UserGroup individualGroup = new UserGroup();
 		individualGroup.setIsIndividual(true);
 		individualGroup.setCreationDate(createdOn);
-		// TODO Ultimately the realm will come from the NewUser object see PLFM-9324
-		individualGroup.setRealmId(AuthorizationConstants.DEFAULT_REALM_ID);
+		individualGroup.setRealmId(realmId);
 		Long principalId = userGroupDAO.create(individualGroup);
 		
 		// Make some credentials for this user
@@ -232,8 +242,7 @@ public class UserManagerImpl implements UserManager {
 		if(groups.contains(TeamConstants.ADMINISTRATORS_TEAM_ID)){
 			isAdmin = true;
 		}
-		UserInfo ui = new UserInfo(isAdmin);
-		ui.setId(principalId);
+		UserInfo ui = new UserInfo(isAdmin, principalId, principal.getRealmId());
 		ui.setCreationDate(principal.getCreationDate());
 		// Put all the pieces together
 		ui.setGroups(groups);

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/UserManagerImpl.java
@@ -29,6 +29,7 @@ import org.sagebionetworks.repo.model.auth.CallersContext;
 import org.sagebionetworks.repo.model.auth.IdentityProvider;
 import org.sagebionetworks.repo.model.auth.NewUser;
 import org.sagebionetworks.repo.model.auth.OAuthIdentityProvider;
+import org.sagebionetworks.repo.model.auth.RealmPrincipal;
 import org.sagebionetworks.repo.model.dao.NotificationEmailDAO;
 import org.sagebionetworks.repo.model.dbo.DBOBasicDao;
 import org.sagebionetworks.repo.model.dbo.auth.UserStatusDao;
@@ -216,19 +217,21 @@ public class UserManagerImpl implements UserManager {
 	public UserInfo getUserInfo(Long principalId) throws NotFoundException {
 		UserGroup principal = userGroupDAO.get(principalId);
 		if(!principal.getIsIndividual()) throw new IllegalArgumentException("Principal: "+principalId+" is not a User");
-		// Lookup the user's name
-		// Check which group(s) of Anonymous, Public, or Authenticated the user belongs to  
+
+		RealmPrincipal realmPrincipals = realmDao.getRealmPrincipals(principal.getRealmId());
+
+		// Check which group(s) of Anonymous, Public, or Authenticated the user belongs to
 		Set<Long> groups = new HashSet<Long>();
-		boolean isUserAnonymous = AuthorizationUtils.isUserAnonymous(principalId);
+		boolean isUserAnonymous = (principalId==Long.parseLong(realmPrincipals.getAnonymousUser()));
 		// Everyone except the anonymous users belongs to "authenticated users"
 		if (!isUserAnonymous) {
 			// All authenticated users belong to the authenticated user group
-			groups.add(BOOTSTRAP_PRINCIPAL.AUTHENTICATED_USERS_GROUP.getPrincipalId());
+			groups.add(Long.parseLong(realmPrincipals.getAuthenticatedUsers()));
 		}
 		
 		// Everyone belongs to their own group and to Public
 		groups.add(principalId);
-		groups.add(BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId());
+		groups.add(Long.parseLong(realmPrincipals.getPublicGroup()));
 		// Add all groups the user belongs to
 		List<UserGroup> groupFromDAO = groupMembersDAO.getUsersGroups(principal.getId());
 		// Add each group

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/handler/grid/GetGridSchemaHandler.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/handler/grid/GetGridSchemaHandler.java
@@ -40,8 +40,10 @@ public class GetGridSchemaHandler implements OpenApiReturnControlHandler {
 		GridAgentSessionContext context = event.getSessionContext(GridAgentSessionContext.class)
 				.orElseThrow(() -> new IllegalArgumentException("GridAgentSessionContext cannot be null"));
 
-		GridSession session = gridManager.getGridSession(new UserInfo(false, event.getRunAsUserId()),
-				context.getGridSessionId());
+		// NOTE Here we do not need to know the user's 'realm'
+		String userRealm = null;
+		UserInfo userInfo = new UserInfo(false, event.getRunAsUserId(), userRealm);
+		GridSession session = gridManager.getGridSession(userInfo, context.getGridSessionId());
 		if (session.getGridJsonSchema$Id() == null) {
 			return "{}";
 		}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/message/MessageTemplate.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/message/MessageTemplate.java
@@ -367,4 +367,14 @@ public class MessageTemplate {
 		};
 	}
 
+	@Override
+	public String toString() {
+		return "MessageTemplate [templateFile=" + templateFile + ", templateCharSet=" + templateCharSet
+				+ ", messageBodyMimeType=" + messageBodyMimeType + ", sender=" + sender + ", bcc=" + bcc + ", cc=" + cc
+				+ ", ignoreNotificationSettings=" + ignoreNotificationSettings + ", subject=" + subject
+				+ ", isNotificationMessage=" + isNotificationMessage + ", includeUnsubscribeLink="
+				+ includeUnsubscribeLink + ", includeProfileSettingLink=" + includeProfileSettingLink + ", recipients="
+				+ recipients + ", context=" + context + "]";
+	}
+
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/principal/PrincipalManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/principal/PrincipalManagerImpl.java
@@ -16,6 +16,7 @@ import org.sagebionetworks.repo.manager.SendRawEmailRequestBuilder.BodyType;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.message.PrincipalNameProvider;
 import org.sagebionetworks.repo.manager.token.TokenGenerator;
+import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationUtils;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.NameConflictException;
@@ -140,7 +141,6 @@ public class PrincipalManagerImpl implements PrincipalManager, PrincipalNameProv
 		newUser.setLastName(accountSetupInfo.getLastName());
 		newUser.setUserName(accountSetupInfo.getUsername());
 		long newPrincipalId = userManager.createUser(newUser);
-		
 		authManager.setPassword(newPrincipalId, accountSetupInfo.getPassword());
 		return authManager.loginWithNoPasswordCheck(newPrincipalId, tokenIssuer);
 	}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/principal/PrincipalManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/principal/PrincipalManagerImpl.java
@@ -16,7 +16,6 @@ import org.sagebionetworks.repo.manager.SendRawEmailRequestBuilder.BodyType;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.message.PrincipalNameProvider;
 import org.sagebionetworks.repo.manager.token.TokenGenerator;
-import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationUtils;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.NameConflictException;
@@ -141,6 +140,7 @@ public class PrincipalManagerImpl implements PrincipalManager, PrincipalNameProv
 		newUser.setLastName(accountSetupInfo.getLastName());
 		newUser.setUserName(accountSetupInfo.getUsername());
 		long newPrincipalId = userManager.createUser(newUser);
+		
 		authManager.setPassword(newPrincipalId, accountSetupInfo.getPassword());
 		return authManager.loginWithNoPasswordCheck(newPrincipalId, tokenIssuer);
 	}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/AdministrationServiceImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/AdministrationServiceImpl.java
@@ -23,6 +23,7 @@ import org.sagebionetworks.repo.model.admin.ExpireQuarantinedEmailRequest;
 import org.sagebionetworks.repo.model.auth.LoginResponse;
 import org.sagebionetworks.repo.model.auth.NewIntegrationTestUser;
 import org.sagebionetworks.repo.model.auth.NewUser;
+import org.sagebionetworks.repo.model.auth.OAuthIdentityProvider;
 import org.sagebionetworks.repo.model.auth.Realm;
 import org.sagebionetworks.repo.model.dbo.dao.DBOChangeDAO;
 import org.sagebionetworks.repo.model.dbo.ses.EmailQuarantineDao;
@@ -172,6 +173,10 @@ public class AdministrationServiceImpl implements AdministrationService  {
 		NewUser nu = new NewUser();
 		nu.setEmail(userSpecs.getEmail());
 		nu.setUserName(userSpecs.getUsername());
+		if (userSpecs.getIdentityProvider() instanceof OAuthIdentityProvider) {
+			OAuthIdentityProvider oidp = (OAuthIdentityProvider)userSpecs.getIdentityProvider();
+			nu.setOauthProvider(oidp.getProvider());
+		}
 		
 		// If null, do not sign
 		boolean signTermsOfService = Boolean.TRUE.equals(userSpecs.getTou());

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/RealmService.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/RealmService.java
@@ -28,4 +28,11 @@ public interface RealmService {
 	 * @return
 	 */
 	public RealmPrincipal getRealmPrincipals(String realmId);
+	
+	/**
+	 * 
+	 * @param userId
+	 * @return
+	 */
+	public RealmPrincipal getRealmPrincipals(Long userId);
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/RealmServiceImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/RealmServiceImpl.java
@@ -39,6 +39,5 @@ public class RealmServiceImpl implements RealmService {
 	public RealmPrincipal getRealmPrincipals(Long userId) {
 		UserInfo userInfo = userManager.getUserInfo(userId);
 		return realmManager.getRealmPrincipals(userInfo.getRealmId());
-
 	}
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/RealmServiceImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/RealmServiceImpl.java
@@ -1,6 +1,8 @@
 package org.sagebionetworks.repo.service;
 
 import org.sagebionetworks.repo.manager.RealmManager;
+import org.sagebionetworks.repo.manager.UserManager;
+import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.Realm;
 import org.sagebionetworks.repo.model.auth.RealmIdList;
 import org.sagebionetworks.repo.model.auth.RealmPrincipal;
@@ -12,6 +14,10 @@ public class RealmServiceImpl implements RealmService {
 	
 	@Autowired
 	RealmManager realmManager;
+	
+
+	@Autowired
+	private UserManager userManager;
 
 	@Override
 	public RealmIdList listRealmIds() {
@@ -26,6 +32,13 @@ public class RealmServiceImpl implements RealmService {
 	@Override
 	public RealmPrincipal getRealmPrincipals(String realmId) {
 		return realmManager.getRealmPrincipals(realmId);
+
+	}	
+	
+	@Override
+	public RealmPrincipal getRealmPrincipals(Long userId) {
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		return realmManager.getRealmPrincipals(userInfo.getRealmId());
 
 	}
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/RealmServiceImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/RealmServiceImpl.java
@@ -15,7 +15,6 @@ public class RealmServiceImpl implements RealmService {
 	@Autowired
 	RealmManager realmManager;
 	
-
 	@Autowired
 	private UserManager userManager;
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImpl.java
@@ -16,6 +16,7 @@ import org.sagebionetworks.repo.manager.oauth.OIDCTokenManager;
 import org.sagebionetworks.repo.manager.oauth.OpenIDConnectManager;
 import org.sagebionetworks.repo.manager.oauth.ProvidedUserInfo;
 import org.sagebionetworks.repo.model.AuthorizationUtils;
+import org.sagebionetworks.repo.model.RealmDao;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.AccessTokenGenerationRequest;
@@ -24,9 +25,11 @@ import org.sagebionetworks.repo.model.auth.AccessTokenRecord;
 import org.sagebionetworks.repo.model.auth.AccessTokenRecordList;
 import org.sagebionetworks.repo.model.auth.AuthenticatedOn;
 import org.sagebionetworks.repo.model.auth.ChangePasswordInterface;
+import org.sagebionetworks.repo.model.auth.IdentityProvider;
 import org.sagebionetworks.repo.model.auth.LoginRequest;
 import org.sagebionetworks.repo.model.auth.LoginResponse;
 import org.sagebionetworks.repo.model.auth.NewUser;
+import org.sagebionetworks.repo.model.auth.OAuthIdentityProvider;
 import org.sagebionetworks.repo.model.auth.PasswordResetSignedToken;
 import org.sagebionetworks.repo.model.auth.TermsOfServiceInfo;
 import org.sagebionetworks.repo.model.auth.TermsOfServiceRequirements;
@@ -61,6 +64,9 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 	
 	@Autowired
 	private UserManager userManager;
+	
+	@Autowired
+	RealmDao realmDao;
 	
 	@Autowired
 	private AuthenticationManager authManager;
@@ -266,11 +272,22 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 			throw new UnauthorizedException("User ID is required.");
 		}
 		
+		UserInfo user = userManager.getUserInfo(userId);
+		
 		AliasAndType providersUserId = oauthManager.retrieveProvidersId(
 				validationRequest.getProvider(), 
 				validationRequest.getAuthenticationCode(),
 				validationRequest.getRedirectUrl());
 		
+		// only allow the binding if the given provider is in the user's realm
+		IdentityProvider identityProvider = new OAuthIdentityProvider().setProvider(validationRequest.getProvider());
+		Optional<String> optionalRealmId = realmDao.getRealmIdForIdentityProvider(identityProvider);
+		if (optionalRealmId.isEmpty()) {
+			throw new IllegalArgumentException("There is no security realm associated with "+validationRequest.getProvider().name());
+		}
+		if (!user.getRealmId().equals(optionalRealmId.get())) {
+			throw new IllegalArgumentException("Cannot bind an alias from "+validationRequest.getProvider().name()+" for this user.");
+		}
 		// now bind the ID to the user account
 		return userManager.bindAlias(providersUserId.getAlias(), providersUserId.getType(), userId);
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/AuthorizationManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/AuthorizationManagerImplUnitTest.java
@@ -149,7 +149,7 @@ public class AuthorizationManagerImplUnitTest {
 	private AuthorizationManagerImpl authorizationManagerSpy;
 
 
-	private static String USER_PRINCIPAL_ID = "123";
+	private static long USER_PRINCIPAL_ID = 123L;
 	private static String EVAL_OWNER_PRINCIPAL_ID = "987";
 	private static String EVAL_ID = "1234567";
 	

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/AuthorizationManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/AuthorizationManagerImplUnitTest.java
@@ -53,7 +53,6 @@ import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.repo.model.AccessRequirementDAO;
 import org.sagebionetworks.repo.model.ActivityDAO;
-import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.DockerNodeDao;
@@ -199,7 +198,7 @@ public class AuthorizationManagerImplUnitTest {
 		userInfo = new UserInfo(false, USER_PRINCIPAL_ID, DEFAULT_REALM_ID);
 		adminUser = new UserInfo(true, 456L, DEFAULT_REALM_ID);
 		
-		anonymousUserInfo = new UserInfo(false, BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId(), AuthorizationConstants.DEFAULT_REALM_ID);
+		anonymousUserInfo = new UserInfo(false, BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId(), DEFAULT_REALM_ID);
 
 		evaluation = new Evaluation();
 		evaluation.setId(EVAL_ID);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/AuthorizationManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/AuthorizationManagerImplUnitTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 import static org.sagebionetworks.repo.model.docker.RegistryEventAction.pull;
 import static org.sagebionetworks.repo.model.docker.RegistryEventAction.push;
 import static org.sagebionetworks.repo.model.oauth.OAuthScope.download;
@@ -52,6 +53,7 @@ import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.AccessRequirement;
 import org.sagebionetworks.repo.model.AccessRequirementDAO;
 import org.sagebionetworks.repo.model.ActivityDAO;
+import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.DockerNodeDao;
@@ -84,7 +86,6 @@ import org.sagebionetworks.repo.model.oauth.OAuthScope;
 import org.sagebionetworks.repo.model.subscription.SubscriptionObjectType;
 import org.sagebionetworks.repo.model.v2.dao.V2WikiPageDao;
 import org.sagebionetworks.repo.web.NotFoundException;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
@@ -160,8 +161,8 @@ public class AuthorizationManagerImplUnitTest {
 	
 	private static final long USER_ID = 111L;
 
-	private static final UserInfo USER_INFO = new UserInfo(false, USER_ID);
-	private static final UserInfo ADMIN_INFO = new UserInfo(true, 1L);
+	private static final UserInfo USER_INFO = new UserInfo(false, USER_ID, DEFAULT_REALM_ID);
+	private static final UserInfo ADMIN_INFO = new UserInfo(true, 1L, DEFAULT_REALM_ID);
 	
 	private static final String REGISTRY_HOST = "docker.synapse.org";
 	private static final String SERVICE = REGISTRY_HOST;
@@ -195,10 +196,10 @@ public class AuthorizationManagerImplUnitTest {
 
 	@BeforeEach
 	public void setUp() throws Exception {
-		userInfo = new UserInfo(false, USER_PRINCIPAL_ID);
-		adminUser = new UserInfo(true, 456L);
+		userInfo = new UserInfo(false, USER_PRINCIPAL_ID, DEFAULT_REALM_ID);
+		adminUser = new UserInfo(true, 456L, DEFAULT_REALM_ID);
 		
-		anonymousUserInfo = new UserInfo(false, BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId());
+		anonymousUserInfo = new UserInfo(false, BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId(), AuthorizationConstants.DEFAULT_REALM_ID);
 
 		evaluation = new Evaluation();
 		evaluation.setId(EVAL_ID);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/NotificationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/NotificationManagerImplTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER;
 
 import java.util.Collections;
 import java.util.Date;
@@ -29,7 +31,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.manager.message.MessageTemplate;
 import org.sagebionetworks.repo.manager.message.TemplatedMessageSender;
-import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.file.S3FileHandle;
@@ -121,7 +122,7 @@ public class NotificationManagerImplTest {
 			.withIncludeProfileSettingLink(false)
 			.withIncludeUnsubscribeLink(false)
 			.withIgnoreNotificationSettings(true)
-			.withSender(new UserInfo(true, AuthorizationConstants.BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId()))
+			.withSender(new UserInfo(true, THE_ADMIN_USER.getPrincipalId(), DEFAULT_REALM_ID))
 			.withRecipients(Collections.singleton(user.getId().toString()))
 			.withTemplateFile(template)
 			.withSubject(subject)
@@ -147,7 +148,7 @@ public class NotificationManagerImplTest {
 			.withIncludeProfileSettingLink(false)
 			.withIncludeUnsubscribeLink(false)
 			.withIgnoreNotificationSettings(true)
-			.withSender(new UserInfo(true, AuthorizationConstants.BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId()))
+			.withSender(new UserInfo(true, THE_ADMIN_USER.getPrincipalId(), DEFAULT_REALM_ID))
 			.withRecipients(Collections.singleton(user.getId().toString()))
 			.withTemplateFile(template)
 			.withSubject(subject)

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserManagerImplUnitTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.repo.manager;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserManagerImplUnitTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -102,7 +103,13 @@ public class UserManagerImplUnitTest {
 	private String alias;
 	private PrincipalAlias principalAlias;
 	private String sessionId;
-	private RealmPrincipal realmPrincipals;
+	private RealmPrincipal defaultRealmPrincipals;
+	private RealmPrincipal altRealmPrincipals;
+	
+	private static final String REALM_ID = "1";
+	private static final String REALM_ANONYMOUS_ID = "101";
+	private static final String REALM_AUTH_USERS_ID = "102";
+	private static final String REALM_PUBLIC_ID = "103";
 	
 	@BeforeEach
 	public void setUp() throws Exception {
@@ -116,11 +123,17 @@ public class UserManagerImplUnitTest {
 		principalAlias.setPrincipalId(123L);
 		principalAlias.setType(AliasType.USER_NAME);
 		sessionId = SessionIdThreadLocal.createNewSessionIdForThread();
-		realmPrincipals = new RealmPrincipal();
-		realmPrincipals.setRealmId(AuthorizationConstants.DEFAULT_REALM_ID);
-		realmPrincipals.setAnonymousUser(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId().toString());
-		realmPrincipals.setAuthenticatedUsers(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.AUTHENTICATED_USERS_GROUP.getPrincipalId().toString());
-		realmPrincipals.setPublicGroup(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId().toString());
+		defaultRealmPrincipals = new RealmPrincipal();
+		defaultRealmPrincipals.setRealmId(DEFAULT_REALM_ID);
+		defaultRealmPrincipals.setAnonymousUser(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId().toString());
+		defaultRealmPrincipals.setAuthenticatedUsers(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.AUTHENTICATED_USERS_GROUP.getPrincipalId().toString());
+		defaultRealmPrincipals.setPublicGroup(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId().toString());
+		altRealmPrincipals = new RealmPrincipal();
+		altRealmPrincipals.setRealmId(REALM_ID);
+		altRealmPrincipals.setAnonymousUser(REALM_ANONYMOUS_ID);
+		altRealmPrincipals.setAuthenticatedUsers(REALM_AUTH_USERS_ID);
+		altRealmPrincipals.setPublicGroup(REALM_PUBLIC_ID);
+
 	}
 	
 	@AfterEach
@@ -134,6 +147,7 @@ public class UserManagerImplUnitTest {
 		UserGroup principal = new UserGroup();
 		principal.setId(principalId.toString());
 		principal.setIsIndividual(true);
+		principal.setRealmId(REALM_ID);
 		when(mockUserGroupDAO.get(principalId)).thenReturn(principal);
 		
 		UserGroup someGroup = new UserGroup();
@@ -141,8 +155,7 @@ public class UserManagerImplUnitTest {
 		someGroup.setId("222");
 		when(mockGroupMembersDAO.getUsersGroups(principalId.toString())).thenReturn(Collections.singletonList(someGroup));
 		when(mockAuthDAO.isTwoFactorAuthEnabled(anyLong())).thenReturn(true);
-		when(mockRealmDao.getRealmPrincipals(any())).thenReturn(realmPrincipals);
-				
+		when(mockRealmDao.getRealmPrincipals(REALM_ID)).thenReturn(altRealmPrincipals);
 		
 		// method under test
 		UserInfo userInfo = userManager.getUserInfo(principalId);
@@ -155,12 +168,38 @@ public class UserManagerImplUnitTest {
 		Set<Long> expectedUserGroupIds = new HashSet<Long>();
 		expectedUserGroupIds.add(Long.parseLong(someGroup.getId()));
 		expectedUserGroupIds.add(principalId);
-		expectedUserGroupIds.add(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.AUTHENTICATED_USERS_GROUP.getPrincipalId());
-		expectedUserGroupIds.add(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId());
+		expectedUserGroupIds.add(Long.parseLong(REALM_AUTH_USERS_ID));
+		expectedUserGroupIds.add(Long.parseLong(REALM_PUBLIC_ID));
 
 		assertEquals(expectedUserGroupIds, userInfo.getGroups());
 		assertEquals(principalId, userInfo.getId());
 		assertTrue(userInfo.hasTwoFactorAuthEnabled());
+	}
+	
+	@Test
+	public void testGetUserInfoAnonymous() {
+		Long principalId = Long.parseLong(REALM_ANONYMOUS_ID);
+		UserGroup principal = new UserGroup();
+		principal.setId(principalId.toString());
+		principal.setIsIndividual(true);
+		principal.setRealmId(REALM_ID);
+		when(mockUserGroupDAO.get(principalId)).thenReturn(principal);
+		
+		when(mockGroupMembersDAO.getUsersGroups(principalId.toString())).thenReturn(Collections.EMPTY_LIST);
+		when(mockAuthDAO.isTwoFactorAuthEnabled(anyLong())).thenReturn(false);
+		when(mockRealmDao.getRealmPrincipals(REALM_ID)).thenReturn(altRealmPrincipals);
+		
+		// method under test
+		UserInfo userInfo = userManager.getUserInfo(principalId);
+		
+		assertFalse(userInfo.isAdmin());
+		Set<Long> expectedUserGroupIds = new HashSet<Long>();
+		expectedUserGroupIds.add(principalId);
+		expectedUserGroupIds.add(Long.parseLong(REALM_PUBLIC_ID));
+
+		assertEquals(expectedUserGroupIds, userInfo.getGroups());
+		assertEquals(principalId, userInfo.getId());
+		assertFalse(userInfo.hasTwoFactorAuthEnabled());
 	}
 	
 	@Test
@@ -169,6 +208,7 @@ public class UserManagerImplUnitTest {
 		UserGroup principal = new UserGroup();
 		principal.setId(principalId.toString());
 		principal.setIsIndividual(true);
+		principal.setRealmId(DEFAULT_REALM_ID);
 		when(mockUserGroupDAO.get(principalId)).thenReturn(principal);
 		
 		UserGroup someGroup = new UserGroup();
@@ -176,7 +216,7 @@ public class UserManagerImplUnitTest {
 		someGroup.setId("222");
 		when(mockGroupMembersDAO.getUsersGroups(principalId.toString())).thenReturn(Collections.singletonList(someGroup));
 		when(mockAuthDAO.isTwoFactorAuthEnabled(anyLong())).thenReturn(true);
-		when(mockRealmDao.getRealmPrincipals(any())).thenReturn(realmPrincipals);
+		when(mockRealmDao.getRealmPrincipals(DEFAULT_REALM_ID)).thenReturn(defaultRealmPrincipals);
 		
 		SessionIdThreadLocal.clearThreadsSessionId();
 		
@@ -192,6 +232,7 @@ public class UserManagerImplUnitTest {
 		UserGroup principal = new UserGroup();
 		principal.setId(principalId.toString());
 		principal.setIsIndividual(true);
+		principal.setRealmId(DEFAULT_REALM_ID);
 		when(mockUserGroupDAO.get(principalId)).thenReturn(principal);
 		
 		UserGroup adminGroup = new UserGroup();
@@ -199,7 +240,7 @@ public class UserManagerImplUnitTest {
 		adminGroup.setId(TeamConstants.ADMINISTRATORS_TEAM_ID.toString());
 		when(mockGroupMembersDAO.getUsersGroups(principalId.toString())).thenReturn(Collections.singletonList(adminGroup));
 		when(mockAuthDAO.isTwoFactorAuthEnabled(anyLong())).thenReturn(true);
-		when(mockRealmDao.getRealmPrincipals(any())).thenReturn(realmPrincipals);
+		when(mockRealmDao.getRealmPrincipals(DEFAULT_REALM_ID)).thenReturn(defaultRealmPrincipals);
 				
 		// method under test
 		UserInfo userInfo = userManager.getUserInfo(principalId);
@@ -233,6 +274,7 @@ public class UserManagerImplUnitTest {
 		long principalId=1111L;
 		when(mockUserGroup.getId()).thenReturn(""+principalId);
 		when(mockUserGroup.getIsIndividual()).thenReturn(true);
+		when(mockUserGroup.getRealmId()).thenReturn(DEFAULT_REALM_ID);
 		when(mockUserGroupDAO.get(any(Long.class))).thenReturn(mockUserGroup);
 		PrincipalAlias alias = new PrincipalAlias();
 		alias.setPrincipalId(principalId);
@@ -243,7 +285,7 @@ public class UserManagerImplUnitTest {
 		nu.setUserName(username);
 		nu.setEmail(email);
 		when(mockPrincipalAliasDAO.findPrincipalWithAlias(username)).thenReturn(alias);
-		when(mockRealmDao.getRealmPrincipals(any())).thenReturn(realmPrincipals);
+		when(mockRealmDao.getRealmPrincipals(DEFAULT_REALM_ID)).thenReturn(defaultRealmPrincipals);
 				
 		// method under test
 		UserInfo userInfo = userManager.createOrGetTestUser(admin, nu, null, true);
@@ -570,7 +612,7 @@ public class UserManagerImplUnitTest {
 		
 		when(mockPrincipalOidcDao.findBindingForSubject(any(), any())).thenReturn(Optional.of(new PrincipalOidcBinding()));
 		
-		String result = assertThrows(NameConflictException.class, () -> {			
+		String result = assertThrows(NameConflictException.class, () -> {
 			// Call under test
 			userManager.createUser(user);
 		}).getMessage();

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserManagerImplUnitTest.java
@@ -36,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.GroupMembersDAO;
 import org.sagebionetworks.repo.model.NameConflictException;
+import org.sagebionetworks.repo.model.RealmDao;
 import org.sagebionetworks.repo.model.SessionIdThreadLocal;
 import org.sagebionetworks.repo.model.TeamConstants;
 import org.sagebionetworks.repo.model.UnauthorizedException;
@@ -46,7 +47,10 @@ import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.UserProfileDAO;
 import org.sagebionetworks.repo.model.auth.AuthenticationDAO;
 import org.sagebionetworks.repo.model.auth.CallersContext;
+import org.sagebionetworks.repo.model.auth.IdentityProvider;
 import org.sagebionetworks.repo.model.auth.NewUser;
+import org.sagebionetworks.repo.model.auth.OAuthIdentityProvider;
+import org.sagebionetworks.repo.model.auth.RealmPrincipal;
 import org.sagebionetworks.repo.model.dao.NotificationEmailDAO;
 import org.sagebionetworks.repo.model.dbo.DBOBasicDao;
 import org.sagebionetworks.repo.model.dbo.auth.UserStatusDao;
@@ -66,6 +70,8 @@ public class UserManagerImplUnitTest {
 
 	@Mock
 	private UserGroupDAO mockUserGroupDAO;
+	@Mock
+	private RealmDao mockRealmDao;
 	@Mock
 	private UserProfileDAO userProfileDAO;
 	@Mock
@@ -96,6 +102,7 @@ public class UserManagerImplUnitTest {
 	private String alias;
 	private PrincipalAlias principalAlias;
 	private String sessionId;
+	private RealmPrincipal realmPrincipals;
 	
 	@BeforeEach
 	public void setUp() throws Exception {
@@ -109,6 +116,11 @@ public class UserManagerImplUnitTest {
 		principalAlias.setPrincipalId(123L);
 		principalAlias.setType(AliasType.USER_NAME);
 		sessionId = SessionIdThreadLocal.createNewSessionIdForThread();
+		realmPrincipals = new RealmPrincipal();
+		realmPrincipals.setRealmId(AuthorizationConstants.DEFAULT_REALM_ID);
+		realmPrincipals.setAnonymousUser(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId().toString());
+		realmPrincipals.setAuthenticatedUsers(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.AUTHENTICATED_USERS_GROUP.getPrincipalId().toString());
+		realmPrincipals.setPublicGroup(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId().toString());
 	}
 	
 	@AfterEach
@@ -129,7 +141,8 @@ public class UserManagerImplUnitTest {
 		someGroup.setId("222");
 		when(mockGroupMembersDAO.getUsersGroups(principalId.toString())).thenReturn(Collections.singletonList(someGroup));
 		when(mockAuthDAO.isTwoFactorAuthEnabled(anyLong())).thenReturn(true);
-		
+		when(mockRealmDao.getRealmPrincipals(any())).thenReturn(realmPrincipals);
+				
 		
 		// method under test
 		UserInfo userInfo = userManager.getUserInfo(principalId);
@@ -163,6 +176,7 @@ public class UserManagerImplUnitTest {
 		someGroup.setId("222");
 		when(mockGroupMembersDAO.getUsersGroups(principalId.toString())).thenReturn(Collections.singletonList(someGroup));
 		when(mockAuthDAO.isTwoFactorAuthEnabled(anyLong())).thenReturn(true);
+		when(mockRealmDao.getRealmPrincipals(any())).thenReturn(realmPrincipals);
 		
 		SessionIdThreadLocal.clearThreadsSessionId();
 		
@@ -185,7 +199,8 @@ public class UserManagerImplUnitTest {
 		adminGroup.setId(TeamConstants.ADMINISTRATORS_TEAM_ID.toString());
 		when(mockGroupMembersDAO.getUsersGroups(principalId.toString())).thenReturn(Collections.singletonList(adminGroup));
 		when(mockAuthDAO.isTwoFactorAuthEnabled(anyLong())).thenReturn(true);
-		
+		when(mockRealmDao.getRealmPrincipals(any())).thenReturn(realmPrincipals);
+				
 		// method under test
 		UserInfo userInfo = userManager.getUserInfo(principalId);
 		
@@ -228,7 +243,8 @@ public class UserManagerImplUnitTest {
 		nu.setUserName(username);
 		nu.setEmail(email);
 		when(mockPrincipalAliasDAO.findPrincipalWithAlias(username)).thenReturn(alias);
-		
+		when(mockRealmDao.getRealmPrincipals(any())).thenReturn(realmPrincipals);
+				
 		// method under test
 		UserInfo userInfo = userManager.createOrGetTestUser(admin, nu, null, true);
 		// we get back the principal ID for the existing user
@@ -576,11 +592,14 @@ public class UserManagerImplUnitTest {
 	@Test
 	public void testCreateUserWithOauthProvider() {
 		Long userId = 123L;
+		String realmId="3";
 		
 		when(mockUserGroupDAO.create(any())).thenReturn(userId);
 		when(mockPrincipalAliasDAO.bindAliasToPrincipal(any())).thenReturn(principalAlias);
 		when(mockPrincipalOidcDao.findBindingForSubject(any(), any())).thenReturn(Optional.empty(), Optional.of(new PrincipalOidcBinding()));
-		
+		IdentityProvider identityProvider = new OAuthIdentityProvider().setProvider(OAuthProvider.GOOGLE_OAUTH_2_0);
+		when(mockRealmDao.getRealmIdForIdentityProvider(identityProvider)).thenReturn(Optional.of(realmId));
+				
 		NewUser user = new NewUser()
 			.setUserName(UUID.randomUUID().toString())
 			.setEmail(UUID.randomUUID().toString())
@@ -597,14 +616,14 @@ public class UserManagerImplUnitTest {
 		verify(mockPrincipalOidcDao, times(2)).findBindingForSubject(user.getOauthProvider(), user.getSubject());
 		
 		UserGroup expectedGroup = new UserGroup()
-			.setIsIndividual(true);
+			.setIsIndividual(true).setRealmId(realmId);
 		
 		ArgumentCaptor<UserGroup> ugCaptor = ArgumentCaptor.forClass(UserGroup.class);
 		
 		verify(mockUserGroupDAO).create(ugCaptor.capture());
 		
 		assertEquals(expectedGroup.setCreationDate(
-			ugCaptor.getValue().getCreationDate()).setRealmId(AuthorizationConstants.DEFAULT_REALM_ID), 
+			ugCaptor.getValue().getCreationDate()).setRealmId(realmId), 
 			ugCaptor.getValue());
 		
 		verify(mockAuthDAO).createNew(userId);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/dataaccess/AccessRequirementManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/dataaccess/AccessRequirementManagerImplUnitTest.java
@@ -96,7 +96,7 @@ public class AccessRequirementManagerImplUnitTest {
 	@Mock
 	private JiraClient jiraClient;
 
-	private static final String TEST_PRINCIPAL_ID = "1010101";
+	private static final long TEST_PRINCIPAL_ID = 1010101L;
 	private static final String TEST_ENTITY_ID = "syn98786543";
 
 	@Mock

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/dataaccess/AccessRequirementManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/dataaccess/AccessRequirementManagerImplUnitTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.repo.manager.dataaccess.AccessRequirementManagerImpl.DEFAULT_LIMIT;
 import static org.sagebionetworks.repo.manager.dataaccess.AccessRequirementManagerImpl.DEFAULT_OFFSET;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -131,7 +132,7 @@ public class AccessRequirementManagerImplUnitTest {
 
 	@BeforeEach
 	public void setUp() throws Exception {
-		userInfo = new UserInfo(false, TEST_PRINCIPAL_ID);
+		userInfo = new UserInfo(false, TEST_PRINCIPAL_ID, DEFAULT_REALM_ID);
 	}
 
 	@Test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/evaluation/SubmissionManagerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/evaluation/SubmissionManagerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,9 +53,6 @@ import org.sagebionetworks.repo.manager.EntityManager;
 import org.sagebionetworks.repo.manager.MessageToUserAndBody;
 import org.sagebionetworks.repo.manager.NodeManager;
 import org.sagebionetworks.repo.manager.UserProfileManager;
-import org.sagebionetworks.repo.manager.evaluation.EvaluationPermissionsManager;
-import org.sagebionetworks.repo.manager.evaluation.SubmissionEligibilityManager;
-import org.sagebionetworks.repo.manager.evaluation.SubmissionManagerImpl;
 import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.manager.file.FileHandleUrlRequest;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
@@ -197,8 +195,8 @@ public class SubmissionManagerTest {
     @BeforeEach
     public void setUp() throws Exception {
 		// User Info
-    	ownerInfo = new UserInfo(false, OWNER_ID);
-    	userInfo = new UserInfo(false, USER_ID);
+    	ownerInfo = new UserInfo(false, OWNER_ID, DEFAULT_REALM_ID);
+    	userInfo = new UserInfo(false, USER_ID, DEFAULT_REALM_ID);
     	
     	// FileHandles
 		List<FileHandle> handles = new ArrayList<FileHandle>();

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/evaluation/SubmissionManagerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/evaluation/SubmissionManagerTest.java
@@ -195,8 +195,8 @@ public class SubmissionManagerTest {
     @BeforeEach
     public void setUp() throws Exception {
 		// User Info
-    	ownerInfo = new UserInfo(false, OWNER_ID, DEFAULT_REALM_ID);
-    	userInfo = new UserInfo(false, USER_ID, DEFAULT_REALM_ID);
+    	ownerInfo = new UserInfo(false, Long.parseLong(OWNER_ID), DEFAULT_REALM_ID);
+    	userInfo = new UserInfo(false, Long.parseLong(USER_ID), DEFAULT_REALM_ID);
     	
     	// FileHandles
 		List<FileHandle> handles = new ArrayList<FileHandle>();

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleAuthorizationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleAuthorizationManagerImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.dbo.file.FileHandleDao;
 import org.sagebionetworks.repo.web.NotFoundException;
@@ -30,8 +32,8 @@ public class FileHandleAuthorizationManagerImplTest {
 	
 	@BeforeEach
 	public void before() {
-		userInfo = new UserInfo(false, 123L);
-		adminUser = new UserInfo(true, 455L);
+		userInfo = new UserInfo(false, 123L, DEFAULT_REALM_ID);
+		adminUser = new UserInfo(true, 455L, DEFAULT_REALM_ID);
 	}
 
 	@Test
@@ -43,7 +45,7 @@ public class FileHandleAuthorizationManagerImplTest {
 		assertTrue(manager.canAccessRawFileHandleById(adminUser, fileHandlId).isAuthorized(), "Admin should have access to all FileHandles");
 		assertTrue(manager.canAccessRawFileHandleById(userInfo, fileHandlId).isAuthorized(), "Creator should have access to their own FileHandles");
 		// change the users id
-		UserInfo notTheCreatoro = new UserInfo(false, "999999");
+		UserInfo notTheCreatoro = new UserInfo(false, "999999", DEFAULT_REALM_ID);
 		assertFalse(manager.canAccessRawFileHandleById(notTheCreatoro, fileHandlId).isAuthorized(), "Only the creator (or admin) should have access a FileHandle");
 		verify(fileHandleDao, times(2)).getHandleCreator(fileHandlId);
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleAuthorizationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleAuthorizationManagerImplTest.java
@@ -45,7 +45,7 @@ public class FileHandleAuthorizationManagerImplTest {
 		assertTrue(manager.canAccessRawFileHandleById(adminUser, fileHandlId).isAuthorized(), "Admin should have access to all FileHandles");
 		assertTrue(manager.canAccessRawFileHandleById(userInfo, fileHandlId).isAuthorized(), "Creator should have access to their own FileHandles");
 		// change the users id
-		UserInfo notTheCreatoro = new UserInfo(false, "999999", DEFAULT_REALM_ID);
+		UserInfo notTheCreatoro = new UserInfo(false, 999999L, DEFAULT_REALM_ID);
 		assertFalse(manager.canAccessRawFileHandleById(notTheCreatoro, fileHandlId).isAuthorized(), "Only the creator (or admin) should have access a FileHandle");
 		verify(fileHandleDao, times(2)).getHandleCreator(fileHandlId);
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleManagerImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.repo.manager.file.FileHandleManagerImpl.MAX_REQUESTS_PER_CALL;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 import java.io.File;
 import java.io.IOException;
@@ -279,11 +280,11 @@ public class FileHandleManagerImplTest {
 		key = BASE_KEY + "/some-key";
 
 		// The user is not really a mock
-		mockUser = new UserInfo(false,"987");
+		mockUser = new UserInfo(false,"987",DEFAULT_REALM_ID);
 		sessionId = UUID.randomUUID().toString();
 		mockUser.setContext(new CallersContext().setSessionId(sessionId));
 		
-		anonymousUser = new UserInfo(false, AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId());
+		anonymousUser = new UserInfo(false, AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId(),DEFAULT_REALM_ID);
 
 		// This file stream is actually a file and not a parameter
 		String contentType = "text/plain";
@@ -1288,7 +1289,7 @@ public class FileHandleManagerImplTest {
 		String expecedURL = "https://amamzon.com";
 		when(mockS3Client.generatePresignedUrl(any(GeneratePresignedUrlRequest.class))).thenReturn(new URL(expecedURL));
 		when(mockStackConfig.getS3Bucket()).thenReturn("data.dev.sagebase.org");
-		mockUser = new UserInfo(false, 456L);
+		mockUser = new UserInfo(false, 456L, DEFAULT_REALM_ID);
 		String redirect = manager.getRedirectURLForFileHandle(mockUser, s3FileHandle.getId());
 		assertEquals(expecedURL, redirect);
 	}
@@ -1301,7 +1302,7 @@ public class FileHandleManagerImplTest {
 		s3FileHandle.setBucketName("bucket");
 		s3FileHandle.setKey("key");
 		when(mockFileHandleDao.get(s3FileHandle.getId())).thenReturn(s3FileHandle);
-		mockUser = new UserInfo(false, 896L);
+		mockUser = new UserInfo(false, 896L, DEFAULT_REALM_ID);
 		assertThrows(UnauthorizedException.class, () -> manager.getRedirectURLForFileHandle(mockUser, s3FileHandle.getId()));
 	}
 	

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/file/FileHandleManagerImplTest.java
@@ -280,7 +280,7 @@ public class FileHandleManagerImplTest {
 		key = BASE_KEY + "/some-key";
 
 		// The user is not really a mock
-		mockUser = new UserInfo(false,"987",DEFAULT_REALM_ID);
+		mockUser = new UserInfo(false,987L,DEFAULT_REALM_ID);
 		sessionId = UUID.randomUUID().toString();
 		mockUser.setContext(new CallersContext().setSessionId(sessionId));
 		

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/migration/MigrationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/migration/MigrationManagerImplTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -235,7 +236,7 @@ public class MigrationManagerImplTest {
 	@Test
 	public void testgetMigrationChecksumForTypeReadWriteMode() throws Exception {
 		when(mockStatusDao.getCurrentStatus()).thenReturn(StatusEnum.READ_WRITE);
-		UserInfo user = new UserInfo(true, "0");
+		UserInfo user = new UserInfo(true, "0", DEFAULT_REALM_ID);
 		assertThrows(RuntimeException.class, ()->{
 			// call under test
 			manager.getChecksumForType(user, MigrationType.FILE_HANDLE);
@@ -245,7 +246,7 @@ public class MigrationManagerImplTest {
 	@Test
 	public void testgetMigrationChecksumForTypeReadOnlyMode() throws Exception {
 		when(mockStatusDao.getCurrentStatus()).thenReturn(StatusEnum.READ_ONLY);
-		UserInfo user = new UserInfo(true, "0");
+		UserInfo user = new UserInfo(true, "0", DEFAULT_REALM_ID);
 		MigrationTypeChecksum c = manager.getChecksumForType(user, MigrationType.FILE_HANDLE);
 	}
 	

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/migration/MigrationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/migration/MigrationManagerImplTest.java
@@ -236,7 +236,7 @@ public class MigrationManagerImplTest {
 	@Test
 	public void testgetMigrationChecksumForTypeReadWriteMode() throws Exception {
 		when(mockStatusDao.getCurrentStatus()).thenReturn(StatusEnum.READ_WRITE);
-		UserInfo user = new UserInfo(true, "0", DEFAULT_REALM_ID);
+		UserInfo user = new UserInfo(true, 0L, DEFAULT_REALM_ID);
 		assertThrows(RuntimeException.class, ()->{
 			// call under test
 			manager.getChecksumForType(user, MigrationType.FILE_HANDLE);
@@ -246,7 +246,7 @@ public class MigrationManagerImplTest {
 	@Test
 	public void testgetMigrationChecksumForTypeReadOnlyMode() throws Exception {
 		when(mockStatusDao.getCurrentStatus()).thenReturn(StatusEnum.READ_ONLY);
-		UserInfo user = new UserInfo(true, "0", DEFAULT_REALM_ID);
+		UserInfo user = new UserInfo(true, 0L, DEFAULT_REALM_ID);
 		MigrationTypeChecksum c = manager.getChecksumForType(user, MigrationType.FILE_HANDLE);
 	}
 	

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/team/MembershipInvitationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/team/MembershipInvitationManagerImplTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.repo.manager.team.MembershipInvitationManagerImpl.TWENTY_FOUR_HOURS_IN_MS;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -136,7 +137,7 @@ public class MembershipInvitationManagerImplTest {
 
 	@BeforeEach
 	public void setUp() throws Exception {
-		userInfo = new UserInfo(false, MEMBER_PRINCIPAL_ID);
+		userInfo = new UserInfo(false, MEMBER_PRINCIPAL_ID, DEFAULT_REALM_ID);
 		userInfo.setGroups(Collections.singleton(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.CERTIFIED_USERS.getPrincipalId()));
 		userProfile = new UserProfile();
 		userProfile.setFirstName("First");

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/team/MembershipInvitationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/team/MembershipInvitationManagerImplTest.java
@@ -137,7 +137,7 @@ public class MembershipInvitationManagerImplTest {
 
 	@BeforeEach
 	public void setUp() throws Exception {
-		userInfo = new UserInfo(false, MEMBER_PRINCIPAL_ID, DEFAULT_REALM_ID);
+		userInfo = new UserInfo(false, Long.parseLong(MEMBER_PRINCIPAL_ID), DEFAULT_REALM_ID);
 		userInfo.setGroups(Collections.singleton(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.CERTIFIED_USERS.getPrincipalId()));
 		userProfile = new UserProfile();
 		userProfile.setFirstName("First");

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/team/TeamManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/team/TeamManagerImplTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -157,7 +158,7 @@ public class TeamManagerImplTest {
 	}
 	
 	private static UserInfo createUserInfo(boolean isAdmin, String principalId) {
-		UserInfo userInfo = new UserInfo(isAdmin, principalId);
+		UserInfo userInfo = new UserInfo(isAdmin, principalId, DEFAULT_REALM_ID);
 		return userInfo;
 	}
 	

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/team/TeamManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/team/TeamManagerImplTest.java
@@ -134,6 +134,7 @@ public class TeamManagerImplTest {
 	private UserProfile up;
 	
 	private static final String MEMBER_PRINCIPAL_ID = "999";
+	private static final Long MEMBER_PRINCIPAL_ID_LONG = Long.parseLong(MEMBER_PRINCIPAL_ID);
 	private static final String TEAM_ID = "123";
 
 	private RestrictionInformationRequest restrictionInfoRqst;
@@ -142,12 +143,12 @@ public class TeamManagerImplTest {
 
 	@BeforeEach
 	public void setUp() {
-		userInfo = createUserInfo(false, MEMBER_PRINCIPAL_ID);
+		userInfo = createUserInfo(false, MEMBER_PRINCIPAL_ID_LONG);
 		up = new UserProfile();
 		up.setFirstName("foo");
 		up.setLastName("bar");
 		up.setUserName("userName");
-		adminInfo = createUserInfo(true, "-1");
+		adminInfo = createUserInfo(true, -1L);
 		restrictionInfoRqst = new RestrictionInformationRequest();
 		restrictionInfoRqst.setRestrictableObjectType(RestrictableObjectType.TEAM);
 		restrictionInfoRqst.setObjectId(TEAM_ID);
@@ -157,7 +158,7 @@ public class TeamManagerImplTest {
 		noUnmetAccessRqmtResponse.setHasUnmetAccessRequirement(false);
 	}
 	
-	private static UserInfo createUserInfo(boolean isAdmin, String principalId) {
+	private static UserInfo createUserInfo(boolean isAdmin, Long principalId) {
 		UserInfo userInfo = new UserInfo(isAdmin, principalId, DEFAULT_REALM_ID);
 		return userInfo;
 	}
@@ -262,7 +263,7 @@ public class TeamManagerImplTest {
 		assertEquals(TEAM_ID, acl.getId());
 		assertEquals(3, acl.getResourceAccess().size());
 		for (ResourceAccess ra : acl.getResourceAccess()) {
-			if (ra.getPrincipalId().toString().equals(MEMBER_PRINCIPAL_ID)) {
+			if (ra.getPrincipalId().equals(MEMBER_PRINCIPAL_ID_LONG)) {
 				assertEquals(new HashSet<ACCESS_TYPE>(Arrays.asList(new ACCESS_TYPE[]{
 						ACCESS_TYPE.READ, 
 						ACCESS_TYPE.UPDATE, 
@@ -293,7 +294,7 @@ public class TeamManagerImplTest {
 		assertEquals(1, acl.getResourceAccess().size());
 		ResourceAccess ra = acl.getResourceAccess().iterator().next();
 		assertEquals(new HashSet<ACCESS_TYPE>(Arrays.asList(new ACCESS_TYPE[]{ACCESS_TYPE.TEAM_MEMBERSHIP_UPDATE})), ra.getAccessType());
-		assertEquals((Long)Long.parseLong(MEMBER_PRINCIPAL_ID), ra.getPrincipalId());
+		assertEquals(MEMBER_PRINCIPAL_ID_LONG, ra.getPrincipalId());
 	}
 	
 	@Test
@@ -624,7 +625,7 @@ public class TeamManagerImplTest {
 
 		// I canNOT add myself if I'm not an admin on the Team if I haven't been invited...
 		when(mockAuthorizationManager.canAccess(userInfo, TEAM_ID, ObjectType.TEAM, ACCESS_TYPE.TEAM_MEMBERSHIP_UPDATE)).thenReturn(AuthorizationStatus.accessDenied(""));
-		when(mockMembershipInvitationDAO.getOpenByTeamAndUserCount(eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(MEMBER_PRINCIPAL_ID)), anyLong())).thenReturn(0L);
+		when(mockMembershipInvitationDAO.getOpenByTeamAndUserCount(eq(Long.parseLong(TEAM_ID)), eq(MEMBER_PRINCIPAL_ID_LONG), anyLong())).thenReturn(0L);
 		assertEquals(teamManagerImpl.canAddTeamMember(userInfo, TEAM_ID, userInfo, false), TeamManagerImpl.UNAUTHORIZED_ADD_TEAM_MEMBER_MUST_HAVE_INVITATION);
 		// ... but it returns true if I'm already on the team...
 		assertEquals(teamManagerImpl.canAddTeamMember(userInfo, TEAM_ID, userInfo, true), TeamManagerImpl.AUTHORIZED_ADD_TEAM_MEMBER);
@@ -635,22 +636,22 @@ public class TeamManagerImplTest {
 
 		// I can add myself if I'm not an admin on the team if I've been invited
 		when(mockTeamDAO.getState(TEAM_ID)).thenReturn(TeamState.CLOSED);
-		when(mockMembershipInvitationDAO.getOpenByTeamAndUserCount(eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(MEMBER_PRINCIPAL_ID)), anyLong())).thenReturn(1L);
+		when(mockMembershipInvitationDAO.getOpenByTeamAndUserCount(eq(Long.parseLong(TEAM_ID)), eq(MEMBER_PRINCIPAL_ID_LONG), anyLong())).thenReturn(1L);
 		assertEquals(teamManagerImpl.canAddTeamMember(userInfo, TEAM_ID, userInfo, false), TeamManagerImpl.AUTHORIZED_ADD_TEAM_MEMBER);
 		
 		// I can't add myself if I'm invited to some other team...
 		when(mockMembershipInvitationDAO.getOpenByTeamAndUserCount(
-				eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(MEMBER_PRINCIPAL_ID)), anyLong())).thenReturn(1L);
+				eq(Long.parseLong(TEAM_ID)), eq(MEMBER_PRINCIPAL_ID_LONG), anyLong())).thenReturn(1L);
 		assertEquals(teamManagerImpl.canAddTeamMember(userInfo, TEAM_ID, userInfo, false),  TeamManagerImpl.AUTHORIZED_ADD_TEAM_MEMBER);
 		
 		when(mockMembershipInvitationDAO.getOpenByTeamAndUserCount(
-				eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(MEMBER_PRINCIPAL_ID)), anyLong())).thenReturn(0L);
+				eq(Long.parseLong(TEAM_ID)), eq(MEMBER_PRINCIPAL_ID_LONG), anyLong())).thenReturn(0L);
 		assertEquals(teamManagerImpl.canAddTeamMember(userInfo, TEAM_ID, userInfo, false), TeamManagerImpl.UNAUTHORIZED_ADD_TEAM_MEMBER_MUST_HAVE_INVITATION);
 		// ok if I'm already in the team
 		assertEquals(teamManagerImpl.canAddTeamMember(userInfo, TEAM_ID, userInfo, true), TeamManagerImpl.AUTHORIZED_ADD_TEAM_MEMBER);
 		// restore the mock
 		when(mockMembershipInvitationDAO.getOpenByTeamAndUserCount(
-				eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(MEMBER_PRINCIPAL_ID)), anyLong())).thenReturn(1L);
+				eq(Long.parseLong(TEAM_ID)), eq(MEMBER_PRINCIPAL_ID_LONG), anyLong())).thenReturn(1L);
 
 		assertEquals(teamManagerImpl.canAddTeamMember(adminInfo, TEAM_ID, adminInfo, false), TeamManagerImpl.AUTHORIZED_ADD_TEAM_MEMBER);
 
@@ -675,19 +676,19 @@ public class TeamManagerImplTest {
 		//	 I am an admin for the team
 		when(mockAuthorizationManager.canAccess(userInfo, TEAM_ID, ObjectType.TEAM, ACCESS_TYPE.TEAM_MEMBERSHIP_UPDATE)).thenReturn(AuthorizationStatus.authorized());
 		//	 there has been no membership request
-		String otherPrincipalId = "987";
+		Long otherPrincipalId = 987L;
 		UserInfo otherUserInfo = createUserInfo(false, otherPrincipalId);
 		when(mockRestrictionInformationManager.
 				getRestrictionInformation(otherUserInfo, restrictionInfoRqst)).
 					thenReturn(noUnmetAccessRqmtResponse);
 
-		when(mockMembershipRequestDAO.getOpenByTeamAndRequesterCount(eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(otherPrincipalId)), anyLong())).thenReturn(0L);
+		when(mockMembershipRequestDAO.getOpenByTeamAndRequesterCount(eq(Long.parseLong(TEAM_ID)), eq(otherPrincipalId), anyLong())).thenReturn(0L);
 		assertEquals(teamManagerImpl.canAddTeamMember(userInfo, TEAM_ID, otherUserInfo, false), TeamManagerImpl.UNAUTHORIZED_ADD_TEAM_MEMBER_MUST_HAVE_REQUEST);
 		// but the check returns true if I'm already on the Team
 		assertEquals(teamManagerImpl.canAddTeamMember(userInfo, TEAM_ID, otherUserInfo, true), TeamManagerImpl.AUTHORIZED_ADD_TEAM_MEMBER);
 		
 		//	 now there IS a membership request
-		when(mockMembershipRequestDAO.getOpenByTeamAndRequesterCount(eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(otherPrincipalId)), anyLong())).thenReturn(3L);
+		when(mockMembershipRequestDAO.getOpenByTeamAndRequesterCount(eq(Long.parseLong(TEAM_ID)), eq(otherPrincipalId), anyLong())).thenReturn(3L);
 		assertEquals(teamManagerImpl.canAddTeamMember(userInfo, TEAM_ID, otherUserInfo, false), TeamManagerImpl.AUTHORIZED_ADD_TEAM_MEMBER);
 		
 		// also, I can't add them even though there's a request if I'm not an admin on the team
@@ -713,32 +714,32 @@ public class TeamManagerImplTest {
 	public void testAddMember() {
 		// 'userInfo' is a team admin and there is a membership request from 987
 		when(mockAuthorizationManager.canAccess(userInfo, TEAM_ID, ObjectType.TEAM, ACCESS_TYPE.TEAM_MEMBERSHIP_UPDATE)).thenReturn(AuthorizationStatus.authorized());
-		String principalId = "987";
+		Long principalId = 987L;
 		UserInfo principalUserInfo = createUserInfo(false, principalId);
-		when(mockMembershipRequestDAO.getOpenByTeamAndRequesterCount(eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(principalId)), anyLong())).thenReturn(1L);
+		when(mockMembershipRequestDAO.getOpenByTeamAndRequesterCount(eq(Long.parseLong(TEAM_ID)), eq(principalId), anyLong())).thenReturn(1L);
 		when(mockRestrictionInformationManager.
 				getRestrictionInformation(principalUserInfo, restrictionInfoRqst)).
 					thenReturn(noUnmetAccessRqmtResponse);
 		
 		boolean added = teamManagerImpl.addMember(userInfo, TEAM_ID, principalUserInfo);
 		assertTrue(added);
-		verify(mockGroupMembersDAO).addMembers(TEAM_ID, Arrays.asList(new String[]{principalId}));
-		verify(mockMembershipInvitationDAO).deleteByTeamAndUser(Long.parseLong(TEAM_ID), Long.parseLong(principalId));
-		verify(mockMembershipRequestDAO).deleteByTeamAndRequester(Long.parseLong(TEAM_ID), Long.parseLong(principalId));
-		verify(mockProjectStatsManager).memberAddedToTeam(eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(principalId)), any(Date.class));
+		verify(mockGroupMembersDAO).addMembers(TEAM_ID, Arrays.asList(new String[]{principalId.toString()}));
+		verify(mockMembershipInvitationDAO).deleteByTeamAndUser(Long.parseLong(TEAM_ID), principalId);
+		verify(mockMembershipRequestDAO).deleteByTeamAndRequester(Long.parseLong(TEAM_ID), principalId);
+		verify(mockProjectStatsManager).memberAddedToTeam(eq(Long.parseLong(TEAM_ID)), eq(principalId), any(Date.class));
 	}
 	
 	@Test
 	public void testAddMemberAlreadyOnTeam() {
 		// 'userInfo' is a team admin and there is a membership request from 987
-		String principalId = "987";
+		Long principalId = 987L;
 		UserInfo principalUserInfo = createUserInfo(false, principalId);
 		when(mockGroupMembersDAO.getMemberIdsForUpdate(Long.valueOf(TEAM_ID))).thenReturn(ImmutableSet.of(Long.valueOf(principalId)));
 		boolean added = teamManagerImpl.addMember(userInfo, TEAM_ID, principalUserInfo);
 		assertFalse(added);
-		verify(mockGroupMembersDAO, never()).addMembers(TEAM_ID, Arrays.asList(new String[]{principalId}));
-		verify(mockMembershipInvitationDAO).deleteByTeamAndUser(Long.parseLong(TEAM_ID), Long.parseLong(principalId));
-		verify(mockMembershipRequestDAO).deleteByTeamAndRequester(Long.parseLong(TEAM_ID), Long.parseLong(principalId));
+		verify(mockGroupMembersDAO, never()).addMembers(TEAM_ID, Arrays.asList(new String[]{principalId.toString()}));
+		verify(mockMembershipInvitationDAO).deleteByTeamAndUser(Long.parseLong(TEAM_ID), principalId);
+		verify(mockMembershipRequestDAO).deleteByTeamAndRequester(Long.parseLong(TEAM_ID), principalId);
 	}
 	
     @Test
@@ -797,7 +798,7 @@ public class TeamManagerImplTest {
 	@Test
 	public void testPLFM_3612() {
 		// this user is the only one in the team
-		when(mockGroupMembersDAO.getMemberIdsForUpdate(Long.valueOf(TEAM_ID))).thenReturn(Collections.singleton(Long.valueOf(MEMBER_PRINCIPAL_ID)));
+		when(mockGroupMembersDAO.getMemberIdsForUpdate(Long.valueOf(TEAM_ID))).thenReturn(Collections.singleton(MEMBER_PRINCIPAL_ID_LONG));
 		Assertions.assertThrows(UnauthorizedException.class, ()-> {
 			// if we remove the only member then there is no one who can administer the team
 			teamManagerImpl.removeMember(userInfo, TEAM_ID, MEMBER_PRINCIPAL_ID);
@@ -1265,13 +1266,13 @@ public class TeamManagerImplTest {
 		// let the team be a non-Open team (which it is by default)
 		when(mockTeamDAO.getState(TEAM_ID)).thenReturn(TeamState.CLOSED);
 		
-		String principalId = MEMBER_PRINCIPAL_ID;
+		Long principalId = MEMBER_PRINCIPAL_ID_LONG;
 		UserInfo principalUserInfo = createUserInfo(false, principalId);
 		
-		when(mockGroupMembersDAO.areMemberOf(TEAM_ID, Collections.singleton(principalId))).thenReturn(true);
+		when(mockGroupMembersDAO.areMemberOf(TEAM_ID, Collections.singleton(principalId.toString()))).thenReturn(true);
 		
-		when(mockMembershipInvitationDAO.getOpenByTeamAndUserCount(eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(MEMBER_PRINCIPAL_ID)), anyLong())).thenReturn(1L);
-		when(mockMembershipRequestDAO.getOpenByTeamAndRequesterCount(eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(MEMBER_PRINCIPAL_ID)), anyLong())).thenReturn(1L);
+		when(mockMembershipInvitationDAO.getOpenByTeamAndUserCount(eq(Long.parseLong(TEAM_ID)), eq(MEMBER_PRINCIPAL_ID_LONG), anyLong())).thenReturn(1L);
+		when(mockMembershipRequestDAO.getOpenByTeamAndRequesterCount(eq(Long.parseLong(TEAM_ID)), eq(MEMBER_PRINCIPAL_ID_LONG), anyLong())).thenReturn(1L);
 		when(mockAuthorizationManager.canAccess(userInfo, TEAM_ID, ObjectType.TEAM, ACCESS_TYPE.TEAM_MEMBERSHIP_UPDATE)).thenReturn(AuthorizationStatus.accessDenied(""));
 		when(mockAuthorizationManager.canAccess(userInfo, TEAM_ID, ObjectType.TEAM, ACCESS_TYPE.SEND_MESSAGE)).thenReturn(AuthorizationStatus.accessDenied(""));
 		when(mockRestrictionInformationManager.
@@ -1280,7 +1281,7 @@ public class TeamManagerImplTest {
 		
 		TeamMembershipStatus tms = teamManagerImpl.getTeamMembershipStatus(userInfo, TEAM_ID, principalUserInfo);
 		assertEquals(TEAM_ID, tms.getTeamId());
-		assertEquals(principalId, tms.getUserId());
+		assertEquals(principalId.toString(), tms.getUserId());
 		assertTrue(tms.getIsMember());
 		assertTrue(tms.getHasOpenInvitation());
 		assertTrue(tms.getHasOpenRequest());
@@ -1293,7 +1294,7 @@ public class TeamManagerImplTest {
 		
 		tms = teamManagerImpl.getTeamMembershipStatus(userInfo, TEAM_ID, principalUserInfo);
 		assertEquals(TEAM_ID, tms.getTeamId());
-		assertEquals(principalId, tms.getUserId());
+		assertEquals(principalId.toString(), tms.getUserId());
 		assertTrue(tms.getIsMember());
 		assertTrue(tms.getHasOpenInvitation());
 		assertTrue(tms.getHasOpenRequest());
@@ -1302,12 +1303,12 @@ public class TeamManagerImplTest {
 		assertFalse(tms.getHasUnmetAccessRequirement());
 		assertTrue(tms.getCanSendEmail());
 		
-		when(mockGroupMembersDAO.areMemberOf(TEAM_ID, Collections.singleton(principalId))).thenReturn(false);
+		when(mockGroupMembersDAO.areMemberOf(TEAM_ID, Collections.singleton(principalId.toString()))).thenReturn(false);
 		when(mockMembershipInvitationDAO.getOpenByTeamAndUserCount(eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(MEMBER_PRINCIPAL_ID)), anyLong())).thenReturn(0L);
 		when(mockMembershipRequestDAO.getOpenByTeamAndRequesterCount(eq(Long.parseLong(TEAM_ID)), eq(Long.parseLong(MEMBER_PRINCIPAL_ID)), anyLong())).thenReturn(0L);
 		tms = teamManagerImpl.getTeamMembershipStatus(userInfo, TEAM_ID, principalUserInfo);
 		assertEquals(TEAM_ID, tms.getTeamId());
-		assertEquals(principalId, tms.getUserId());
+		assertEquals(principalId.toString(), tms.getUserId());
 		assertFalse(tms.getIsMember());
 		assertFalse(tms.getHasOpenInvitation());
 		assertFalse(tms.getHasOpenRequest());
@@ -1320,7 +1321,7 @@ public class TeamManagerImplTest {
 		when(mockTeamDAO.getState(TEAM_ID)).thenReturn(TeamState.PUBLIC);
 		tms = teamManagerImpl.getTeamMembershipStatus(userInfo, TEAM_ID, principalUserInfo);
 		assertEquals(TEAM_ID, tms.getTeamId());
-		assertEquals(principalId, tms.getUserId());
+		assertEquals(principalId.toString(), tms.getUserId());
 		assertFalse(tms.getIsMember());
 		assertFalse(tms.getHasOpenInvitation());
 		assertFalse(tms.getHasOpenRequest());
@@ -1334,7 +1335,7 @@ public class TeamManagerImplTest {
 					thenReturn(hasUnmetAccessRqmtResponse);
 		tms = teamManagerImpl.getTeamMembershipStatus(userInfo, TEAM_ID, principalUserInfo);
 		assertEquals(TEAM_ID, tms.getTeamId());
-		assertEquals(principalId, tms.getUserId());
+		assertEquals(principalId.toString(), tms.getUserId());
 		assertFalse(tms.getCanJoin());
 		assertFalse(tms.getMembershipApprovalRequired());
 		assertTrue(tms.getHasUnmetAccessRequirement());
@@ -1410,7 +1411,7 @@ public class TeamManagerImplTest {
 		team.setName("test-name");
 		when(mockTeamDAO.get(TEAM_ID)).thenReturn(team);
 
-		String otherPrincipalId = "987";
+		Long otherPrincipalId = 987L;
 		String teamEndpoint = "https://synapse.org/#Team:";
 		String notificationUnsubscribeEndpoint = "https://synapse.org/#notificationUnsubscribeEndpoint:";
 		UserInfo otherUserInfo = createUserInfo(false, otherPrincipalId);
@@ -1421,9 +1422,9 @@ public class TeamManagerImplTest {
 		assertEquals(1, resultList.size());
 		MessageToUserAndBody result = resultList.get(0);
 		assertEquals("Your Team Membership Has Been Approved", result.getMetadata().getSubject());
-		assertEquals(Collections.singleton(otherPrincipalId), result.getMetadata().getRecipients());
+		assertEquals(Collections.singleton(otherPrincipalId.toString()), result.getMetadata().getRecipients());
 		UserProfile userProfile = mockUserProfileManager.getUserProfile(userInfo.getId().toString());
-		String userId = MEMBER_PRINCIPAL_ID;
+		Long userId = MEMBER_PRINCIPAL_ID_LONG;
 		String displayName = EmailUtils.getDisplayNameWithUsername(userProfile);
 		String teamWebLink = teamEndpoint + TEAM_ID;
 		String teamName = "test-name";

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/wiki/V2WikiManagerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/wiki/V2WikiManagerTest.java
@@ -73,7 +73,7 @@ public class V2WikiManagerTest {
 	
 	@Before
 	public void before() {
-		user = new UserInfo(false, "987", DEFAULT_REALM_ID);
+		user = new UserInfo(false, 987L, DEFAULT_REALM_ID);
 		ownerId = "123";
 		ownerType = ObjectType.EVALUATION;
 		wikiId = "345";

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/wiki/V2WikiManagerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/wiki/V2WikiManagerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,7 +73,7 @@ public class V2WikiManagerTest {
 	
 	@Before
 	public void before() {
-		user = new UserInfo(false, "987");
+		user = new UserInfo(false, "987", DEFAULT_REALM_ID);
 		ownerId = "123";
 		ownerType = ObjectType.EVALUATION;
 		wikiId = "345";

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/RealmServiceImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/RealmServiceImplTest.java
@@ -12,6 +12,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.repo.manager.RealmManager;
+import org.sagebionetworks.repo.manager.UserManager;
+import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.Realm;
 import org.sagebionetworks.repo.model.auth.RealmIdList;
 import org.sagebionetworks.repo.model.auth.RealmPrincipal;
@@ -22,10 +24,15 @@ class RealmServiceImplTest {
 	@Mock
 	private RealmManager mockRealmManager;
 	
+	@Mock
+	private UserManager mockUserManager;
+	
 	@InjectMocks
 	private RealmServiceImpl realmService;
 	
 	private static final String REALM_ID = "1";
+	
+	private static final Long USER_ID = 101L;
 	
 	@Test
 	public void testListRealms() {
@@ -54,13 +61,28 @@ class RealmServiceImplTest {
 	}
 
 	@Test
-	public void testGetRealmPrincipals() {
+	public void testGetRealmPrincipalsGivenId() {
 		RealmPrincipal expected = new RealmPrincipal();
 		expected.setRealmId(REALM_ID);
 		when (mockRealmManager.getRealmPrincipals(REALM_ID)).thenReturn(expected);
 		
 		// method under test
 		RealmPrincipal actual = realmService.getRealmPrincipals(REALM_ID);
+		
+		assertEquals(expected, actual);
+		verify(mockRealmManager).getRealmPrincipals(REALM_ID);
+	}
+
+	@Test
+	public void testGetRealmPrincipals() {
+		RealmPrincipal expected = new RealmPrincipal();
+		expected.setRealmId(REALM_ID);
+		when (mockRealmManager.getRealmPrincipals(REALM_ID)).thenReturn(expected);
+		UserInfo userInfo = new UserInfo(false, USER_ID, REALM_ID);
+		when(mockUserManager.getUserInfo(USER_ID)).thenReturn(userInfo);
+		
+		// method under test
+		RealmPrincipal actual = realmService.getRealmPrincipals(USER_ID);
 		
 		assertEquals(expected, actual);
 		verify(mockRealmManager).getRealmPrincipals(REALM_ID);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
@@ -613,7 +613,56 @@ public class AuthenticationServiceImplTest {
 		assertThrows(UnauthorizedException.class, ()->service.bindExternalID(
 				AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId(), null));
 	}
+
+	@Test
+	public void testBindExternalIDWrongRealm() throws NotFoundException{
+		String userRealmId = "3";
+		String requestRealmId = "4";
+		userInfo = new UserInfo(false, userId, userRealmId);
+		OAuthValidationRequest request = new OAuthValidationRequest();
+		request.setAuthenticationCode("some code");
+		request.setProvider(OAuthProvider.ORCID);
+		request.setRedirectUrl("https://domain.com");
+		String aliasName = "name";
+		Long principalId = 101L;
+		AliasAndType aliasAndType = new AliasAndType(aliasName, AliasType.USER_ORCID);
+		when(mockOAuthManager.retrieveProvidersId(
+				request.getProvider(), request.getAuthenticationCode(), request.getRedirectUrl())).thenReturn(aliasAndType);
+
+		when(mockUserManager.getUserInfo(principalId)).thenReturn(userInfo);
+		when(mockRealmDao.getRealmIdForIdentityProvider(any())).thenReturn(Optional.of(requestRealmId));
+		
+		// method under test
+		assertThrows(IllegalArgumentException.class, ()->{
+			service.bindExternalID(principalId, request);
+		});
+	}
 	
+
+	@Test
+	public void testBindExternalIDNoRealm() throws NotFoundException{
+		String userRealmId = "3";
+		userInfo = new UserInfo(false, userId, userRealmId);
+		OAuthValidationRequest request = new OAuthValidationRequest();
+		request.setAuthenticationCode("some code");
+		request.setProvider(OAuthProvider.ORCID);
+		request.setRedirectUrl("https://domain.com");
+		String aliasName = "name";
+		Long principalId = 101L;
+		AliasAndType aliasAndType = new AliasAndType(aliasName, AliasType.USER_ORCID);
+		when(mockOAuthManager.retrieveProvidersId(
+				request.getProvider(), request.getAuthenticationCode(), request.getRedirectUrl())).thenReturn(aliasAndType);
+
+		when(mockUserManager.getUserInfo(principalId)).thenReturn(userInfo);
+		when(mockRealmDao.getRealmIdForIdentityProvider(any())).thenReturn(Optional.empty());
+		
+		// method under test
+		assertThrows(IllegalArgumentException.class, ()->{
+			service.bindExternalID(principalId, request);
+		});
+	}
+	
+
 	@Test
 	public void testUnbindExternalID() throws NotFoundException{
 		Long principalId = 101L;

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
@@ -31,6 +31,7 @@ import org.sagebionetworks.repo.manager.oauth.OIDCTokenManager;
 import org.sagebionetworks.repo.manager.oauth.OpenIDConnectManager;
 import org.sagebionetworks.repo.manager.oauth.ProvidedUserInfo;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
+import org.sagebionetworks.repo.model.RealmDao;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.auth.ChangePasswordWithToken;
@@ -59,6 +60,8 @@ public class AuthenticationServiceImplTest {
 	
 	@Mock
 	private UserManager mockUserManager;
+	@Mock
+	private RealmDao mockRealmDao;
 	@Mock
 	private AuthenticationManager mockAuthenticationManager;
 	@Mock
@@ -94,8 +97,7 @@ public class AuthenticationServiceImplTest {
 		credential.setEmail(username);
 		credential.setPassword(password);
 		
-		userInfo = new UserInfo(false);
-		userInfo.setId(userId);
+		userInfo = new UserInfo(false, userId);
 		
 
 		alias = "alias";
@@ -580,6 +582,8 @@ public class AuthenticationServiceImplTest {
 	
 	@Test
 	public void testBindExternalID() throws NotFoundException{
+		String realmId = "3";
+		userInfo = new UserInfo(false, userId, realmId);
 		OAuthValidationRequest request = new OAuthValidationRequest();
 		request.setAuthenticationCode("some code");
 		request.setProvider(OAuthProvider.ORCID);
@@ -596,6 +600,10 @@ public class AuthenticationServiceImplTest {
 		when(mockOAuthManager.retrieveProvidersId(
 				request.getProvider(), request.getAuthenticationCode(), request.getRedirectUrl())).thenReturn(aliasAndType);
 
+		when(mockUserManager.getUserInfo(principalId)).thenReturn(userInfo);
+		when(mockRealmDao.getRealmIdForIdentityProvider(any())).thenReturn(Optional.of(realmId));
+		
+		// method under test
 		PrincipalAlias result = service.bindExternalID(principalId, request);
 		assertEquals(principalAlias, result);
 	}

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
@@ -1325,6 +1325,7 @@ public class UrlHelpers {
 	public static final String ADMIN_REALM = ADMIN+REALM;
 	public static final String REALM_LIST = REALM + "/list";
 	public static final String REALM_ID = REALM + ID;
+	public static final String REALM_PRINCIPALS = REALM + "/principals";
 	public static final String REALM_ID_PRINCIPALS = REALM + ID+"/principals";
 	public static final String ADMIN_REALM_ID = ADMIN_REALM + ID;
 	

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/RealmController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/RealmController.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.repo.web.controller;
 import static org.sagebionetworks.repo.model.oauth.OAuthScope.view;
 import static org.sagebionetworks.repo.web.UrlHelpers.ID_PATH_VARIABLE;
 
+import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.auth.Realm;
 import org.sagebionetworks.repo.model.auth.RealmIdList;
 import org.sagebionetworks.repo.model.auth.RealmPrincipal;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -58,7 +60,21 @@ public class RealmController {
 	@ResponseStatus(HttpStatus.OK)
 	@RequestMapping(value = UrlHelpers.REALM_ID_PRINCIPALS, method = RequestMethod.GET)
 	@ResponseBody
-	public RealmPrincipal getRealmPrincipals(@PathVariable(ID_PATH_VARIABLE) String realmId) {
+	public RealmPrincipal getRealmPrincipalsGivenId(@PathVariable(ID_PATH_VARIABLE) String realmId) {
 		return serviceProvider.getRealmService().getRealmPrincipals(realmId);
+	}	
+	
+	/**
+	 * Retrieve the principals for a realm
+	 * @param realmId
+	 */
+	@RequiredScope({view})
+	@ResponseStatus(HttpStatus.OK)
+	@RequestMapping(value = UrlHelpers.REALM_PRINCIPALS, method = RequestMethod.GET)
+	@ResponseBody
+	public RealmPrincipal getRealmPrincipals(
+			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM) Long userId,
+			@PathVariable(ID_PATH_VARIABLE) String realmId) {
+		return serviceProvider.getRealmService().getRealmPrincipals(userId);
 	}
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/RealmController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/RealmController.java
@@ -73,8 +73,7 @@ public class RealmController {
 	@RequestMapping(value = UrlHelpers.REALM_PRINCIPALS, method = RequestMethod.GET)
 	@ResponseBody
 	public RealmPrincipal getRealmPrincipals(
-			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM) Long userId,
-			@PathVariable(ID_PATH_VARIABLE) String realmId) {
+			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM) Long userId) {
 		return serviceProvider.getRealmService().getRealmPrincipals(userId);
 	}
 }

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/RealmController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/RealmController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ControllerInfo(displayName="User & Group Services", path="repo/v1")
+@ControllerInfo(displayName="Realm Services", path="repo/v1")
 @Controller
 @RequestMapping(UrlHelpers.REPO_PATH)
 public class RealmController {

--- a/services/workers/src/main/java/org/sagebionetworks/trash/worker/TrashWorker.java
+++ b/services/workers/src/main/java/org/sagebionetworks/trash/worker/TrashWorker.java
@@ -13,6 +13,7 @@ import org.sagebionetworks.util.progress.ProgressingRunner;
 import org.sagebionetworks.repo.model.StackStatusDao;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.springframework.beans.factory.annotation.Autowired;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 public class TrashWorker implements ProgressingRunner {
 	private final static Logger LOG = LogManager.getLogger(TrashWorker.class);
@@ -28,7 +29,7 @@ public class TrashWorker implements ProgressingRunner {
 	@Autowired
 	private WorkerLogger workerLogger;
 
-	private UserInfo adminUser = new UserInfo(true, BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId());
+	private UserInfo adminUser = new UserInfo(true, BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId(), DEFAULT_REALM_ID);
 
 	@Override
 	public void run(ProgressCallback progressCallback) {


### PR DESCRIPTION
This PR:

Adds a DAO-level query to get the realm ID for a given identity provider.

In UserManagerImpl.createUser(), sets the user's realm according to the identity provider used to authenticate.

Adds realmId to the UserInfo constructor and cleans up the various constructors by (1) removing one which is superfluous and (2) marking as 'deprecated' several others which would be laborious to remove since they are used in many, many tests.

In UserManagerImpl.getUserInfo(), sets PUBLIC, ANONYMOUS, AUTHENTICATED_USERS IDs according to the user's realm.

In AuthenticationServiceImpl.bindExternalID, disallows the binding if the user's existing realm is not associated with the identity provider which is the source of new identity attempting to be bound to the user.

Bonus:

Adds a service to get the realm principals based on user id. (The user id will come from the access token in the request.) This allows the client to be able to get the realm principals without needing to know the realm id explicitly.

