### PR TITLE
PLFM-9325

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImpl.java
@@ -112,7 +112,7 @@ public class AuthenticationManagerImpl implements AuthenticationManager {
 		UserInfo userInfo = userManager.getUserInfo(userId);
 		// changing a password is only allowed if the user is in the default Synapse realm
 		if (!AuthorizationConstants.DEFAULT_REALM_ID.equals(userInfo.getRealmId())) {
-			throw new IllegalArgumentException("Cannot change user email for realm "+userInfo.getRealmId());
+			throw new IllegalArgumentException("Cannot set user password in realm "+userInfo.getRealmId());
 		}
 		setPassword(userId, changePasswordInterface.getNewPassword());
 		userCredentialValidator.forceResetLoginThrottle(userId);

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImpl.java
@@ -10,6 +10,7 @@ import org.sagebionetworks.repo.manager.feature.FeatureManager;
 import org.sagebionetworks.repo.manager.oauth.OIDCTokenManager;
 import org.sagebionetworks.repo.manager.password.InvalidPasswordException;
 import org.sagebionetworks.repo.manager.password.PasswordValidator;
+import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationUtils;
 import org.sagebionetworks.repo.model.UnauthenticatedException;
 import org.sagebionetworks.repo.model.UnauthorizedException;
@@ -108,6 +109,11 @@ public class AuthenticationManagerImpl implements AuthenticationManager {
 			throw new IllegalArgumentException("Unknown implementation of ChangePasswordInterface");
 		}
 
+		UserInfo userInfo = userManager.getUserInfo(userId);
+		// changing a password is only allowed if the user is in the default Synapse realm
+		if (!AuthorizationConstants.DEFAULT_REALM_ID.equals(userInfo.getRealmId())) {
+			throw new IllegalArgumentException("Cannot change user email for realm "+userInfo.getRealmId());
+		}
 		setPassword(userId, changePasswordInterface.getNewPassword());
 		userCredentialValidator.forceResetLoginThrottle(userId);
 		return userId;

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/principal/PrincipalManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/principal/PrincipalManagerImpl.java
@@ -16,6 +16,7 @@ import org.sagebionetworks.repo.manager.SendRawEmailRequestBuilder.BodyType;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.message.PrincipalNameProvider;
 import org.sagebionetworks.repo.manager.token.TokenGenerator;
+import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationUtils;
 import org.sagebionetworks.repo.model.DatastoreException;
 import org.sagebionetworks.repo.model.NameConflictException;
@@ -141,6 +142,12 @@ public class PrincipalManagerImpl implements PrincipalManager, PrincipalNameProv
 		newUser.setUserName(accountSetupInfo.getUsername());
 		long newPrincipalId = userManager.createUser(newUser);
 		
+		// Since the new user is created with a password (not via OAuth authentication) it must be in the default Synapse realm
+		// if this is not the case, something has gone wrong.
+		UserInfo userInfo = userManager.getUserInfo(newPrincipalId);
+		if (!AuthorizationConstants.DEFAULT_REALM_ID.equals(userInfo.getRealmId())) {
+			throw new IllegalStateException("New user must be created in the default Synapse realm not in realm "+userInfo.getRealmId());
+		}
 		authManager.setPassword(newPrincipalId, accountSetupInfo.getPassword());
 		return authManager.loginWithNoPasswordCheck(newPrincipalId, tokenIssuer);
 	}
