### PR TITLE
PLFM-9493

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/auth/RealmDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/auth/RealmDaoImpl.java
@@ -206,16 +206,28 @@ public class RealmDaoImpl implements RealmDao {
 		return result;
 	}
 
-	private DBORealm createPrivate(Realm dto) {
+	private static String sqlInsertCmd(boolean idempotent) {
+		return idempotent ? "INSERT IGNORE" : "INSERT";
+	}
+	
+	/**
+	 * 
+	 * @param dto the Realm to create
+	 * @param idempotent create idempotently, required for the bootstrapped realm
+	 * @return
+	 */
+	private DBORealm createRealmPrivate(Realm dto, boolean idempotent) {
 		dto.setCreatedOn(new Date());
 		DBORealm dbo = copyRealmToDBORealm(dto);
 		dbo = basicDao.createNew(dbo);
 		
-		// remove existing IDPs for this realm
-		jdbcTemplate.update(DELETE_IDPS_SQL, dto.getId());
 		// create the IDPs
 		List<DBORealmIdentityProvider> idps = copyRealmToRealmIdps(dto);
-		basicDao.createBatch(idps);
+		List<Object[]> batchArgs = new ArrayList<Object[]>();
+		for (DBORealmIdentityProvider idp: idps) {
+			batchArgs.add(new Object[] { idp.getRealmId(), idp.getIdentityProvider() } );
+		}
+		jdbcTemplate.batchUpdate(sqlInsertCmd(idempotent)+" INTO SYNAPSE_REALM_IDP (REALM_ID, PROVIDER) VALUES (?,?) ", batchArgs);
 		return dbo;
 	}
 
@@ -223,19 +235,32 @@ public class RealmDaoImpl implements RealmDao {
 	@Override
 	public Realm createRealm(Realm dto) {
 		dto.setId(idGenerator.generateNewId(IdType.REALM).toString());
-		createPrivate(dto);
+		// idempotent MUST be false for the DB to ensure an IdP is not reused across realms
+		createRealmPrivate(dto, false);
 		return dto;
 	}
 	
 	@WriteTransaction
 	@Override
 	public RealmPrincipal createRealmPrincipals(RealmPrincipal dto) {
-		// remove the principals for the realm, prior to recreating them
-		jdbcTemplate.update(DELETE_PRINCIPALS_SQL, dto.getRealmId());
-		// create realm principals
+		// idempotent MUST be false for the DB to ensure realm principals aren't reused across realms
+		return createRealmPrincipalsPrivate(dto, false);
+	}
+	
+	/**
+	 * 
+	 * @param dto
+	 * @param idempotent create idempotently, required for the bootstrapped realm
+	 * @return
+	 */
+	private RealmPrincipal createRealmPrincipalsPrivate(RealmPrincipal dto, boolean idempotent) {
 		List<DBORealmPrincipal> principals = copyRealmPrincipalsToDBOList(dto);
 		if (!principals.isEmpty()) {
-			basicDao.createBatch(principals);
+			List<Object[]> batchArgs = new ArrayList<Object[]>();
+			for (DBORealmPrincipal p: principals) {
+				batchArgs.add(new Object[] { p.getId(), p.getRealmId(), p.getPrincipalId(), p.getPrincipalType() } );
+			}
+			jdbcTemplate.batchUpdate(sqlInsertCmd(idempotent)+" INTO SYNAPSE_REALM_PRINCIPAL (ID, REALM_ID, PRINCIPAL_ID, TYPE) VALUES (?,?,?,?) ", batchArgs);
 		}
 		return dto;
 	}
@@ -324,7 +349,9 @@ public class RealmDaoImpl implements RealmDao {
 		orcidIdp.setProvider(OAuthProvider.ORCID);
 		idps.add(orcidIdp);
 		defaultRealm.setIdentityProvider(idps);
-		createPrivate(defaultRealm);
+		// idempotent MUST be true to ensure that multiple, concurrent servers
+		// can bootstrap the default realm without any errors
+		createRealmPrivate(defaultRealm, true);
 	}
 
 	@WriteTransaction
@@ -339,7 +366,9 @@ public class RealmDaoImpl implements RealmDao {
 		realmPrincipal.setAnonymousUser(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId().toString());
 		realmPrincipal.setAuthenticatedUsers(BOOTSTRAP_PRINCIPAL.AUTHENTICATED_USERS_GROUP.getPrincipalId().toString());
 		realmPrincipal.setPublicGroup(BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId().toString());
-		createRealmPrincipals(realmPrincipal);
+		// idempotent MUST be true to ensure that multiple, concurrent servers
+		// can bootstrap the default realm without any errors
+		createRealmPrincipalsPrivate(realmPrincipal, true);
 	}
 	
 	@Override

--- a/lib/jdomodels/src/main/resources/private/dao-beans.spb.xml
+++ b/lib/jdomodels/src/main/resources/private/dao-beans.spb.xml
@@ -162,22 +162,22 @@
 			<util:map>
 				<entry key="273950">
 					<bean class="java.lang.Long">
-						<constructor-arg value="1261"/>
+						<constructor-arg value="1"/>
 					</bean>
 				</entry>
 				<entry key="273948">
 					<bean class="java.lang.Long">
-						<constructor-arg value="1263"/>
+						<constructor-arg value="2"/>
 					</bean>
 				</entry>
 				<entry key="273949">
 					<bean class="java.lang.Long">
-						<constructor-arg value="1262"/>
+						<constructor-arg value="3"/>
 					</bean>
 				</entry>
 				<entry key="2">
 					<bean class="java.lang.Long">
-						<constructor-arg value="1264"/>
+						<constructor-arg value="4"/>
 					</bean>
 				</entry>
 			</util:map>

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/auth/RealmDaoImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/auth/RealmDaoImplTest.java
@@ -113,16 +113,16 @@ class RealmDaoImplTest {
 		List<DBORealmPrincipal> principals = jdbcTemplate.query(sql, (new DBORealmPrincipal()).getTableMapping(), id);
 		for (DBORealmPrincipal dbo: principals) {
 			if (dbo.getPrincipalId().equals(BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId())) {
-				assertEquals(1261L, dbo.getId());
+				assertEquals(1L, dbo.getId());
 			}
 			if (dbo.getPrincipalId().equals(BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP.getPrincipalId())) {
-				assertEquals(1262L, dbo.getId());
+				assertEquals(3L, dbo.getId());
 			}
 			if (dbo.getPrincipalId().equals(BOOTSTRAP_PRINCIPAL.AUTHENTICATED_USERS_GROUP.getPrincipalId())) {
-				assertEquals(1263L, dbo.getId());
+				assertEquals(2L, dbo.getId());
 			}
 			if (dbo.getPrincipalId().equals(BOOTSTRAP_PRINCIPAL.ADMINISTRATORS_GROUP.getPrincipalId())) {
-				assertEquals(1264L, dbo.getId());
+				assertEquals(4L, dbo.getId());
 			}
 		}
 		


### PR DESCRIPTION
- freeze IDs for the realm-principal rows for the default realm to be 1,2,3,4
- remove row deletion for secondary realm tables which are unneeded and can break bootstrapping
- use `insert ignore` for bootstrapping but NOT when creating later realms, since we want DB constraints to be enforced