### PR TITLE
PLFM-9477

### DIFF
--- a/lib/lib-grid-db/src/main/java/org/sagebionetworks/grid/db/GridIndexDao.java
+++ b/lib/lib-grid-db/src/main/java/org/sagebionetworks/grid/db/GridIndexDao.java
@@ -226,14 +226,15 @@ public interface GridIndexDao {
 
 
 	/**
-	 * 
+	 * Returns the last node ID in the given array, or the array node ID itself if the array is empty.
+	 * This is intended to be used to append new nodes to the end of an array.
 	 * @param sessionIdString
 	 * @param replicaId
 	 * @param arrayId
 	 * 
-	 * @return The last node in the given array, empty if the array has no nodes.
+	 * @return The last node ID in the given array, or the array node ID itself if the array is empty.
 	 */
-	Optional<RGANode> getRgaLastNode(String sessionIdString, Long replicaId, LogicalTimestamp arrayId);
+	LogicalTimestamp getArrayLastNodeId(String sessionIdString, Long replicaId, LogicalTimestamp arrayId);
 	
 	/**
 	 * Given a new {@link RGANode} to insert, find the location where the node

--- a/lib/lib-grid-db/src/main/java/org/sagebionetworks/grid/db/GridIndexDaoImpl.java
+++ b/lib/lib-grid-db/src/main/java/org/sagebionetworks/grid/db/GridIndexDaoImpl.java
@@ -588,7 +588,7 @@ public class GridIndexDaoImpl implements GridIndexDao {
 	}
 
 	@Override
-	public Optional<RGANode> getRgaLastNode(String sessionIdString, Long replicaId, LogicalTimestamp arrayId) {
+	public LogicalTimestamp getArrayLastNodeId(String sessionIdString, Long replicaId, LogicalTimestamp arrayId) {
 		Long sessionId = validateReplica(sessionIdString, replicaId);
 		MapSqlParameterSource params = new MapSqlParameterSource();
 		params.addValue("sessionId", sessionId);
@@ -600,7 +600,7 @@ public class GridIndexDaoImpl implements GridIndexDao {
 
 		return namedTemplate.query(String.format(LIST_ARRAY_ORDER_SQL, EXCLUDE_DELETED_NODES_SQL_COND, "DESC"), params, RGA_NODE_MAPPER)
 			.stream()
-			.findFirst();
+			.findFirst().map(RGANode::getNodeId).orElse(arrayId);
 	}
 
 	@Override

--- a/lib/lib-grid-db/src/test/java/org/sagebionetworks/grid/db/GridIndexDaoImplTest.java
+++ b/lib/lib-grid-db/src/test/java/org/sagebionetworks/grid/db/GridIndexDaoImplTest.java
@@ -1036,16 +1036,16 @@ public class GridIndexDaoImplTest {
 	}
 	
 	@Test
-	public void testGetRgaLastNode() {
+	public void testGetArrayLastNodeId() {
 		// Creates an empty array
 		LogicalTimestamp arrOneId = new LogicalTimestamp().setReplicaId(4L).setSequenceNumber(44L);
-		
+
 		createArray(sessionIdOne, replicaIdOne, arrOneId);
+
+		// Call under test - return the array ID when there are no rows
+		LogicalTimestamp lastNodeId = gridIndexDao.getArrayLastNodeId(sessionIdOne, replicaIdOne, arrOneId);
 		
-		// Call under test
-		Optional<RGANode> lastNode = gridIndexDao.getRgaLastNode(sessionIdOne, replicaIdOne, arrOneId);
-		
-		assertTrue(lastNode.isEmpty());
+		assertEquals(lastNodeId, arrOneId);
 		
 		RGANode firstNode = new RGANode()
 			.setContainerId(arrOneId)
@@ -1057,7 +1057,7 @@ public class GridIndexDaoImplTest {
 		gridIndexDao.insertIntoRepeatedGrowableArray(sessionIdOne, replicaIdOne, firstNode);
 		
 		// Call under test
-		assertEquals(Optional.of(firstNode), gridIndexDao.getRgaLastNode(sessionIdOne, replicaIdOne, arrOneId));
+		assertEquals(firstNode.getNodeId(), gridIndexDao.getArrayLastNodeId(sessionIdOne, replicaIdOne, arrOneId));
 		
 		RGANode secondNode = new RGANode()
 			.setContainerId(arrOneId)
@@ -1069,7 +1069,7 @@ public class GridIndexDaoImplTest {
 		gridIndexDao.insertIntoRepeatedGrowableArray(sessionIdOne, replicaIdOne, secondNode);
 		
 		// Call under test
-		assertEquals(Optional.of(secondNode), gridIndexDao.getRgaLastNode(sessionIdOne, replicaIdOne, arrOneId));
+		assertEquals(secondNode.getNodeId(), gridIndexDao.getArrayLastNodeId(sessionIdOne, replicaIdOne, arrOneId));
 		
 		// Deletes the first node
 		gridIndexDao.deleteRgaNodes(sessionIdOne, replicaIdOne, arrOneId, List.of(
@@ -1077,7 +1077,7 @@ public class GridIndexDaoImplTest {
 		));
 		
 		// Call under test
-		assertEquals(Optional.of(secondNode), gridIndexDao.getRgaLastNode(sessionIdOne, replicaIdOne, arrOneId));
+		assertEquals(secondNode.getNodeId(), gridIndexDao.getArrayLastNodeId(sessionIdOne, replicaIdOne, arrOneId));
 	}
 	
 	@Test

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/JoinedRowChangePublisher.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/JoinedRowChangePublisher.java
@@ -47,9 +47,7 @@ public class JoinedRowChangePublisher {
 			
 			// The iterator of joined rows is sorted by upsert key descending, this allows us to use the current last row id
 			// as the insert position for all new rows (since they will be inserted in reverse order)
-			LogicalTimestamp lastRowId = gridIndexDao.getRgaLastNode(header.getSessionId(), header.getReplicaId(), rowsArrayId)
-				.map(RGANode::getNodeId)
-				.orElse(null);
+			LogicalTimestamp lastRowId = gridIndexDao.getArrayLastNodeId(header.getSessionId(), header.getReplicaId(), rowsArrayId);
 			
 			while (joinedRowStream.hasNext()) {
 				JoinedRow joinedRow = joinedRowStream.next();

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/synch/handler/CopyHandlerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/synch/handler/CopyHandlerImpl.java
@@ -56,8 +56,7 @@ public class CopyHandlerImpl implements CopyHandler {
 	}
 
 	LogicalTimestamp getLastRowsRgaNodeId(GridIndexDao gridIndexDao, GridHeader header) {
-		return gridIndexDao.getRgaLastNode(header.getSessionId(), header.getReplicaId(), header.getRowsId())
-				.map(RGANode::getNodeId).orElse(null);
+		return gridIndexDao.getArrayLastNodeId(header.getSessionId(), header.getReplicaId(), header.getRowsId());
 	}
 
 	private Map<Integer, String> buildIndexToColumnMap(List<Column> columns) {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/JoinedRowChangePublisherTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/JoinedRowChangePublisherTest.java
@@ -82,8 +82,8 @@ public class JoinedRowChangePublisherTest {
 
 	@Test
 	public void testProcessJoinedRows() {
-		when(mockGridIndexDao.getRgaLastNode(header.getSessionId(), header.getReplicaId(), header.getRowsId()))
-			.thenReturn(Optional.of(new RGANode().setNodeId(mockTimestamp)));
+		when(mockGridIndexDao.getArrayLastNodeId(header.getSessionId(), header.getReplicaId(), header.getRowsId()))
+			.thenReturn(mockTimestamp);
 		
 		when(mockConnInfo.getSessionId()).thenReturn(header.getSessionId());
 		when(mockConnInfo.getConnectionId()).thenReturn("connId");

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/synch/handler/CopyHandlerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/synch/handler/CopyHandlerImplTest.java
@@ -69,7 +69,6 @@ public class CopyHandlerImplTest {
 	private Long userReplicaId;
 	private LogicalTimestamp lastRowsRgaNodeId;
 	private LogicalTimestamp rowsId;
-	private RGANode rgaNode;
 
 	@BeforeEach
 	public void before() {
@@ -81,7 +80,6 @@ public class CopyHandlerImplTest {
 		rowsId = new LogicalTimestamp().setReplicaId(internalReplicaId).setSequenceNumber(4L);
 		columns = List.of(new Column().setName("a").setVectorIndex(1), new Column().setName("b").setVectorIndex(0));
 		gridSource = new GridSource(222L, EntityType.entityview);
-		rgaNode = new RGANode().setContainerId(rowsId).setNodeId(lastRowsRgaNodeId);
 	}
 
 	CopyHandlerImpl setupHandler() {
@@ -91,7 +89,7 @@ public class CopyHandlerImplTest {
 		when(mockGridManager.getSingletonConnection(sessionId, EventSource.USER_SUPPORT))
 				.thenReturn(Optional.of(mockConnection));
 		when(mockHeader.getRowsId()).thenReturn(rowsId);
-		when(mockGridIndexDao.getRgaLastNode(sessionId, internalReplicaId, rowsId)).thenReturn(Optional.of(rgaNode));
+		when(mockGridIndexDao.getArrayLastNodeId(sessionId, internalReplicaId, rowsId)).thenReturn(lastRowsRgaNodeId);
 		when(mockHeader.getSessionId()).thenReturn(sessionId);
 		when(mockHeader.getReplicaId()).thenReturn(internalReplicaId);
 		return new CopyHandlerImpl(mockGridReplicaViewManager, mockGridReplicaSupport, mockGridIndexDao,


### PR DESCRIPTION
- Fix issue where CSV importer would fail to insert rows if no insert exists

Changed GridIndexDao#getRgaLastNode to GridIndexDao#getArrayLastNodeId since the method was only ever used to find an ID suitable for appending rows. Updated the implementation to return the array ID when no RGA nodes are found. This is consistent with the JSON CRDT RGA implementation where an RGA node may reference the array ID.