### PR TITLE
[DPE-1597] Remove modify from get/list curation tasks

### DIFF
--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/CurationTaskController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/CurationTaskController.java
@@ -75,7 +75,7 @@ public class CurationTaskController {
      * @throws InvalidModelException
      * @throws IOException
      */
-    @RequiredScope({view, modify})
+    @RequiredScope({view})
     @ResponseStatus(HttpStatus.OK)
     @RequestMapping(value = UrlHelpers.CURATION_TASK_ID, method = RequestMethod.GET)
     public @ResponseBody
@@ -143,7 +143,7 @@ public class CurationTaskController {
      * @throws InvalidModelException
      * @throws IOException
      */
-    @RequiredScope({view, modify})
+    @RequiredScope({view})
     @ResponseStatus(HttpStatus.OK)
     @RequestMapping(value = UrlHelpers.CURATION_TASK_LIST, method = RequestMethod.POST)
     public @ResponseBody


### PR DESCRIPTION
This pull request updates the security annotations in the `CurationTaskController` to restrict certain endpoints to require only the `view` scope, rather than both `view` and `modify`.

**Security and permissions updates:**

* Changed the `@RequiredScope` annotation from `{view, modify}` to `{view}` on the `getCurationTask` method in `CurationTaskController.java`, so only the `view` scope is now required to access this endpoint.
* Changed the `@RequiredScope` annotation from `{view, modify}` to `{view}` on the `getListOfCurationTasks` method in `CurationTaskController.java`, so only the `view` scope is now required to access this endpoint.