@@ -150,6 +157,11 @@ public class PrincipalManagerImpl implements PrincipalManager, PrincipalNameProv
 			throws NotFoundException {
 		if (AuthorizationUtils.isUserAnonymous(userInfo.getId()))
 			throw new UnauthorizedException("Anonymous user may not add email address.");
+		// adding an email address is only allowed if the user is in the default Synapse realm
+		if (!AuthorizationConstants.DEFAULT_REALM_ID.equals(userInfo.getRealmId())) {
+			throw new IllegalArgumentException("Cannot set user email for realm "+userInfo.getRealmId());
+		}
+		
 		AliasEnum.USER_EMAIL.validateAlias(email.getEmail());
 		// is the email taken?
 		if (!principalAliasDAO.isAliasAvailable(email.getEmail())) {
@@ -185,6 +197,12 @@ public class PrincipalManagerImpl implements PrincipalManager, PrincipalNameProv
 	public void addEmail(UserInfo userInfo, EmailValidationSignedToken emailValidationSignedToken,
 						 Boolean setAsNotificationEmail) throws NotFoundException {
 		String newEmail = PrincipalUtils.validateAdditionalEmailSignedToken(emailValidationSignedToken, Long.toString(userInfo.getId()), new Date(), tokenGenerator);
+
+		// adding an email address is only allowed if the user is in the default Synapse realm
+		if (!AuthorizationConstants.DEFAULT_REALM_ID.equals(userInfo.getRealmId())) {
+			throw new IllegalArgumentException("Cannot set user email for realm "+userInfo.getRealmId());
+		}
+		
 		PrincipalAlias alias = new PrincipalAlias();
 		alias.setAlias(newEmail);
 		alias.setPrincipalId(userInfo.getId());

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImpl.java
@@ -15,6 +15,7 @@ import org.sagebionetworks.repo.manager.oauth.OAuthManager;
 import org.sagebionetworks.repo.manager.oauth.OIDCTokenManager;
 import org.sagebionetworks.repo.manager.oauth.OpenIDConnectManager;
 import org.sagebionetworks.repo.manager.oauth.ProvidedUserInfo;
+import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationUtils;
 import org.sagebionetworks.repo.model.RealmDao;
 import org.sagebionetworks.repo.model.UnauthorizedException;
@@ -136,6 +137,11 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 	public void sendPasswordResetEmail(String passwordResetUrlPrefix, String usernameOrEmail) {
 		try {
 			PrincipalAlias principalAlias = userManager.lookupUserByUsernameOrEmail(usernameOrEmail);
+			UserInfo userInfo = userManager.getUserInfo(principalAlias.getPrincipalId());
+			// can only reset password if user is in the default Synapse realm
+			if (!AuthorizationConstants.DEFAULT_REALM_ID.equals(userInfo.getRealmId())) {
+				throw new IllegalArgumentException("Cannot reset user email for realm "+userInfo.getRealmId());
+			}
 			PasswordResetSignedToken passwordRestToken = authManager.createPasswordResetToken(principalAlias.getPrincipalId());
 			messageManager.sendNewPasswordResetEmail(passwordResetUrlPrefix, passwordRestToken, principalAlias);
 		} catch (NotFoundException e) {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImpl.java
@@ -140,7 +140,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 			UserInfo userInfo = userManager.getUserInfo(principalAlias.getPrincipalId());
 			// can only reset password if user is in the default Synapse realm
 			if (!AuthorizationConstants.DEFAULT_REALM_ID.equals(userInfo.getRealmId())) {
-				throw new IllegalArgumentException("Cannot reset user email for realm "+userInfo.getRealmId());
+				throw new IllegalArgumentException("Cannot reset password for users in realm "+userInfo.getRealmId());
 			}
 			PasswordResetSignedToken passwordRestToken = authManager.createPasswordResetToken(principalAlias.getPrincipalId());
 			messageManager.sendNewPasswordResetEmail(passwordResetUrlPrefix, passwordRestToken, principalAlias);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImplUnitTest.java
@@ -153,8 +153,7 @@ public class AuthenticationManagerImplUnitTest {
 		changePasswordWithToken.setPasswordChangeToken(passwordResetSignedToken);
 		passwordResetSignedToken.setUserId(userId.toString());
 		
-		userInfo = new UserInfo(false, userId);
-		userInfo.setRealmId(AuthorizationConstants.DEFAULT_REALM_ID);
+		userInfo = new UserInfo(false, userId, AuthorizationConstants.DEFAULT_REALM_ID);
 	}
 
 	@Test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImplUnitTest.java
@@ -154,7 +154,7 @@ public class AuthenticationManagerImplUnitTest {
 		passwordResetSignedToken.setUserId(userId.toString());
 		
 		userInfo = new UserInfo(false, userId);
-
+		userInfo.setRealmId(AuthorizationConstants.DEFAULT_REALM_ID);
 	}
 
 	@Test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/authentication/AuthenticationManagerImplUnitTest.java
@@ -867,6 +867,20 @@ public class AuthenticationManagerImplUnitTest {
 	}
 	
 	@Test
+	public void testChangePasswordNotInSynapseRealm(){
+		when(mockUserCredentialValidator.checkPasswordWithThrottling(userId, password)).thenReturn(true);
+		setupMockPrincipalAliasDAO();
+		String nonSynapseRealmId = "5";
+		UserInfo otherUserInfo = new UserInfo(false, userId, nonSynapseRealmId);
+		when(mockUserManager.getUserInfo(any())).thenReturn(otherUserInfo);
+		
+		// method under test
+		assertThrows(IllegalArgumentException.class, ()->{
+			authManager.changePassword(changePasswordWithCurrentPassword);
+		});
+	}
+
+	@Test
 	public void testLoginWith2Fa() {
 		
 		AuthenticationManagerImpl authManagerSpy = Mockito.spy(authManager);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/principal/PrincipalManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/principal/PrincipalManagerImplUnitTest.java
@@ -290,6 +290,27 @@ public class PrincipalManagerImplUnitTest {
 		verify(mockAuthManager).loginWithNoPasswordCheck(USER_ID, ISSUER);
 	}
 
+	@Test
+	public void testCreateNewAccountNotInSynapseRealm() throws Exception {
+		AccountSetupInfo accountSetupInfo = new AccountSetupInfo();
+		EmailValidationSignedToken emailValidationSignedToken = new EmailValidationSignedToken();
+		emailValidationSignedToken.setEmail(user.getEmail());
+		emailValidationSignedToken.setCreatedOn(now);
+		emailValidationSignedToken.setHmac("signed");
+		accountSetupInfo.setEmailValidationSignedToken(emailValidationSignedToken);
+		accountSetupInfo.setPassword(PASSWORD);
+		when(mockUserManager.createUser((NewUser)any())).thenReturn(USER_ID);
+		String nonSynapseRealmId = "5";
+		UserInfo userInfo = new UserInfo(false, USER_ID, nonSynapseRealmId);
+		when(mockUserManager.getUserInfo(USER_ID)).thenReturn(userInfo);
+		
+		// Cannot create a new user with a password in a non-Synapse realm
+		assertThrows(IllegalStateException.class, ()->{
+			// method under test
+			manager.createNewAccount(accountSetupInfo, ISSUER);
+		});
+	}
+
 	// token is OK 23 hours from now
 	@Test
 	public void testValidateAdditionalEmailNOTtooOLDTimestamp() {
@@ -373,12 +394,12 @@ public class PrincipalManagerImplUnitTest {
 	}
 	
 	@Test
-	public void testAdditionalEmailValidationAnonymous() throws Exception {
-		Long anonId = AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId();
-		UserInfo userInfo = new UserInfo(false, anonId);
+	public void testAdditionalEmailValidationNotInSynapseRealm() throws Exception {
+		String nonSynapseRealmId = "5";
+		UserInfo userInfo = new UserInfo(false, USER_ID, nonSynapseRealmId);
 		Username email = new Username();
 		email.setEmail(EMAIL);
-		Assertions.assertThrows(UnauthorizedException.class, ()-> {	
+		Assertions.assertThrows(IllegalArgumentException.class, ()-> {	
 			manager.additionalEmailValidation(userInfo, email, PORTAL_ENDPOINT, now);
 		});
 	}	
@@ -399,6 +420,17 @@ public class PrincipalManagerImplUnitTest {
 		Username email = new Username();
 		email.setEmail(EMAIL);
 		Assertions.assertThrows(IllegalArgumentException.class, ()-> {	
+			manager.additionalEmailValidation(userInfo, email, PORTAL_ENDPOINT, now);
+		});
+	}	
+	
+	@Test
+	public void testAdditionalEmailValidationAnonymous() throws Exception {
+		Long anonId = AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId();
+		UserInfo userInfo = new UserInfo(false, anonId);
+		Username email = new Username();
+		email.setEmail(EMAIL);
+		Assertions.assertThrows(UnauthorizedException.class, ()-> {	
 			manager.additionalEmailValidation(userInfo, email, PORTAL_ENDPOINT, now);
 		});
 	}	
@@ -455,6 +487,16 @@ public class PrincipalManagerImplUnitTest {
 	public void testAddEmailWrongUser() throws Exception {
 		UserInfo userInfo = new UserInfo(false, USER_ID);
 		EmailValidationSignedToken emailValidationSignedToken = PrincipalUtils.createEmailValidationSignedToken(222L, EMAIL, now, mockTokenGenerator);
+		Assertions.assertThrows(IllegalArgumentException.class, ()-> {	
+			manager.addEmail(userInfo, emailValidationSignedToken, null);
+		});
+	}
+	
+	@Test
+	public void testAddEmailNotSynapseRealm() throws Exception {
+		String nonSynapseRealmId = "5";
+		UserInfo userInfo = new UserInfo(false, USER_ID, nonSynapseRealmId);
+		EmailValidationSignedToken emailValidationSignedToken = PrincipalUtils.createEmailValidationSignedToken(USER_ID, EMAIL, now, mockTokenGenerator);
 		Assertions.assertThrows(IllegalArgumentException.class, ()-> {	
 			manager.addEmail(userInfo, emailValidationSignedToken, null);
 		});

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/principal/PrincipalManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/principal/PrincipalManagerImplUnitTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.sagebionetworks.repo.model.AuthorizationConstants.DEFAULT_REALM_ID;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
@@ -272,6 +273,8 @@ public class PrincipalManagerImplUnitTest {
 		accountSetupInfo.setPassword(PASSWORD);
 		accountSetupInfo.setUsername(USER_NAME);
 		when(mockUserManager.createUser((NewUser)any())).thenReturn(USER_ID);
+		UserInfo userInfo = new UserInfo(false, USER_ID, DEFAULT_REALM_ID);
+		when(mockUserManager.getUserInfo(USER_ID)).thenReturn(userInfo);
 		
 		// method under test
 		manager.createNewAccount(accountSetupInfo, ISSUER);
@@ -307,7 +310,7 @@ public class PrincipalManagerImplUnitTest {
 
 	@Test
 	public void testAdditionalEmailValidation() throws Exception {
-		UserInfo userInfo = new UserInfo(false, USER_ID);
+		UserInfo userInfo = new UserInfo(false, USER_ID, DEFAULT_REALM_ID);
 		Username email = new Username();
 		email.setEmail(EMAIL);
 		when(mockPrincipalAliasDAO.isAliasAvailable(EMAIL)).thenReturn(true);
@@ -339,7 +342,7 @@ public class PrincipalManagerImplUnitTest {
 	
 	@Test
 	public void testAdditionalEmailWithQuarantinedAddress() throws Exception {
-		UserInfo userInfo = new UserInfo(false, USER_ID);
+		UserInfo userInfo = new UserInfo(false, USER_ID, DEFAULT_REALM_ID);
 		Username email = new Username();
 		email.setEmail(EMAIL);
 		
@@ -358,7 +361,7 @@ public class PrincipalManagerImplUnitTest {
 
 	@Test
 	public void testAdditionalEmailEmailAlreadyUsed() throws Exception {
-		UserInfo userInfo = new UserInfo(false, USER_ID);
+		UserInfo userInfo = new UserInfo(false, USER_ID, DEFAULT_REALM_ID);
 		Username email = new Username();
 		email.setEmail(EMAIL);
 		// the following line simulates that the email is already used
@@ -402,7 +405,7 @@ public class PrincipalManagerImplUnitTest {
 	
 	@Test
 	public void testAddEmail() throws Exception {
-		UserInfo userInfo = new UserInfo(false, USER_ID);
+		UserInfo userInfo = new UserInfo(false, USER_ID, DEFAULT_REALM_ID);
 
 		EmailValidationSignedToken emailValidationSignedToken = PrincipalUtils.createEmailValidationSignedToken(USER_ID, EMAIL, now, mockTokenGenerator);
 
@@ -423,7 +426,7 @@ public class PrincipalManagerImplUnitTest {
 	
 	@Test
 	public void testAddEmailNoSetNotification() throws Exception {
-		UserInfo userInfo = new UserInfo(false, USER_ID);
+		UserInfo userInfo = new UserInfo(false, USER_ID, DEFAULT_REALM_ID);
 		
 		EmailValidationSignedToken emailValidationSignedToken = PrincipalUtils.createEmailValidationSignedToken(USER_ID, EMAIL, now, mockTokenGenerator);
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
@@ -97,7 +97,7 @@ public class AuthenticationServiceImplTest {
 		credential.setEmail(username);
 		credential.setPassword(password);
 		
-		userInfo = new UserInfo(false, userId);
+		userInfo = new UserInfo(false, userId, AuthorizationConstants.DEFAULT_REALM_ID);
 		
 
 		alias = "alias";
@@ -693,6 +693,7 @@ public class AuthenticationServiceImplTest {
 		String passwordResetUrlPrefix = "synapse.org";
 		PasswordResetSignedToken token = new PasswordResetSignedToken();
 		when(mockUserManager.lookupUserByUsernameOrEmail(email)).thenReturn(principalAlias);
+		when(mockUserManager.getUserInfo(userId)).thenReturn(userInfo);
 		when(mockAuthenticationManager.createPasswordResetToken(principalAlias.getPrincipalId())).thenReturn(token);
 
 		//method under test
@@ -721,6 +722,7 @@ public class AuthenticationServiceImplTest {
 	@Test
 	public void testSendPasswordResetEmailWithEmailAlias() {
 		when(mockUserManager.lookupUserByUsernameOrEmail(aliasEmail)).thenReturn(principalEmailAlias);
+		when(mockUserManager.getUserInfo(userId)).thenReturn(userInfo);
 
 		String passwordResetUrlPrefix = "synapse.org";
 		

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
@@ -738,6 +738,23 @@ public class AuthenticationServiceImplTest {
 	}
 	
 	@Test
+	public void testSendPasswordResetEmailNotInSynapseRealm() {
+		String nonSynapseRealmId = "5";
+		UserInfo nonSynapseRealmUserInfo = new UserInfo(false, userId, nonSynapseRealmId);
+		
+		String email = "user@test.com";
+		String passwordResetUrlPrefix = "synapse.org";
+		PasswordResetSignedToken token = new PasswordResetSignedToken();
+		when(mockUserManager.lookupUserByUsernameOrEmail(email)).thenReturn(principalAlias);
+		when(mockUserManager.getUserInfo(userId)).thenReturn(nonSynapseRealmUserInfo);
+
+		assertThrows(IllegalArgumentException.class, ()->{
+			//method under test
+			service.sendPasswordResetEmail(passwordResetUrlPrefix, email);
+		});
+	}
+
+	@Test
 	public void testHasUserAcceptedTermsOfService() {
 		when(mockTosManager.hasUserAcceptedTermsOfService(userId)).thenReturn(true);
 		


### PR DESCRIPTION
The following are only allowed if the realm of the authenticated user allows Synapse as the IdP
/account/{id}/emailValidation
/email (This service completes the email validation process for adding a new email address to an existing account.)
/user/password/reset
/user/changePassword

Here’s where the changes are made:

/account/{id}/emailValidation -> PrincipalManagerImpl.additionalEmailValidation() (Sends out email.)
/email -> PrincipalManagerImpl.addEmail() (Completes the process of adding a new email.)
Also:
PrincipalManagerImpl.createNewAccount(): Verify that new user is in the default realm.
/user/password/reset -> AuthenticationServiceImpl.sendPasswordResetEmail()
/user/changePassword -> AuthenticationManagerImpl.changePassword()