### PR TITLE
Add code review conventions to CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,9 @@ A dedicated worker listens to grid changes via an SQS queue, validates each chan
 - Entity IDs: String-typed but numeric (`KeyFactory` converts)
 - Spring config: mix of XML (`WEB-INF/` and `src/main/resources/*-spb.xml`) and annotations
 - Logging: Log4j 2
+- **JSON serialization**: Use `JDOSecondaryPropertyUtils.createJSONFromObject()` / `createObjectFromJSON()` for converting `JSONEntity` objects to/from JSON strings. Do not write custom serialization code.
+- **SQL safety**: All SQL must use bind variables. Never concatenate strings into SQL. For generated values (UUIDs, timestamps), prefer MySQL functions (`UUID()`, `NOW(3)`) over Java-side generation.
+- **Controller testing**: Use IT tests with the Java client in `integration-test/`, not autowired controller tests. Every new controller method needs a corresponding `SynapseClient`/`SynapseClientImpl` method and an IT test.
 
 ## Critical Constraints
 

--- a/lib/jdomodels/CLAUDE.md
+++ b/lib/jdomodels/CLAUDE.md
@@ -100,6 +100,32 @@ Naming: `TABLE_` prefix for table names, `COL_` for columns, `DDL_` for DDL path
 
 This module primarily targets the **main (transactional) database**. The index database is managed by `lib-table-cluster`. The two databases use separate `DataSource` / `JdbcTemplate` beans.
 
+## JSON Serialization in DAOs
+
+When serializing/deserializing `JSONEntity` objects to/from JSON strings for database storage, **always use `JDOSecondaryPropertyUtils`**:
+```java
+// Object → JSON string
+String json = JDOSecondaryPropertyUtils.createJSONFromObject(myEntity);
+
+// JSON string → Object
+MyClass obj = JDOSecondaryPropertyUtils.createObjectFromJSON(MyClass.class, jsonString);
+```
+
+Do NOT create custom `ObjectMapper` or `JSONObjectAdapter` serialization code in DAO classes — the utilities in `JDOSecondaryPropertyUtils` are already tested and handle null/error cases.
+
+## SQL Patterns
+
+- **Database-generated values**: Prefer MySQL functions over Java-side generation:
+  - Use `UUID()` in SQL for etag generation instead of passing `UUID.randomUUID().toString()` as a bind parameter
+  - Use `NOW(3)` for timestamps instead of passing `new Timestamp(System.currentTimeMillis())`
+- **SQL injection prevention**: All SQL MUST use bind variables (`?` or named parameters). Never concatenate user input into SQL strings.
+- **Inline SQL preferred**: The legacy pattern of defining SQL as `static final String` concatenations of column/table constants was a workaround for a Java memory bug that no longer exists. For new code, prefer writing SQL inline where it's used. Column/table name constants are still appropriate in DDL, DBO field mappings, and row mappers — just not for building SQL query strings via concatenation.
+
+## Method Naming Conventions
+
+- Methods that use `SELECT ... FOR UPDATE` should include `ForUpdate` in the name (e.g., `getCurrentEtagForUpdate()`) to signal pessimistic locking to readers.
+- Methods intended only for bootstrapping/system use should include `ForBootstrapOnly` in the name (e.g., `createOrUpdateForBootstrapOnly()`) to prevent misuse for user-facing operations where etag checks are required.
+
 ## Testing
 
 - DAO unit tests mock `JdbcTemplate` / `NamedParameterJdbcTemplate`

--- a/services/repository-managers/CLAUDE.md
+++ b/services/repository-managers/CLAUDE.md
@@ -102,6 +102,32 @@ For long-running operations exposed as async REST endpoints:
 - **Legacy**: Spring XML configs (`*-spb.xml` in `src/main/resources/`) still used for some beans and `MigrationTypeListener` registration (`managers-spb.xml`). Do not add new XML configs.
 - Controllers access managers through `ServiceProvider` (not direct injection)
 
+## Common Patterns
+
+### ID Parsing
+When parsing string IDs to Long, always wrap `Long.parseLong()` in a try-catch that throws `IllegalArgumentException` with a descriptive message. Extract to a common private method if the same parsing is needed in multiple places within a class:
+```java
+private Long parseId(String value, String fieldName) {
+    try {
+        return Long.parseLong(value);
+    } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Invalid " + fieldName + ": '" + value + "'", e);
+    }
+}
+```
+
+### Pagination
+Use the existing `NextPageToken` utility for all paginated list operations. Do NOT create custom pagination logic:
+```java
+NextPageToken nextPageToken = new NextPageToken(request.getNextPageToken());
+List<T> page = dao.list(nextPageToken.getLimitForQuery(), nextPageToken.getOffset());
+return new ListResponse().setResults(page)
+    .setNextPageToken(nextPageToken.getNextPageTokenForCurrentResults(page));
+```
+
+### Interfaces
+Only create a separate interface when there's a genuine abstraction benefit (multiple implementations, or callers need to be decoupled from the implementation). For classes with a single implementation and no need for abstraction, use the concrete class directly. Don't copy the interface+impl pattern from older code just because it exists.
+
 ## Testing
 
 - Unit tests: `@ExtendWith(MockitoExtension.class)` with `@Mock` and `@InjectMocks`
