### PR TITLE
PLFM-9353

### DIFF
--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/auth/DBOAuthenticationDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/auth/DBOAuthenticationDAOImplTest.java
@@ -163,7 +163,7 @@ public class DBOAuthenticationDAOImplTest {
 		// Most bootstrapped users should have signed the terms
 		List<BootstrapPrincipal> ugs = userGroupDAO.getBootstrapPrincipals();
 		for (BootstrapPrincipal agg: ugs) {
-			if (agg instanceof BootstrapUser && !AuthorizationUtils.isDefaultRealmAnonymousId(agg.getId())) {
+			if (agg instanceof BootstrapUser && !BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId().equals(agg.getId())) {
 				MapSqlParameterSource param = new MapSqlParameterSource();
 				param.addValue("principalId", agg.getId());
 				basicDAO.getObjectByPrimaryKey(DBOCredential.class, param).get();

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthorizationConstants.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthorizationConstants.java
@@ -81,6 +81,13 @@ public class AuthorizationConstants {
 	public static final String USER_ID_PARAM = "userId";
 	
 	/**
+	 * Request parameter indicating whether the user is anonymous. Note that
+	 * callers of the service do not actually use this parameter. Instead they
+	 * use a token parameter which is then validated to determine if the user is anonymous
+	 */
+	public static final String ANONYMOUS_PARAM = "anonymous";
+	
+	/**
 	 * The name of the client make the REST call. For a few calls, behavior will change depending on domain (at the
 	 * least, email contents change).
 	 */

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthorizationUtils.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/AuthorizationUtils.java
@@ -1,15 +1,10 @@
 package org.sagebionetworks.repo.model;
 
-import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
 import org.sagebionetworks.repo.model.auth.AuthorizationStatus;
 
 public class AuthorizationUtils {
 
 	private static final String FILE_HANDLE_UNAUTHORIZED_TEMPLATE = "Only the creator of a FileHandle can access it directly by its ID.  FileHandleId = '%1$s', UserId = '%2$s'";
-
-	public static boolean isDefaultRealmAnonymousId(Long id) {
-		return id == null || BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId().equals(id);
-	}
 
 	/**
 	 * returns true iff the user is a certified user

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/UserManagerImplTest.java
@@ -56,8 +56,8 @@ public class UserManagerImplTest {
 	public void testGetAnonymous() throws Exception {
 		UserInfo ui = userManager.getUserInfo(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId());
 		assertTrue(ui.isUserAnonymous());
-		assertTrue(AuthorizationUtils.isDefaultRealmAnonymousId(ui.getId()));
-		assertTrue(AuthorizationUtils.isDefaultRealmAnonymousId(Long.parseLong(ui.getId().toString())));
+		assertEquals(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId(), ui.getId());
+		assertEquals(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId(), Long.parseLong(ui.getId().toString()));
 		assertNotNull(ui.getId());
 		assertEquals(2, ui.getGroups().size());
 		assertTrue(ui.getGroups().contains(ui.getId()));

--- a/services/repository/src/main/java/org/sagebionetworks/auth/HttpAuthUtil.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/HttpAuthUtil.java
@@ -198,5 +198,10 @@ public class HttpAuthUtil {
 		}
 		reject(resp, er, status);
 	}
+	
+	public static boolean isAnonymous(HttpServletRequest httpRequest) {
+		String param = httpRequest.getParameter(AuthorizationConstants.ANONYMOUS_PARAM);
+		return Boolean.parseBoolean(param);
+	}
 
 }

--- a/services/repository/src/main/java/org/sagebionetworks/auth/filter/AcceptTermsOfUseFilter.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/filter/AcceptTermsOfUseFilter.java
@@ -32,9 +32,6 @@ public class AcceptTermsOfUseFilter implements Filter {
 	
 	@Autowired
 	private AuthenticationService authenticationService;
-	
-	@Autowired
-	private UserManager userManager;
 
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
@@ -58,8 +55,8 @@ public class AcceptTermsOfUseFilter implements Filter {
 		Long userId = Long.parseLong(userIdParam);
 		
 		// If the user is not anonymous, check if they have accepted the terms of use
-		UserInfo userInfo = userManager.getUserInfo(userId);
-		if (!userInfo.isUserAnonymous()) {
+		boolean isAnonymous = HttpAuthUtil.isAnonymous(httpRequest);
+		if (!isAnonymous) {
 			if (!authenticationService.hasUserAcceptedTermsOfService(userId)) {
 				HttpAuthUtil.rejectWithErrorResponse(httpResponse, TOU_UNSIGNED_REASON, HttpStatus.FORBIDDEN);
 				return;

--- a/services/repository/src/main/java/org/sagebionetworks/auth/filter/AuthenticationFilter.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/filter/AuthenticationFilter.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.auth.filter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -22,6 +23,7 @@ import org.sagebionetworks.repo.manager.oauth.OpenIDConnectManager;
 import org.sagebionetworks.repo.model.AuthenticationMethod;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
+import org.sagebionetworks.repo.model.RealmDao;
 import org.sagebionetworks.repo.web.ForbiddenException;
 import org.sagebionetworks.repo.web.OAuthException;
 import org.sagebionetworks.util.ThreadLocalProvider;
@@ -46,6 +48,9 @@ public class AuthenticationFilter implements Filter {
 
 	@Autowired
 	private OpenIDConnectManager oidcManager;
+	
+	@Autowired
+	private RealmDao realmDao;
 
 	@Override
 	public void destroy() { }
@@ -68,6 +73,7 @@ public class AuthenticationFilter implements Filter {
 		}
 		
 		Long userId = null;
+		boolean isAnonymous = false;
 
 			if (!isTokenEmptyOrNull(accessToken)) {
 				try {
@@ -76,6 +82,8 @@ public class AuthenticationFilter implements Filter {
 					if (authenticationMethod == null) { // accessToken came in as sessionToken
 						authenticationMethod = AuthenticationMethod.BEARERTOKEN;
 					}
+					Optional<String> anonymousUserRealm = realmDao.getRealmForAnonymousPrincipal(userId.toString());
+					isAnonymous = anonymousUserRealm.isPresent(); // true if userId is the anonymous user in some realm
 				} catch (IllegalArgumentException | ForbiddenException | OAuthClientNotVerifiedException e) {
 					String failureReason = "Invalid access token";
 					HttpAuthUtil.reject((HttpServletResponse)servletResponse, failureReason);
@@ -88,6 +96,7 @@ public class AuthenticationFilter implements Filter {
 				}
 			} else { // anonymous
 				userId = BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId();
+				isAnonymous = true;
 			}
 
 		if (authenticationMethod == null && HttpAuthUtil.usesBasicAuthentication(req)) {
@@ -104,6 +113,7 @@ public class AuthenticationFilter implements Filter {
 		try {
 			Map<String, String[]> modParams = new HashMap<String, String[]>(req.getParameterMap());
 			modParams.put(AuthorizationConstants.USER_ID_PARAM, new String[] { userId.toString() });
+			modParams.put(AuthorizationConstants.ANONYMOUS_PARAM, new String[] { ""+isAnonymous });
 			Map<String, String[]> modHeaders = HttpAuthUtil.filterAuthorizationHeaders(req);
 			if (accessToken!=null) {
 				HttpAuthUtil.setBearerTokenHeader(modHeaders, accessToken);

--- a/services/repository/src/main/java/org/sagebionetworks/auth/filter/TwoFactorAuthRequiredFilter.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/filter/TwoFactorAuthRequiredFilter.java
@@ -8,11 +8,11 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.sagebionetworks.auth.HttpAuthUtil;
 import org.sagebionetworks.repo.manager.feature.FeatureManager;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
 import org.sagebionetworks.repo.model.GroupMembersDAO;
-import org.sagebionetworks.repo.model.RealmDao;
 import org.sagebionetworks.repo.model.auth.AuthenticationDAO;
 import org.sagebionetworks.repo.model.feature.Feature;
 import org.sagebionetworks.repo.web.TwoFactorAuthEnabledRequiredException;
@@ -28,14 +28,12 @@ public class TwoFactorAuthRequiredFilter extends OncePerRequestFilter {
 	private GroupMembersDAO groupMemberDao;
 	private AuthenticationDAO authDao;
 	private FeatureManager featureManager;
-	private RealmDao realmDao;
 	
 	
-	public TwoFactorAuthRequiredFilter(GroupMembersDAO groupMemberDao, AuthenticationDAO authDao, FeatureManager featureManager, RealmDao realmDao) {
+	public TwoFactorAuthRequiredFilter(GroupMembersDAO groupMemberDao, AuthenticationDAO authDao, FeatureManager featureManager) {
 		this.groupMemberDao = groupMemberDao;
 		this.authDao = authDao;
 		this.featureManager = featureManager;
-		this.realmDao = realmDao;
 	}
 
 	@Override
@@ -46,7 +44,7 @@ public class TwoFactorAuthRequiredFilter extends OncePerRequestFilter {
 		
 		// The anonymous user is not a conventional user and cannot enable 2fa
 		// we check to see if the given user is the anonymous user in any realm
-		if (realmDao.getRealmForAnonymousPrincipal(userId.toString()).isPresent()) {
+		if (HttpAuthUtil.isAnonymous(httpRequest)) {
 			filterChain.doFilter(httpRequest, httpResponse);
 			return;
 		}

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/OAuthScopeInterceptor.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/OAuthScopeInterceptor.java
@@ -16,7 +16,6 @@ import org.sagebionetworks.auth.HttpAuthUtil;
 import org.sagebionetworks.repo.manager.oauth.ClaimsJsonUtil;
 import org.sagebionetworks.repo.manager.oauth.OIDCTokenManager;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
-import org.sagebionetworks.repo.model.AuthorizationUtils;
 import org.sagebionetworks.repo.model.oauth.OAuthScope;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
@@ -59,15 +58,6 @@ public class OAuthScopeInterceptor implements HandlerInterceptor {
 		return false;
 	}
 	
-	public static boolean isUnAuthenticated(HttpServletRequest request) {
-		// if a request is unauthenticated then AuthenticationFilter will fill in
-		// user-id with the id of the default anonymous user
-		String userIdRequestParameter = request.getParameter(AuthorizationConstants.USER_ID_PARAM);
-
-		return userIdRequestParameter==null ||
-			AuthorizationUtils.isDefaultRealmAnonymousId(Long.parseLong(userIdRequestParameter));
-	}
-	
 	public static boolean isServiceCall(HttpServletRequest request) {
 		String serviceName = request.getHeader(AuthorizationConstants.SYNAPSE_HEADER_SERVICE_NAME);
 		return serviceName != null;
@@ -83,7 +73,7 @@ public class OAuthScopeInterceptor implements HandlerInterceptor {
 		}
 		
 		// unauthenticated requests can't have scope checked, as there is no access token defining scopes
-		if (isUnAuthenticated(request)) {
+		if (HttpAuthUtil.isAnonymous(request)) {
 			return true;
 		}
 		

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/filter/throttle/RequestThrottleFilter.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/filter/throttle/RequestThrottleFilter.java
@@ -11,9 +11,10 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 
+import org.sagebionetworks.auth.HttpAuthUtil;
 import org.sagebionetworks.cloudwatch.Consumer;
-import org.sagebionetworks.repo.model.AuthorizationUtils;
 import org.sagebionetworks.repo.web.HttpRequestIdentifier;
 import org.sagebionetworks.repo.web.HttpRequestIdentifierUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +35,7 @@ public class RequestThrottleFilter implements Filter {
 		HttpRequestIdentifier httpRequestIdentifier = HttpRequestIdentifierUtils.getRequestIdentifier(request);
 
 		//TODO: remove exception for anonymous users once java client has a way to get session id from cookies
-		if (isMigrationAdmin(httpRequestIdentifier.getUserId()) || AuthorizationUtils.isDefaultRealmAnonymousId(httpRequestIdentifier.getUserId())) { //do not throttle the admin responsible for migration.
+		if (isMigrationAdmin(httpRequestIdentifier.getUserId()) || HttpAuthUtil.isAnonymous((HttpServletRequest)request)) { //do not throttle the admin responsible for migration.
 			//proceed to next filter and exit early
 			chain.doFilter(request, response);
 			return;

--- a/services/repository/src/test/java/org/sagebionetworks/auth/HttpAuthUtilTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/HttpAuthUtilTest.java
@@ -274,5 +274,16 @@ class HttpAuthUtilTest {
 		verify(mockWriter).println("{\"concreteType\":\"org.sagebionetworks.repo.model.ErrorResponse\",\"reason\":\"missing token\"}");
 		
 	}
+	
+	@Test
+	void testIsAnonymousTrue() throws Exception {
+		when(httpRequest.getParameter("anonymous")).thenReturn("true");
+		assertTrue(HttpAuthUtil.isAnonymous(httpRequest));
+	}	
+	@Test
+	void testIsAnonymousFalse() throws Exception {
+		when(httpRequest.getParameter("anonymous")).thenReturn("false");
+		assertFalse(HttpAuthUtil.isAnonymous(httpRequest));
+	}
 
 }

--- a/services/repository/src/test/java/org/sagebionetworks/auth/filter/AcceptTermsOfUseFilterTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/filter/AcceptTermsOfUseFilterTest.java
@@ -38,8 +38,6 @@ class AcceptTermsOfUseFilterTest {
 	private FilterChain mockFilterChain;
 	@Mock
 	private PrintWriter mockPrintWriter;
-	@Mock
-	private UserManager mockUserManager;
 	
 	@Mock
 	private AuthenticationService mockAuthService;
@@ -59,8 +57,8 @@ class AcceptTermsOfUseFilterTest {
 	@Test
 	void testHASAcceptedTermsOfUse() throws Exception {
 		when(mockRequest.getParameter("userId")).thenReturn(userId.toString());
+		when(mockRequest.getParameter("anonymous")).thenReturn("false");
 		when(mockAuthService.hasUserAcceptedTermsOfService(userId)).thenReturn(true);
-		when(mockUserManager.getUserInfo(userId)).thenReturn(userInfo);
 		
 		// method under test
 		filter.doFilter(mockRequest, mockResponse, mockFilterChain);
@@ -73,9 +71,7 @@ class AcceptTermsOfUseFilterTest {
 	void testAnonymous() throws Exception {
 		Long anonId = BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId();
 		when(mockRequest.getParameter("userId")).thenReturn(anonId.toString());
-		UserInfo anonUserInfo = new UserInfo(false, anonId, "0");
-		anonUserInfo.setRealmAnonymousUserId(anonId);
-		when(mockUserManager.getUserInfo(anonId)).thenReturn(anonUserInfo);
+		when(mockRequest.getParameter("anonymous")).thenReturn("true");
 		
 		// method under test
 		filter.doFilter(mockRequest, mockResponse, mockFilterChain);
@@ -87,8 +83,8 @@ class AcceptTermsOfUseFilterTest {
 	@Test
 	public void testHasNOTAcceptedTermsOfUse() throws Exception {
 		when(mockRequest.getParameter("userId")).thenReturn(userId.toString());
+		when(mockRequest.getParameter("anonymous")).thenReturn("false");
 		when(mockResponse.getWriter()).thenReturn(mockPrintWriter);
-		when(mockUserManager.getUserInfo(userId)).thenReturn(userInfo);
 
 		// method under test
 		filter.doFilter(mockRequest, mockResponse, mockFilterChain);

--- a/services/repository/src/test/java/org/sagebionetworks/auth/filter/AuthenticationFilterTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/filter/AuthenticationFilterTest.java
@@ -133,6 +133,7 @@ public class AuthenticationFilterTest {
 		String anonymous = modRequest.getParameter(AuthorizationConstants.USER_ID_PARAM);
 		assertEquals(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId().toString(), anonymous);
 		assertNull(modRequest.getHeader(AuthorizationConstants.SYNAPSE_AUTHENTICATION_METHOD_HEADER_NAME));
+		assertEquals("true", modRequest.getParameter(AuthorizationConstants.ANONYMOUS_PARAM));
 	}
 	
 	/**
@@ -193,6 +194,7 @@ public class AuthenticationFilterTest {
 		verify(mockFilterChain).doFilter(requestCaptor.capture(), (ServletResponse)any());
 		
 		assertEquals(""+userId, requestCaptor.getValue().getParameter(AuthorizationConstants.USER_ID_PARAM));
+		assertEquals("false", requestCaptor.getValue().getParameter(AuthorizationConstants.ANONYMOUS_PARAM));
 		assertEquals("Bearer "+BEARER_TOKEN, requestCaptor.getValue().getHeader(AuthorizationConstants.SYNAPSE_AUTHORIZATION_HEADER_NAME));
 		assertEquals(AuthenticationMethod.BEARERTOKEN.name(), requestCaptor.getValue().getHeader(AuthorizationConstants.SYNAPSE_AUTHENTICATION_METHOD_HEADER_NAME));
 	}
@@ -274,6 +276,7 @@ public class AuthenticationFilterTest {
 		verify(mockOidcManager, never()).validateAccessToken(BEARER_TOKEN);
 		
 		assertEquals("273950", requestCaptor.getValue().getParameter(AuthorizationConstants.USER_ID_PARAM));
+		assertEquals("true", requestCaptor.getValue().getParameter(AuthorizationConstants.ANONYMOUS_PARAM));
 		assertNull(requestCaptor.getValue().getHeader(AuthorizationConstants.SYNAPSE_AUTHORIZATION_HEADER_NAME));
 		assertNull(requestCaptor.getValue().getHeader(AuthorizationConstants.SYNAPSE_AUTHENTICATION_METHOD_HEADER_NAME));
 	}

--- a/services/repository/src/test/java/org/sagebionetworks/auth/filter/AuthenticationFilterTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/filter/AuthenticationFilterTest.java
@@ -17,7 +17,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
+import java.util.Optional;
 
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -39,6 +39,7 @@ import org.sagebionetworks.repo.manager.oauth.OpenIDConnectManager;
 import org.sagebionetworks.repo.model.AuthenticationMethod;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
+import org.sagebionetworks.repo.model.RealmDao;
 import org.sagebionetworks.repo.model.principal.PrincipalAlias;
 import org.sagebionetworks.repo.web.OAuthErrorCode;
 import org.sagebionetworks.repo.web.OAuthUnauthenticatedException;
@@ -68,6 +69,9 @@ public class AuthenticationFilterTest {
 	
 	@Mock
 	private OpenIDConnectManager mockOidcManager;
+	
+	@Mock
+	private RealmDao mockRealmDao;
 	
 	@Captor
 	private ArgumentCaptor<HttpServletRequest> requestCaptor;
@@ -178,8 +182,9 @@ public class AuthenticationFilterTest {
 		when(mockHttpRequest.getHeaderNames()).thenReturn(Collections.enumeration(HEADER_NAMES));
 		when(mockHttpRequest.getHeaders("Authorization")).thenReturn(Collections.enumeration(Collections.singletonList(BEARER_TOKEN_HEADER)));
 		when(mockOidcManager.validateAccessToken(anyString())).thenReturn(""+userId);
-
 		// by default the mocked oidcTokenHelper.validateJWT(bearerToken) won't throw any exception, so the token is deemed valid
+		
+		when(mockRealmDao.getRealmForAnonymousPrincipal(""+userId)).thenReturn(Optional.empty()); // userId is not anonymous
 
 		// method under test
 		filter.doFilter(mockHttpRequest, mockHttpResponse, mockFilterChain);
@@ -197,7 +202,8 @@ public class AuthenticationFilterTest {
 		when(mockHttpRequest.getHeader(AuthorizationConstants.SESSION_TOKEN_PARAM)).thenReturn(BEARER_TOKEN);
 		when(mockHttpRequest.getHeaderNames()).thenReturn(Collections.enumeration(Collections.singletonList("sessionToken")));
 		when(mockOidcManager.validateAccessToken(anyString())).thenReturn(""+userId);
-
+		when(mockRealmDao.getRealmForAnonymousPrincipal(""+userId)).thenReturn(Optional.empty()); // userId is not anonymous
+		
 		// method under test
 		filter.doFilter(mockHttpRequest, mockHttpResponse, mockFilterChain);
 		
@@ -220,6 +226,7 @@ public class AuthenticationFilterTest {
 		when(mockHttpRequest.getHeaderNames()).thenReturn(Collections.enumeration(HEADER_NAMES));
 		when(mockHttpRequest.getHeaders("Authorization")).thenReturn(Collections.enumeration(Collections.singletonList(BEARER_TOKEN_HEADER)));
 		when(mockOidcManager.validateAccessToken(anyString())).thenReturn(""+userId);
+		when(mockRealmDao.getRealmForAnonymousPrincipal(""+userId)).thenReturn(Optional.empty()); // userId is not anonymous
 
 		// method under test
 		filter.doFilter(mockHttpRequest, mockHttpResponse, mockFilterChain);

--- a/services/repository/src/test/java/org/sagebionetworks/auth/filter/TwoFactorAuthRequiredFilterTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/auth/filter/TwoFactorAuthRequiredFilterTest.java
@@ -37,9 +37,6 @@ public class TwoFactorAuthRequiredFilterTest {
 	private AuthenticationDAO mockAuthDao;
 	
 	@Mock
-	private RealmDao mockRealmDao;
-	
-	@Mock
 	private FeatureManager mockFeatureManager;
 	
 	@InjectMocks
@@ -60,7 +57,7 @@ public class TwoFactorAuthRequiredFilterTest {
 	public void testDoFilterWithAnonymousUser() throws Exception {
 		String anonId = AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId().toString();
 		when(mockHttpRequest.getParameter(AuthorizationConstants.USER_ID_PARAM)).thenReturn(anonId);
-		when(mockRealmDao.getRealmForAnonymousPrincipal(anonId)).thenReturn(Optional.of("0"));
+		when(mockHttpRequest.getParameter(AuthorizationConstants.ANONYMOUS_PARAM)).thenReturn("true");
 				
 		// Call under test
 		filter.doFilter(mockHttpRequest, mockHttpResponse, mockFilterChain);
@@ -120,7 +117,6 @@ public class TwoFactorAuthRequiredFilterTest {
 		when(mockHttpRequest.getParameter(AuthorizationConstants.USER_ID_PARAM)).thenReturn(USER_ID);
 		when(mockFeatureManager.isFeatureEnabled(Feature.DISABLE_2FA_REQUIREMENT)).thenReturn(false);
 		when(mockAuthDao.isTwoFactorAuthEnabled(123L)).thenReturn(true);
-		when(mockRealmDao.getRealmForAnonymousPrincipal(USER_ID)).thenReturn(Optional.empty());
 		
 		// Call under test
 		filter.doFilter(mockHttpRequest, mockHttpResponse, mockFilterChain);

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/OAuthScopeInterceptorTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/OAuthScopeInterceptorTest.java
@@ -74,7 +74,6 @@ class OAuthScopeInterceptorTest {
 	@Mock
 	private RequestHeader mockRequestHeader;
 	
-	private static final String USER_ID = "100001";
 	private static final String ACCESS_TOKEN = "access-token";
 	
 	private static RequiredScope createRequiredScopeAnnotation(final OAuthScope[] scopes) {
@@ -109,12 +108,12 @@ class OAuthScopeInterceptorTest {
 		when(mockUserIdParameter.getParameterAnnotation(RequestParam.class)).thenReturn(mockRequestParam);
 	}
 	
-	private void mockRequest(String userId, String accessToken) {
+	private void mockRequest(boolean isAnonymous, String accessToken) {
 		if (accessToken!=null) {
 			when(mockRequest.getHeader(SYNAPSE_AUTHORIZATION_HEADER_NAME)).thenReturn("Bearer "+accessToken);
 		}
 		when(mockRequest.getHeader(AuthorizationConstants.SYNAPSE_HEADER_SERVICE_NAME)).thenReturn(null);
-		when(mockRequest.getParameter(AuthorizationConstants.USER_ID_PARAM)).thenReturn(userId); 	
+		when(mockRequest.getParameter(AuthorizationConstants.ANONYMOUS_PARAM)).thenReturn(""+isAnonymous); 	
 	}
 	
 	private void mockAccessToken(OAuthScope[] scopes) {
@@ -156,27 +155,10 @@ class OAuthScopeInterceptorTest {
 		assertFalse(OAuthScopeInterceptor.hasUserIdParameterOrAccessTokenHeader(mockHandler));
 	}
 	
-	@Test
-	void testIsAnonymous_anonymousId() {
-		when(mockRequest.getParameter(AuthorizationConstants.USER_ID_PARAM)).
-			thenReturn(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId().toString());
-		assertTrue(OAuthScopeInterceptor.isUnAuthenticated(mockRequest));
-	}
-	
-	@Test
-	void testIsAnonymous_missingId() {
-		assertTrue(OAuthScopeInterceptor.isUnAuthenticated(mockRequest));
-	}
-	
-	@Test
-	void testIsAnonymous_NOT_anonymous() {
-		when(mockRequest.getParameter(AuthorizationConstants.USER_ID_PARAM)).thenReturn("123");
-		assertFalse(OAuthScopeInterceptor.isUnAuthenticated(mockRequest));
-	}
 	
 	@Test
 	void testPrehandleAnonymous() throws Exception {
-		mockRequest(AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId().toString(), null);// anonymous, no access token
+		mockRequest(true, null);// anonymous, no access token
 		
 		// method under test
 		boolean result = oauthScopeInterceptor.preHandle(mockRequest, mockResponse, mockHandler);
@@ -184,7 +166,6 @@ class OAuthScopeInterceptorTest {
 		assertTrue(result);
 		
 		verify(mockRequest).getHeader(AuthorizationConstants.SYNAPSE_HEADER_SERVICE_NAME);
-		verify(mockRequest).getParameter(AuthorizationConstants.USER_ID_PARAM);
 		
 		verifyNoMoreInteractions(mockRequest);
 		verifyZeroInteractions(mockResponse);
@@ -193,7 +174,7 @@ class OAuthScopeInterceptorTest {
 
 	@Test
 	void testPrehandleAnonymous_handlerWrongType() throws Exception {
-		mockRequest("123", null);// NOT anonymous
+		mockRequest(false, null);// NOT anonymous
 		
 		// method under test
 		assertThrows(IllegalStateException.class, 
@@ -204,7 +185,7 @@ class OAuthScopeInterceptorTest {
 
 	@Test
 	void testPrehandleNoUserIdORAccessTokenParameter() throws Exception {
-		mockRequest(null, null);// anonymous, no access token
+		mockRequest(true, null);// anonymous, no access token
 
 		// method under test
 		boolean result = oauthScopeInterceptor.preHandle(mockRequest, mockResponse, mockHandler);
@@ -216,7 +197,7 @@ class OAuthScopeInterceptorTest {
 	void testPrehandleHappyCase() throws Exception {
 		mockRequiredScopeAnnotation();
 		mockRequestIdParam();
-		mockRequest(USER_ID, ACCESS_TOKEN);// NOT anonymous	
+		mockRequest(false, ACCESS_TOKEN);// NOT anonymous	
 		mockAccessToken(OAuthScope.values());
 		
 		// method under test
@@ -231,7 +212,7 @@ class OAuthScopeInterceptorTest {
 
 	@Test
 	void testPrehandleNoScopeAnnotation() throws Exception {
-		mockRequest("123", null);// NOT anonymous
+		mockRequest(false, null);// NOT anonymous
 		mockRequestIdParam();
 		when(mockHandler.getMethodAnnotation(RequiredScope.class)).thenReturn(null);
 		
@@ -250,7 +231,7 @@ class OAuthScopeInterceptorTest {
 		mockRequiredScopeAnnotation();
 		mockRequestIdParam();
 		
-		mockRequest(USER_ID, ACCESS_TOKEN);// NOT anonymous	
+		mockRequest(false, ACCESS_TOKEN);// NOT anonymous	
 		mockAccessToken(new OAuthScope[] {OAuthScope.view});
 		OutputStream os = mockResponse();
 		
@@ -274,7 +255,7 @@ class OAuthScopeInterceptorTest {
 		mockRequiredScopeAnnotation();
 		mockRequestIdParam();
 		
-		mockRequest(USER_ID, null);// NOT anonymous, no access token
+		mockRequest(false, null);// NOT anonymous, no access token
 		OutputStream os = mockResponse();
 		
 		// method under test
@@ -297,7 +278,7 @@ class OAuthScopeInterceptorTest {
 		mockRequiredScopeAnnotation();
 		mockRequestIdParam();
 		
-		mockRequest(USER_ID, ACCESS_TOKEN);// NOT anonymous, no access token
+		mockRequest(false, ACCESS_TOKEN);// NOT anonymous, no access token
 		
 		String message = "the error message";
 

--- a/services/repository/src/test/java/org/sagebionetworks/repo/web/filter/throttle/RequestThrottleFilterTest.java
+++ b/services/repository/src/test/java/org/sagebionetworks/repo/web/filter/throttle/RequestThrottleFilterTest.java
@@ -79,7 +79,8 @@ public class RequestThrottleFilterTest {
 	@Test
 	public void testAnonymousUser() throws Exception{ //TODO: remove once java client has a way to get session id from cookies
 		mockRequest.setParameter(AuthorizationConstants.USER_ID_PARAM, AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId().toString());
-
+		mockRequest.setParameter(AuthorizationConstants.ANONYMOUS_PARAM, "true");
+		
 		//method under test
 		filter.doFilter(mockRequest, mockResponse, mockFilterChain);
 


### PR DESCRIPTION
- Add an 'anonymous' request parameter in the AuthenticationFilter which downstream filters can use, rather than issuing their own DB query to find out if the user is anonymous;
- Remove AuthorizationUtils.isDefaultRealmAnonymousId(), no longer needed;
- Although we discussed making a (cached) query to get anonymous principals for all realms, this did not end up being necessary
