### PR TITLE
PLFM-9490

### DIFF
--- a/lib/lib-grid/src/main/java/org/sagebionetworks/repo/model/grid/encoding/IndexedEncodingUtils.java
+++ b/lib/lib-grid/src/main/java/org/sagebionetworks/repo/model/grid/encoding/IndexedEncodingUtils.java
@@ -12,6 +12,11 @@ import org.sagebionetworks.util.ValidateArgument;
  */
 public final class IndexedEncodingUtils {
 
+	// The minimum value of length that requires extended encoding. Lengths less than this can be encoded directly in the first byte.
+	// NOTE: The JSON CRDT specification claims this is 31, but in the json-joy implementation, it is actually 24.
+	// See https://github.com/streamich/json-joy/issues/986
+	private final static int INLINE_LENGTH_THRESHOLD = 24;
+
 	private IndexedEncodingUtils() {
 		// Utility class
 	}
@@ -20,8 +25,14 @@ public final class IndexedEncodingUtils {
 	 * Write the node type and length header byte(s).
 	 *
 	 * The first byte encodes the node type in bits 7-5 (3 bits) and the length in bits 4-0 (5 bits).
-	 * When the length is 31 or greater, bits 4-0 are set to 0x1F and the actual length is encoded
-	 * as a vu57 integer in the following bytes.
+	 *
+	 * NOTE: The JSON CRDT spec says lengths 0-30 are inline and 31 triggers vu57 extension.
+	 * However, the json-joy library implementation uses CBOR-style encoding:
+	 *   - 0-23: inline in the lower 5 bits
+	 *   - 24: 1-byte unsigned length follows
+	 *   - 25: 2-byte big-endian unsigned length follows
+	 *   - 26: 4-byte big-endian unsigned length follows
+	 * We match the library's actual behavior for interoperability.
 	 *
 	 * @param nodeType the node type (3 bits, 0-7)
 	 * @param length the length value
@@ -32,30 +43,39 @@ public final class IndexedEncodingUtils {
 	public static int writeNodeHeader(int nodeType, long length, OutputStream out) throws IOException {
 		ValidateArgument.required(out, "out");
 
-		int bytesWritten = 0;
-		// Type occupies bits 7-5 (3 bits), length occupies bits 4-0 (5 bits)
-		nodeType = (byte) (nodeType << 5);
-		if (length < 31) {
-			// When length e is less than 31, the first 3 bits of TL encode the node type c and the remaining 5 bits
-			// encode the length e.
-			nodeType |= (int) length;
-			out.write(nodeType);
-			bytesWritten += 1;
+		int majorOverlay = (nodeType & 0x07) << 5;
+
+		if (length < INLINE_LENGTH_THRESHOLD) {
+			// Length fits directly in the lower 5 bits
+			out.write(majorOverlay | (int) length);
+			return 1;
+		} else if (length <= 0xFF) {
+			// minor = 24: 1-byte unsigned length follows
+			out.write(majorOverlay | 24);
+			out.write((int) length);
+			return 2;
+		} else if (length <= 0xFFFF) {
+			// minor = 25: 2-byte big-endian unsigned length follows
+			out.write(majorOverlay | 25);
+			out.write((int) (length >> 8) & 0xFF);
+			out.write((int) length & 0xFF);
+			return 3;
 		} else {
-			// When length is 31 or greater, the first byte encodes the node type c, and the remaining bits are set to 1.
-			// The length is encoded as a vu57 integer.
-			nodeType |= 0b0001_1111; // length extension indicator
-			out.write(nodeType);
-			bytesWritten += 1;
-			byte[] encodedLength = Vu57Utils.encodeVu57(length);
-			out.write(encodedLength);
-			bytesWritten += encodedLength.length;
+			// minor = 26: 4-byte big-endian unsigned length follows
+			out.write(majorOverlay | 26);
+			out.write((int) (length >> 24) & 0xFF);
+			out.write((int) (length >> 16) & 0xFF);
+			out.write((int) (length >> 8) & 0xFF);
+			out.write((int) length & 0xFF);
+			return 5;
 		}
-		return bytesWritten;
 	}
 
 	/**
 	 * Read the node type and length header from the input stream.
+	 *
+	 * Uses CBOR-style length decoding to match json-joy's actual behavior.
+	 * See {@link #writeNodeHeader} for details on the encoding.
 	 *
 	 * @param in the input stream
 	 * @return a TypeAndLength containing the node type and length
@@ -69,19 +89,39 @@ public final class IndexedEncodingUtils {
 			throw new IOException("Unexpected end of stream while reading node type and length");
 		}
 
-		// Type occupies bits 7-5 (3 bits), length occupies bits 4-0 (5 bits)
 		int nodeType = (firstByte >> 5) & 0x07;
-
-		// Extract length from lower 5 bits
-		int lengthPart = firstByte & 0x1F;
+		int minor = firstByte & 0x1F;
 
 		long length;
-		if (lengthPart < 31) {
-			// Length is directly encoded in the lower 5 bits
-			length = lengthPart;
+		if (minor < INLINE_LENGTH_THRESHOLD) {
+			length = minor;
+		} else if (minor == 24) {
+			// 1-byte unsigned length
+			int b = in.read();
+			if (b == -1) {
+				throw new IOException("Unexpected end of stream while reading 1-byte length");
+			}
+			length = b;
+		} else if (minor == 25) {
+			// 2-byte big-endian unsigned length
+			int b1 = in.read();
+			int b2 = in.read();
+			if (b1 == -1 || b2 == -1) {
+				throw new IOException("Unexpected end of stream while reading 2-byte length");
+			}
+			length = (b1 << 8) | b2;
+		} else if (minor == 26) {
+			// 4-byte big-endian unsigned length
+			int b1 = in.read();
+			int b2 = in.read();
+			int b3 = in.read();
+			int b4 = in.read();
+			if (b1 == -1 || b2 == -1 || b3 == -1 || b4 == -1) {
+				throw new IOException("Unexpected end of stream while reading 4-byte length");
+			}
+			length = ((long) b1 << 24) | (b2 << 16) | (b3 << 8) | b4;
 		} else {
-			// Length extension: read vu57 for actual length
-			length = Vu57Utils.decodeVu57(in);
+			throw new IOException("Unsupported minor value in node header: " + minor);
 		}
 
 		return new IndexedNodeHeader(nodeType, length);

--- a/lib/lib-grid/src/test/java/org/sagebionetworks/repo/model/grid/encoding/IndexedEncodingUtilsTest.java
+++ b/lib/lib-grid/src/test/java/org/sagebionetworks/repo/model/grid/encoding/IndexedEncodingUtilsTest.java
@@ -34,40 +34,103 @@ public class IndexedEncodingUtilsTest {
 	public void testWriteNodeHeaderMaxOneByte() throws IOException {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-		int bytesWritten = IndexedEncodingUtils.writeNodeHeader(0b010, 30L, out);
+		int bytesWritten = IndexedEncodingUtils.writeNodeHeader(0b010, 23L, out);
 		byte[] bytes = out.toByteArray();
 		ByteArrayInputStream byteStream = new ByteArrayInputStream(bytes);
 
 		assertEquals(1, bytesWritten);
-		// Type 010 shifted left 5 = 0100_0000 = 0x40, length 30 = 0x1E
-		assertEquals(0x40 | 0x1E, out.toByteArray()[0] & 0xFF);
+		// Type 010 shifted left 5 = 0100_0000 = 0x40, length 23 = 0x17
+		assertEquals(0x40 | 0x17, out.toByteArray()[0] & 0xFF);
 
 		// Verify decode
 		IndexedNodeHeader typeAndLength = IndexedEncodingUtils.readNodeHeader(byteStream);
 		assertEquals(0b010, typeAndLength.getNodeType());
-		assertEquals(30L, typeAndLength.getLength());
+		assertEquals(23L, typeAndLength.getLength());
 	}
 
 	@Test
-	public void testWriteNodeHeaderMultiByte() throws IOException {
+	public void testWriteNodeHeaderMinMultiByte() throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+		int bytesWritten = IndexedEncodingUtils.writeNodeHeader(0b010, 24L, out);
+		byte[] bytes = out.toByteArray();
+		ByteArrayInputStream byteStream = new ByteArrayInputStream(bytes);
+
+		assertEquals(2, bytesWritten);
+		// Type 010 shifted left 5 = 0100_0000 = 0x40, minor 24 = 0x18
+		assertEquals(0x40 | 0x18, out.toByteArray()[0] & 0xFF);
+		// 1-byte unsigned length follows: 24 = 0x18
+		assertEquals(0x18, out.toByteArray()[1] & 0xFF);
+
+		// Verify decode
+		IndexedNodeHeader typeAndLength = IndexedEncodingUtils.readNodeHeader(byteStream);
+		assertEquals(0b010, typeAndLength.getNodeType());
+		assertEquals(24L, typeAndLength.getLength());
+	}
+
+	@Test
+	public void testWriteNodeHeaderOneByteLengthExtension() throws IOException {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 
 		int bytesWritten = IndexedEncodingUtils.writeNodeHeader(0b011, 100L, out);
 		byte[] bytes = out.toByteArray();
 		ByteArrayInputStream byteStream = new ByteArrayInputStream(bytes);
 
-		// First byte: type in bits 7-5, 0x1F in bits 4-0 (length extension indicator)
-		// Type 011 shifted left 5 = 0110_0000 = 0x60, extension = 0x1F
-		assertEquals(0x60 | 0x1F, out.toByteArray()[0] & 0xFF);
-
-		// Remaining bytes should be vu57 encoding of 100
-		byte[] expectedVu57 = Vu57Utils.encodeVu57(100L);
-		assertEquals(1 + expectedVu57.length, bytesWritten);
+		assertEquals(2, bytesWritten);
+		// Type 011 shifted left 5 = 0110_0000 = 0x60, minor 24 = 0x18
+		assertEquals(0x60 | 0x18, bytes[0] & 0xFF);
+		// 1-byte unsigned length: 100 = 0x64
+		assertEquals(0x64, bytes[1] & 0xFF);
 
 		// Verify decode
 		IndexedNodeHeader typeAndLength = IndexedEncodingUtils.readNodeHeader(byteStream);
 		assertEquals(0b011, typeAndLength.getNodeType());
 		assertEquals(100L, typeAndLength.getLength());
+	}
+
+	@Test
+	public void testWriteNodeHeaderTwoByteLengthExtension() throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+		int bytesWritten = IndexedEncodingUtils.writeNodeHeader(0b001, 1000L, out);
+		byte[] bytes = out.toByteArray();
+		ByteArrayInputStream byteStream = new ByteArrayInputStream(bytes);
+
+		assertEquals(3, bytesWritten);
+		// Type 001 shifted left 5 = 0010_0000 = 0x20, minor 25 = 0x19
+		assertEquals(0x20 | 0x19, bytes[0] & 0xFF);
+		// 2-byte big-endian unsigned length: 1000 = 0x03E8
+		assertEquals(0x03, bytes[1] & 0xFF);
+		assertEquals(0xE8, bytes[2] & 0xFF);
+
+		// Verify decode
+		IndexedNodeHeader typeAndLength = IndexedEncodingUtils.readNodeHeader(byteStream);
+		assertEquals(0b001, typeAndLength.getNodeType());
+		assertEquals(1000L, typeAndLength.getLength());
+	}
+
+	@Test
+	public void testWriteNodeHeaderFourByteLengthExtension() throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+		long length = 100_000L;
+		int bytesWritten = IndexedEncodingUtils.writeNodeHeader(0b100, length, out);
+		byte[] bytes = out.toByteArray();
+		ByteArrayInputStream byteStream = new ByteArrayInputStream(bytes);
+
+		assertEquals(5, bytesWritten);
+		// Type 100 shifted left 5 = 1000_0000 = 0x80, minor 26 = 0x1A
+		assertEquals(0x80 | 0x1A, bytes[0] & 0xFF);
+		// 4-byte big-endian unsigned length: 100000 = 0x000186A0
+		assertEquals(0x00, bytes[1] & 0xFF);
+		assertEquals(0x01, bytes[2] & 0xFF);
+		assertEquals(0x86, bytes[3] & 0xFF);
+		assertEquals(0xA0, bytes[4] & 0xFF);
+
+		// Verify decode
+		IndexedNodeHeader typeAndLength = IndexedEncodingUtils.readNodeHeader(byteStream);
+		assertEquals(0b100, typeAndLength.getNodeType());
+		assertEquals(length, typeAndLength.getLength());
 	}
 
 	@Test


### PR DESCRIPTION
Update IndexedEncodingUtils to encode node length to match the json-joy implementation rather than the JSON CRDT specification.

See https://github.com/streamich/json-joy/issues/986