@@ -109,3 +135,4 @@ For long-running operations exposed as async REST endpoints:
 - Test authorization failures (verify `UnauthorizedException` thrown)
 - Test input validation (verify `IllegalArgumentException` thrown)
 - Integration tests in `integration-test/` module test the full stack
+- **Service layer tests are usually unnecessary.** Most services are thin delegation layers that convert `Long userId` → `UserInfo` and forward to the manager. If the service has no real logic (no branching, no transformation, no error handling), skip the unit test. The IT-level controller test will verify the wiring. Only test services that contain actual business logic (e.g., `EntityService`).

--- a/services/repository/CLAUDE.md
+++ b/services/repository/CLAUDE.md
@@ -49,5 +49,8 @@ public class EntityController {
 ## Testing
 
 - Unit tests: Mock `ServiceProvider` and verify delegation
-- Integration tests: In `integration-test/` module with embedded Tomcat
+- **Do NOT write autowired controller tests** (`*AutowiredTest` extending `AbstractAutowiredControllerTestBase`). These mock the servlet layer and have repeatedly failed to catch real controller bugs.
+- **DO write IT-level integration tests** in `integration-test/src/test/java/` that use the `SynapseClient` Java client to make real HTTP requests against Tomcat. These are the only reliable way to verify controller wiring.
+- IT tests should cover all endpoints with basic happy-path verification. Deep branch coverage is handled by manager unit tests. Follow the pattern in existing IT tests (e.g., `ITGridControllerTest.java`).
 - Migration test: `MigrationIntegrationAutowireTest` — extend when adding new migratable types
+- **New controller endpoints**: Every new controller method needs a corresponding method in `SynapseClient`/`SynapseClientImpl` and an IT test in `integration-test/`.


### PR DESCRIPTION
Capture patterns and conventions from PR #5557 code review:
- jdomodels: JSON serialization via JDOSecondaryPropertyUtils, SQL patterns, method naming
- repository-managers: ID parsing, NextPageToken pagination, interface guidance, service test policy
- repository: IT tests over autowired controller tests, Java client method requirement
- root: JSON serialization, SQL safety, controller testing conventions

# Summary

This pull request updates documentation across several modules to clarify and enforce important coding standards and testing practices. The changes emphasize the use of standardized utilities for JSON serialization, SQL safety, controller testing, and common service patterns. These updates are intended to reduce bugs, improve maintainability, and ensure consistent practices across the codebase.

**Serialization and SQL Safety**

* Mandate use of `JDOSecondaryPropertyUtils` for JSON serialization/deserialization of `JSONEntity` objects in DAOs, prohibiting custom serialization code. [[1]](diffhunk://#diff-25d23f3c8f9909243df692626e1c85fa4c43f2804929e883231fad5af0501b8eR103-R128) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R189-R191)
* Require all SQL to use bind variables and prefer MySQL functions (`UUID()`, `NOW(3)`) for generated values, disallowing string concatenation and Java-side generation. [[1]](diffhunk://#diff-25d23f3c8f9909243df692626e1c85fa4c43f2804929e883231fad5af0501b8eR103-R128) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R189-R191)

**Controller and Service Testing**

* Prohibit autowired controller tests; require IT-level integration tests using the `SynapseClient` Java client for all endpoints, including new controller methods. [[1]](diffhunk://#diff-b72b95117560b715bff9c3594c3ba4d4fb8c3f4c8735a9e61d7775b4c92b908bL52-R56) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R189-R191)
* Specify that service layer unit tests are unnecessary unless the service contains real business logic, relying on IT tests for verification.

**Common Coding Patterns**

* Standardize ID parsing with a try-catch utility method and enforce use of `NextPageToken` for pagination, discouraging custom logic.
* Clarify interface usage: only create interfaces when there is a genuine abstraction need, avoiding unnecessary interface+implementation patterns.

These documentation updates provide clear guidance for serialization, SQL, testing, and common coding patterns to ensure code quality and consistency.