### PR TITLE
Add dependency on teamManager in TextAnalyzerBootstrapper

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapper.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapper.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Service;
 
 @Service
-@DependsOn("updateDefaultRealm")
+@DependsOn({"updateDefaultRealm", "teamManager"})
 public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 
 	public static final long SCIENTIFIC_ID = 1L;


### PR DESCRIPTION
When bootstrapping the TextAnalyzers it needs to depend on the sagebionetworks Organization to exist, however, there are some cases where spring orders the bootstrapping in the `teamManager` occurs after the TextAnalyzerBootstrapper code runs. This will cause [the check in this code to fail ](https://github.com/BryanFauble/Synapse-Repository-Services/blob/f7102e1756630d40c6fad4c3b5c262c9b0a02031/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/schema/JsonSchemaManagerImpl.java#L155-L159)because the admin user isn't officially a part of the admin group until [this section of code runs](https://github.com/BryanFauble/Synapse-Repository-Services/blob/915ba5439e5f46f1c4268d65d1099fad951f90f7/services/repository-managers/src/main/resources/private/managers-spb.xml#L252-L261).