### PR TITLE
PLFM-9475 - Ignore grid data with null upsert key during upsert merge

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridDataStream.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridDataStream.java
@@ -5,45 +5,101 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.sagebionetworks.repo.manager.grid.internal.replica.model.RowView;
+import org.sagebionetworks.repo.model.grid.patch.ConType;
 import org.sagebionetworks.repo.model.grid.patch.ConValue;
 import org.sagebionetworks.repo.model.grid.patch.LogicalTimestamp;
 import org.sagebionetworks.repo.model.grid.patch.compact.LogicalTimestampCompactSerializable;
 
+/**
+ * A {@link DataStream} that streams rows from a grid replica view for import
+ * into a temporary table. Each row is projected into a flat {@code Object[]}
+ * where the upsert-key columns occupy the leading positions (in the order they
+ * appear in the {@link ColumnMapping} array) and the row's vector-clock ID is
+ * appended as the final element.
+ *
+ * <p>Rows whose upsert-key cells carry a {@link org.sagebionetworks.repo.model.grid.patch.ConType#NULL},
+ * {@link org.sagebionetworks.repo.model.grid.patch.ConType#UNDEFINED}, or
+ * {@code null} {@link org.sagebionetworks.repo.model.grid.patch.ConValue} are
+ * silently skipped, because such values cannot serve as a meaningful upsert key. Skipping these rows
+ * effectively ignores them in the upsert step, so these rows will remain unchanged in the grid while
+ * other rows may be added or updated.
+ */
 public class GridDataStream implements DataStream {
 
-	private Iterator<RowView> rowViewIterator;
-	private ColumnMapping[] upsertKey;
+	private final Iterator<RowView> rowViewIterator;
+	private final ColumnMapping[] upsertKey;
+	// Look-ahead buffer: holds the next row to be returned, or null when exhausted
+	private Object[] nextRow;
 
 	public GridDataStream(Iterator<RowView> rowViewIterator, ColumnMapping[] columnMapping) {
 		this.rowViewIterator = rowViewIterator;
 		this.upsertKey = Arrays.stream(columnMapping).filter(ColumnMapping::isUpsertColumn).toArray(ColumnMapping[]::new);
+		advance();
 	}
 
 	@Override
 	public boolean hasNext() {
-		return rowViewIterator.hasNext();
+		return nextRow != null;
 	}
 
 	@Override
 	public Object[] next() {
-		RowView row = rowViewIterator.next();
-		
-		// The id of the vector that holds the row data
-		LogicalTimestamp rowVecId = row.getRowObject().getData().getVectorId();
+		Object[] current = nextRow;
+		advance();
+		return current;
+	}
 
-		// The actual JSON array of cell values
-		List<ConValue> cellValues = row.getRowObject().getData().getCells();
+	/**
+	 * Advances the iterator to the next row that does not have a NULL or UNDEFINED
+	 * ConValue in any of its upsert-key cells. Rows with a NULL or UNDEFINED upsert
+	 * key value are silently skipped. Sets {@code nextRow} to {@code null} when the
+	 * underlying iterator is exhausted.
+	 */
+	private void advance() {
+		nextRow = null;
+		while (rowViewIterator.hasNext()) {
+			RowView row = rowViewIterator.next();
 
-		Object[] values = new Object[upsertKey.length + 1];
+			List<ConValue> cellValues = row.getRowObject().getData().getCells();
 
-		// First we map the upsert key columns
-		for (int i = 0; i < upsertKey.length; i++) {
-			values[i] = cellValues.get(upsertKey[i].getGridIndex()).getValue();
+			if (hasNullOrUndefinedUpsertKey(cellValues)) {
+				// skip this row – its upsert key is not usable
+				continue;
+			}
+
+			// The id of the vector that holds the row data
+			LogicalTimestamp rowVecId = row.getRowObject().getData().getVectorId();
+
+			Object[] values = new Object[upsertKey.length + 1];
+
+			// First we map the upsert key columns
+			for (int i = 0; i < upsertKey.length; i++) {
+				values[i] = cellValues.get(upsertKey[i].getGridIndex()).getValue();
+			}
+
+			values[upsertKey.length] = LogicalTimestampCompactSerializable.serialize(rowVecId);
+
+			nextRow = values;
+			return;
 		}
+	}
 
-		values[upsertKey.length] = LogicalTimestampCompactSerializable.serialize(rowVecId);
-
-		return values;
+	/**
+	 * Returns {@code true} if any upsert-key cell in the given cell list has a
+	 * {@link ConType#NULL} or {@link ConType#UNDEFINED} type.
+	 */
+	private boolean hasNullOrUndefinedUpsertKey(List<ConValue> cellValues) {
+		for (ColumnMapping key : upsertKey) {
+			ConValue cell = cellValues.get(key.getGridIndex());
+			if (cell == null) {
+				return true;
+			}
+			ConType type = cell.getType();
+			if (ConType.NULL.equals(type) || ConType.UNDEFINED.equals(type)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImporterImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridCsvImporterImplTest.java
@@ -138,20 +138,20 @@ public class GridCsvImporterImplTest {
 			"2,2,false" + System.lineSeparator();
 		
 		gridRows = List.of(
-			new RowView().setRowObject(new RowObject().setData(new RowData().setNodes(
-				Arrays.asList(
+			new RowView().setRowObject(new RowObject().setData(new RowData()
+					.setNodes(Arrays.asList(
 						new ConstantNode().setId(new LogicalTimestamp().setReplicaId(100L).setSequenceNumber(100L)).setValue(new ConValue(ConType.LONG, 0)),
 						new ConstantNode().setId(new LogicalTimestamp().setReplicaId(100L).setSequenceNumber(102L)).setValue(new ConValue(ConType.LONG, 1)),
 						new ConstantNode().setId(new LogicalTimestamp().setReplicaId(100L).setSequenceNumber(103L)).setValue(new ConValue(ConType.BOOLEAN, true))
-				)
-			))),
-			new RowView().setRowObject(new RowObject().setData(new RowData().setNodes(
-				Arrays.asList(
+					)).setVectorId(new LogicalTimestamp().setReplicaId(100L).setSequenceNumber(98L))
+			)),
+			new RowView().setRowObject(new RowObject().setData(new RowData()
+					.setNodes(Arrays.asList(
 						new ConstantNode().setId(new LogicalTimestamp().setReplicaId(100L).setSequenceNumber(104L)).setValue(new ConValue(ConType.LONG, 2)),
 						new ConstantNode().setId(new LogicalTimestamp().setReplicaId(100L).setSequenceNumber(105L)).setValue(new ConValue(ConType.LONG, 3)),
 						new ConstantNode().setId(new LogicalTimestamp().setReplicaId(100L).setSequenceNumber(106L)).setValue(new ConValue(ConType.BOOLEAN, true))
-				)
-			)))
+					)).setVectorId(new LogicalTimestamp().setReplicaId(100L).setSequenceNumber(99L)))
+			)
 		);
 		
 		joinedRows = List.of(

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridDataStreamTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/GridDataStreamTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.repo.manager.grid.internal.replica.merge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -16,7 +17,28 @@ import org.sagebionetworks.repo.model.grid.patch.LogicalTimestamp;
 import org.sagebionetworks.repo.model.table.ColumnType;
 
 public class GridDataStreamTest {
-	
+
+	private static final ColumnMapping[] MAPPING = new ColumnMapping[] {
+		new ColumnMapping("a", ColumnType.STRING, 0, 0, true),
+		new ColumnMapping("b", ColumnType.INTEGER, 1, 2, true),
+		new ColumnMapping("c", ColumnType.STRING, 2, 1, false)
+	};
+
+	/** Builds a RowView with the given vectorId increment and three cells at grid indices 0, 1, 2. */
+	private static RowView buildRow(LogicalTimestamp base, long vecIncrement,
+			ConValue cell0, ConValue cell1, ConValue cell2, long n1, long n2, long n3) {
+		LogicalTimestamp vId = new LogicalTimestamp().setReplicaId(base.getReplicaId())
+				.setSequenceNumber(base.getSequenceNumber());
+		return new RowView().setRowObject(new RowObject().setData(
+			new RowData().setVectorId(LogicalTimestamp.newIncrement(vId, vecIncrement))
+				.setNodes(Arrays.asList(
+					new ConstantNode().setId(LogicalTimestamp.newIncrement(vId, n1)).setValue(cell0),
+					new ConstantNode().setId(LogicalTimestamp.newIncrement(vId, n2)).setValue(cell1),
+					new ConstantNode().setId(LogicalTimestamp.newIncrement(vId, n3)).setValue(cell2)
+				))
+		));
+	}
+
     @Test
     public void testStream() {
 
@@ -48,15 +70,9 @@ public class GridDataStreamTest {
 					))
 			))			
 		);
-        
-        ColumnMapping[] mapping = new ColumnMapping[] {
-            new ColumnMapping("a", ColumnType.STRING, 0, 0, true),
-            new ColumnMapping("b", ColumnType.INTEGER, 1, 2, true),
-            new ColumnMapping("c", ColumnType.STRING, 2, 1, false)
-        };
 
-        GridDataStream stream = new GridDataStream(rows.iterator(), mapping);
-        
+        GridDataStream stream = new GridDataStream(rows.iterator(), MAPPING);
+
         long rowId = 1L;
         
         while (stream.hasNext()) {
@@ -66,5 +82,44 @@ public class GridDataStreamTest {
         	assertEquals("[20," + (200 + rowId) + "]", row[2].toString());	// c (vectorId)
 			rowId++;
 		}
+        assertEquals(4L, rowId); // all 3 rows were returned
     }
+
+	@Test
+	public void testStreamSkipsNullAndUndefinedUpsertKeys() {
+		LogicalTimestamp vectorId = new LogicalTimestamp().setReplicaId(20L).setSequenceNumber(200L);
+
+		// Row 1 – upsert key "a" is ConValue.NULL      → skipped
+		// Row 2 – upsert key "b" is ConValue.UNDEFINED  → skipped
+		// Row 3 – valid                         → returned
+		// Row 4 – valid                         → returned
+		// Row 5 – upsert key "a" is null      → skipped
+		List<RowView> rows = new ArrayList<>();
+		rows.add(buildRow(vectorId, 1,
+			new ConValue(ConType.NULL, null),      new ConValue(ConType.STRING, "x"), new ConValue(ConType.LONG, 0L),
+			2, 3, 4));
+		rows.add(buildRow(vectorId, 5,
+			new ConValue(ConType.STRING, "skip2"), new ConValue(ConType.STRING, "x"), new ConValue(ConType.UNDEFINED, null),
+			6, 7, 8));
+		rows.add(buildRow(vectorId, 9,
+			new ConValue(ConType.STRING, "keep1"), new ConValue(ConType.STRING, "x"), new ConValue(ConType.LONG, 1L),
+			10, 11, 12));
+		rows.add(buildRow(vectorId, 13,
+			new ConValue(ConType.STRING, "keep2"), new ConValue(ConType.STRING, "x"), new ConValue(ConType.LONG, 2L),
+			14, 15, 16));
+		rows.add(buildRow(vectorId, 17,
+			null,      new ConValue(ConType.STRING, "x"), new ConValue(ConType.LONG, 3L),
+			18, 19, 20));
+
+		GridDataStream stream = new GridDataStream(rows.iterator(), MAPPING);
+
+		List<Object[]> result = new ArrayList<>();
+		while (stream.hasNext()) {
+			result.add(stream.next());
+		}
+
+		assertEquals(2, result.size());
+		assertEquals("keep1", result.get(0)[0]);
+		assertEquals("keep2", result.get(1)[0]);
+	}
 }


### PR DESCRIPTION
Users may have entered blank rows or rows missing upsert key information in the grid before attempting an upsert. Records with null upsert key values cannot be added to the temporary tables for upsert. Instead of throwing an error when we encounter a null upsert key value, which effectively blocks upsert functionality, we can skip these rows. The skipped rows will remain in the grid, and the upsert process can proceed.