### PR TITLE
Evolve CLAUDE.md with SearchIndex lifecycle lessons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,15 @@ platform (root)
 - **Include real data in tests**: Don't test CRUD with empty payloads. If a feature serializes data (e.g., JSON columns), include actual values in the test fixture and verify the round-trip — because a bug in serialization won't surface if the payload is empty.
 - **List/filter tests need multiple groups**: When testing list/filter operations, create entries across at least 2 categories (e.g., 2 items in org1, 2 in org2). Verify each filtered list returns the correct subset AND verify ordering is deterministic — because a single-group test can pass even if filtering is broken.
 - **Update tests must verify data changed**: Assert that updated values are present in the result, not just that metadata (etag) rotated — because an etag rotation doesn't prove the data write succeeded.
+- **No `any()` matchers in stubs or in `verify(...)`**: use `eq()`, specific values, or `argThat(p -> ...)` predicates. Reserve `any()` for `verify(mock, never()).method(any(...))` where the argument is irrelevant. Why: `any()` in a stub hides what the method-under-test is required to pass — if the call site is wrong, the stub misses, returns null, and an assertion fails explicitly. `any()` in `verify` hides what was actually passed. The only exception is `never()`/`times(0)`, where the test asserts the method wasn't called at all.
+- **No `lenient()` stubs**: strict-stubbing is required. An unused stub means the test is wrong, not the stubbing strictness. Rewrite the test.
+- **Parameterized state-table tests for enum/flag combinations**: use `@ParameterizedTest` + `@ValueSource` / `@MethodSource` to cover every enum value (states, exception types, column type mappings) rather than writing near-duplicate test methods.
+- **Max-length boundary tests on composite unique keys**: for `UNIQUE(a, b)` on string columns, write two rows at max length differing only in the last character, then fetch each by ID and assert ALL fields round-tripped — MySQL index-key-length limits can silently truncate, collapsing two logically-distinct rows into one.
+- **`@InjectMocks` + `@Spy`**: use together when a test must verify the class under test calls its own internal method. Lets you `verify(spiedSelf).someInternalMethod(...)` without extracting an artificial collaborator.
+- **Mock at the immediate collaborator**: do not mock two seams down. The manager test mocks the DAO, not the JdbcTemplate. The worker test mocks the manager, not the DAO.
+- **External-service-backed managers are DAOs for testing purposes**: a manager that proxies AOSS, S3, or SNS (e.g., `OpenSearchManagerImpl`) needs an autowired test against the live service. Mock-only tests do not prove the client API contract holds.
+- **`ArgumentCaptor` for forwarded arguments**: when the manager translates user input (column names, filters, schemas) before passing to a collaborator, capture the translated shape and assert on it. This is where the test catches escaping/translation bugs.
+- **Assert custom exception messages**: when code throws `new X("specific remediation hint")`, the test that triggers it must assert `e.getMessage()` matches — otherwise the message is untested and can drift silently.
 
 ## Deployment & Migration
 
@@ -160,6 +169,25 @@ When a DB column is renamed (e.g., `PROJECT_ID` → `OBJECT_ID`), the backup XML
 ## Curation Grid (Curator)
 
 See `services/repository-managers/CLAUDE.md` and `lib/lib-grid/CLAUDE.md` for the CRDT-based grid architecture, WebSocket protocol, and AI agent integration.
+
+## Search & Indexing
+
+See `services/repository-managers/CLAUDE.md` → "Search & Indexing" for the SearchIndex lifecycle and query paths. Quick orientation:
+
+- **SearchIndex is a Synapse Entity** (`VersionableEntity` + `HasDefiningSql`) managed via `/repo/v1/entity/*`. Query and config live under `/search/*`.
+- **Build-once semantics**: each AOSS index is a point-in-time snapshot. To rebuild, delete and recreate the entity.
+- **Two databases**: configuration tables (`TEXT_ANALYZER`, `SYNONYM_SET`, `COLUMN_ANALYZER_OVERRIDE`, `SEARCH_CONFIGURATION`) live in the transactional DB (migrated between stacks). `SEARCH_INDEX_STATUS` lives in the indexing DB (not migrated; rebuilt organically post-migration from replayed ENTITY change messages).
+- **Lifecycle worker** subscribes to ENTITY change messages via the `SEARCH_INDEX_LIFECYCLE` SQS queue and filters by node type internally — there is no dedicated SearchIndex `ObjectType` or SNS topic.
+- **Anonymous-user indexing**: the lifecycle worker streams data as the realm's anonymous user so `addRowLevelFilter()` enforces benefactor ACLs, guaranteeing only publicly visible rows enter the AOSS index.
+- **Authoritative design doc**: Confluence page "Architecture Design for OpenSearch Integration" (PLFM space).
+
+## PR & Process Patterns
+
+- **Every new SQS queue or async job type requires a companion Synapse-Stack-Builder PR** — queue provisioning is in a separate CloudFormation project. Worker will fail at startup if the queue is missing. Link the companion PR in the description.
+- **Stub-first PRs unblock UI work**: ship schemas + controllers returning mock data directly (no service/manager/DAO chain) so the frontend can wire real endpoints while the backend is being built. Replace in a follow-up PR without breaking the wire shape.
+- **Feature slicing**: large features ship as a series of small stacked PRs (e.g., SearchIndex was PLFM-9509 through PLFM-9518, ~9 PRs), each independently reviewable and mergeable. Favor this over a single monolithic PR.
+- **CLAUDE.md edits happen in the feature branch, not after**: when a reviewer names a durable convention, add it to the relevant CLAUDE.md in the same PR so the agent picks it up on the next iteration.
+- **Working-tree `pr-description-*.md` files**: Bryan sometimes drafts the PR body as a working-tree markdown file before opening the PR. If present, treat it as the authoritative description of what the PR is meant to deliver. These files are not checked in.
 
 ## Key Conventions
 

--- a/client/synapseJavaClient/CLAUDE.md
+++ b/client/synapseJavaClient/CLAUDE.md
@@ -1,0 +1,86 @@
+# client/synapseJavaClient
+
+Java HTTP client for the Synapse REST API. Every controller endpoint in `services/repository` has (or should have) a matching method here, plus an IT test in `integration-test/`.
+
+## Core pattern
+
+```java
+// SynapseClient — interface
+public interface SynapseClient {
+    MyResponse doThing(MyRequest request) throws SynapseException;
+    AsyncJobId startMyAsyncJob(MyAsyncRequest request) throws SynapseException;
+    MyAsyncResponse getMyAsyncJobResults(String asyncToken) throws SynapseException;
+}
+
+// SynapseClientImpl — implementation
+@Override
+public MyResponse doThing(MyRequest request) throws SynapseException {
+    String url = getRepoEndpoint() + "/resource/" + request.getId();
+    return postJSONEntity(url, request, MyResponse.class);
+}
+```
+
+- Every new controller method requires a matching `SynapseClient` interface method AND a `SynapseClientImpl` implementation.
+- Every new client method requires a corresponding `IT*Test` in `integration-test/` — one happy-path call is enough to prove wiring.
+- Return types are generated POJOs from `lib-auto-generated` — do not create client-only wrapper types.
+
+## Async job client pattern
+
+Async job type must be registered in BOTH places — keep the enum name identical:
+
+1. **Server-side**: `lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/asynch/AsynchJobType.java`
+2. **Client-side**: `client/synapseJavaClient/src/main/java/org/sagebionetworks/client/AsynchJobType.java`
+
+Standard method signatures:
+
+```java
+// Start (returns AsyncJobId)
+AsyncJobId startMyJob(MyRequest request) throws SynapseException;
+
+// Poll (returns response body; throws if still running)
+MyResponse getMyJobResults(String asyncToken) throws SynapseException;
+```
+
+For synchronous endpoints (e.g., autocomplete), return the response body directly — no start/poll split.
+
+## Signing up new endpoints
+
+- URL paths go through helper methods (`getRepoEndpoint()`, etc.) — don't hand-write the host.
+- Use `getJSONEntity` / `postJSONEntity` / `putJSONEntity` / `deleteUri` methods on `BaseClient`; they handle serialization and error mapping.
+- PUT endpoints with `{id}` in the URL: the controller sets `request.setId(id)` before forwarding to the service — the client method's signature should surface the ID separately (typically as a constructor arg to the request object the caller builds).
+
+## Compile target
+
+Compiled to **Java 8** for compatibility with downstream consumers (SWC — Synapse Web Client, R/Python bindings via JNI-adjacent builds). Do not use Java 9+ APIs here:
+
+- No `List.of(...)` / `Map.of(...)` (use `Arrays.asList` / `Collections.unmodifiableMap(new HashMap<>())`).
+- No `var` local-variable inference.
+- No `Optional.isEmpty()` (use `!optional.isPresent()`).
+- No `String.isBlank()` (use `trim().isEmpty()`).
+
+## Exception mapping
+
+Server-side exception types map to specific client exceptions via status code:
+
+| HTTP | Client exception |
+|------|------------------|
+| 400 | `SynapseBadRequestException` |
+| 401 | `SynapseUnauthorizedException` |
+| 403 | `SynapseForbiddenException` |
+| 404 | `SynapseNotFoundException` |
+| 409 | `SynapseConflictingUpdateException` |
+| 429 | `SynapseTooManyRequestsException` |
+
+Do not add new exception types unless there's a new HTTP status with distinct semantics.
+
+## Testing
+
+- Unit tests for `SynapseClientImpl` are thin — the real verification is IT-level.
+- Don't mock `HttpClient` to test the client; the integration test covers serialization + network layer together.
+- Add IT tests in `integration-test/` following the conventions in `integration-test/CLAUDE.md`.
+
+## Build
+
+```
+mvn clean install -pl client/synapseJavaClient -DskipTests
+```

--- a/integration-test/CLAUDE.md
+++ b/integration-test/CLAUDE.md
@@ -1,0 +1,78 @@
+# integration-test
+
+End-to-end tests run against a live, embedded Tomcat + MySQL + AWS stack.
+They verify HTTP wiring between the `SynapseClient` Java client and the `services/repository` + `services/workers` WARs.
+
+## What IT tests are for
+
+- Prove each new controller endpoint is wired correctly: one happy-path per endpoint.
+- Prove client method signatures match controller expectations.
+- Prove async job plumbing (start → poll → result).
+- Prove cross-module wiring where only the live stack exposes the integration (e.g., Spring circular dependencies that don't surface in unit tests).
+
+## What IT tests are NOT for
+
+- **Deep branch coverage, error paths, edge cases** — those belong in manager unit tests (`*Test.java`) or autowired DAO tests (`*DaoImplAutowiredTest`). IT runs are expensive and flaky; every extra IT test slows the suite and adds variance.
+- **Business logic assertions** — if an assertion would pass with mocks, move it to the unit layer.
+- **Replacing `*AutowiredControllerTest`** — those mock the servlet layer and miss real controller bugs. IT is the ONLY reliable controller test; do not write `*AutowiredTest extends AbstractAutowiredControllerTestBase` for new work.
+
+## Structure
+
+```java
+@ExtendWith(ITTestExtension.class)
+public class ITMyFeatureTest {
+    private SynapseAdminClient adminSynapse;
+    private SynapseClient synapse;
+
+    // Constructor injection via the extension
+    public ITMyFeatureTest(SynapseAdminClient adminSynapse, SynapseClient synapse) {
+        this.adminSynapse = adminSynapse;
+        this.synapse = synapse;
+    }
+
+    @BeforeEach public void before() throws Exception { /* fixtures */ }
+    @AfterEach  public void after()  throws Exception { /* cleanup */ }
+}
+```
+
+`ITTestExtension` (injected via `@ExtendWith`) resolves `SynapseAdminClient`, `SynapseClient`, `StackConfiguration`, `WarehouseTestHelper`, and `AmazonS3` by parameter type.
+The extension authenticates the admin client, enables 2FA on the admin user, and calls `adminSynapse.clearAllLocks()` in `@BeforeAll` — individual tests do NOT need to call `clearAllLocks()`.
+A dynamic test user is created on first `SynapseClient` injection and deleted in `@AfterAll`.
+
+## Key conventions
+
+- **UUID-suffix every created resource name.** When the resource under test has no admin DELETE endpoint, fixed names fail with "same name already exists" on the second run against a populated dev DB. Pattern: `String unique = UUID.randomUUID().toString().replace("-", ""); String name = "IT_THING_" + unique;`. Required for SynonymSet, ColumnAnalyzerOverride, SearchConfiguration and other no-delete resources.
+- **Clean up in `@AfterEach` for resources with DELETE endpoints** — entities, files, projects. Wrap each cleanup in a null check so a failed fixture setup doesn't mask the real failure.
+- **Assume the DB is NOT clean.** Dev stack is shared. Tests must be idempotent against any residual data.
+- **Full-object `assertEquals(expected, actual)` when the POJO has an `equals()` override** (all generated POJOs do). Preferred over field-by-field. Use field assertions only when verifying a specific transformation.
+- **Poll async jobs via `AsyncJobHelper`** — shared helper at `integration-test/src/test/java/org/sagebionetworks/AsyncJobHelper.java`. Do not hand-roll poll loops.
+
+## Anonymous-user lifecycle test setup
+
+When exercising code paths that index or query as the realm's anonymous user (e.g., SearchIndex builds):
+
+- Set the source table's data type to `OPEN_DATA` via `adminSynapse.changeEntityDataType(id, DataType.OPEN_DATA)`.
+- Grant `AuthorizationConstants.BOOTSTRAP_PRINCIPAL.PUBLIC_GROUP` `READ` access on the parent container.
+- Grant `AuthorizationConstants.BOOTSTRAP_PRINCIPAL.AUTHENTICATED_USERS_GROUP` `DOWNLOAD` access if rows reference file handles.
+
+Without these, the lifecycle worker's `addRowLevelFilter()` sees zero rows and the build completes with an empty index — the test passes vacuously.
+
+## Naming
+
+- `IT<Feature><Verb>Test.java` (e.g., `ITSearchQueryTest`, `ITSearchConfigurationTest`).
+- Historical numeric prefixes (`IT510*`, `IT101*`) exist for ordering but are not required for new tests.
+- Test methods follow the unit test convention: `test<Method>With<Condition>`. For full CRUD lifecycle tests: `testCRUDWith<context>`.
+
+## When NOT to add an IT test
+
+- A bug fix entirely inside a manager — add a unit test, not an IT test.
+- A DAO SQL change — add a `*DaoImplAutowiredTest`, not an IT test.
+- A schema-only change with no new endpoint — the existing IT coverage already verifies wiring.
+
+## Running
+
+```
+mvn verify -f integration-test/pom.xml -Dit.test=ITMyFeatureTest
+```
+
+Requires a live dev stack URL resolvable via `StackConfiguration`.

--- a/lib/jdomodels/CLAUDE.md
+++ b/lib/jdomodels/CLAUDE.md
@@ -60,6 +60,7 @@ new FieldColumn("changeNumber", COL_CHANGES_CHANGE_NUM, true)  // isPrimaryKey
 
 - **Primary**: Has etag column (`withIsEtag(true)`), migrated independently, registered in `dbo-beans.spb.xml`
 - **Secondary**: Owned by a primary table, discovered via `getSecondaryTypes()`, has FK to owner's backup ID, NOT registered in `dbo-beans.spb.xml`
+- **One `MigrationType` per primary DBO**: secondaries are discovered via `getSecondaryTypes()`. Do not also register a secondary in `dbo-beans.spb.xml` — only the first registration takes effect and the subsequent one is silently ignored.
 
 ## DAO Pattern
 
@@ -109,6 +110,8 @@ Naming: `TABLE_` prefix for table names, `COL_` for columns, `DDL_` for DDL path
 
 This module primarily targets the **main (transactional) database**. The index database is managed by `lib-table-cluster`. The two databases use separate `DataSource` / `JdbcTemplate` beans.
 
+- **Indexing-DB tables are not migrated** — they re-build organically post-migration from replayed ENTITY change messages. Example: `SEARCH_INDEX_STATUS` starts empty after a fresh stack comes up; the `SearchIndexLifecycleWorker` sees missing status rows and triggers builds. When adding a new indexing-DB table, its DDL must tolerate "starts empty" — never seed it from a migration script.
+
 ## JSON Serialization in DAOs
 
 When serializing/deserializing `JSONEntity` objects to/from JSON strings for database storage, **always use `JDOSecondaryPropertyUtils`**:
@@ -121,6 +124,8 @@ MyClass obj = JDOSecondaryPropertyUtils.createObjectFromJSON(MyClass.class, json
 ```
 
 Do NOT create custom `ObjectMapper` or `JSONObjectAdapter` serialization code in DAO classes — the utilities in `JDOSecondaryPropertyUtils` are already tested and handle null/error cases.
+
+For simple arrays of scalars stored as JSON columns (e.g., `SEARCH_CONFIGURATION.SYNONYM_SET_IDS` — a plain JSON array of string IDs), use `JSONArray` directly. Cross-resource reference checks against these columns go through MySQL's `JSON_CONTAINS(col, JSON_QUOTE(?))` — don't load the column into Java and scan it.
 
 ## SQL Patterns
 
@@ -139,6 +144,11 @@ Do NOT create custom `ObjectMapper` or `JSONObjectAdapter` serialization code in
   }
   ```
   When a DAO catches and rewrites exceptions like this, **an autowired integration test must verify the user-facing error message**.
+- **Idempotent upsert via `INSERT ... ON DUPLICATE KEY UPDATE col = VALUES(col)`**: for bootstrappers and status tables where absence-vs-presence is the implicit trigger (e.g., `SEARCH_INDEX_STATUS` absence = needs build). `VALUES(col)` on the UPDATE branch reuses the insert row's bound values so parameters are bound once.
+- **`NamedParameterJdbcTemplate` for `IN (...)` batch lookups**: pass a `List` as a named parameter and let the template expand placeholders. Do NOT hand-roll comma-separated `?, ?, ?` or string-format the IN list — neither supports bind-variable safety.
+- **`Optional.ofNullable`, not `Optional.of`, when wrapping `JdbcTemplate` results**: `queryForObject` is documented to allow null in certain paths; `Optional.of(null)` throws NPE.
+- **Explicit `default` branch when switching on `ColumnType` or other enums**: throw `IllegalArgumentException("Unsupported type: " + type)`. Do not rely on fallthrough — adding a new enum value without updating the switch is a bug you want to surface at runtime with a clear message.
+- **ColumnType → external-system mapping as an enum**: when mapping `ColumnType` to a downstream system's concepts (OpenSearch field type, default analyzer, `ignoreAbove`), use an enum-per-`ColumnType` pattern like `ColumnTypeToOpenSearchMapping` rather than a switch or map. Adding a new `ColumnType` without adding its mapping is a compile error, not a runtime surprise.
 
 ## Method Naming Conventions
 

--- a/lib/lib-auto-generated/CLAUDE.md
+++ b/lib/lib-auto-generated/CLAUDE.md
@@ -80,7 +80,7 @@ src/main/resources/schema/org/sagebionetworks/
 - **`format: "date-time"`**: String property treated as ISO 8601 timestamp
 - **Arrays**: `"type": "array"` with `"items": { "$ref": "..." }`, optional `"uniqueItems": true`
 - **Required fields**: `"required": true` on a property
-- **Map types**: For map-like properties, either define the sub-type schema explicitly OR treat the entire value as a plain `"type": "string"` (expecting a JSON string). Do NOT use `Map<String, String>` where the string values are themselves serialized JSON — this creates ambiguous "JSON within JSON" that bypasses schema validation.
+- **Map types / polymorphic JSON**: For map-like properties or values with varying shape, pick one: either define every sub-type schema explicitly (so generated POJOs exist for each variant) OR declare the property as `"type": "string"` expecting the caller to pass a JSON string. Do NOT declare `Map<String, String>` / `Map<String, Object>` where the string values are themselves serialized JSON — this creates ambiguous "JSON within JSON" that bypasses schema validation and forces ad-hoc parsing on the server. Why: generated POJOs carry no type information for inner JSON strings, so every consumer has to re-parse and re-validate.
 - **Descriptions must match implementation**: Schema descriptions (especially for optional fields like "If null, lists X") are API contracts. Always verify the implementation matches the schema description. If behavior changes, update the schema text to match.
 
 ## Generated Code Patterns

--- a/lib/lib-worker/CLAUDE.md
+++ b/lib/lib-worker/CLAUDE.md
@@ -1,0 +1,71 @@
+# lib/lib-worker
+
+Lower-level worker framework — cluster-wide concurrency control, SQS message consumption, and change-message batch processing. Consumed by `services/workers`.
+
+This module is intentionally small and stable; most worker-authoring patterns live in `services/workers/CLAUDE.md`.
+
+## Package Structure
+
+```
+org.sagebionetworks.asynchronous.workers
+├── changes/      # Change-message-driven runners (SNS→SQS fan-out)
+├── concurrent/   # ConcurrentWorkerStack + cluster-wide semaphore management
+└── sqs/          # SQS message utilities + JobCanceledException
+```
+
+## Key Abstractions
+
+### `changes/` — Change-message-driven workers
+
+- **`ChangeMessageDrivenRunner`** — single-message worker. Implementers receive one `ChangeMessage` per `run()` invocation.
+- **`BatchChangeMessageDrivenRunner`** — batch worker. Implementers receive a `List<ChangeMessage>` per `run()`; useful when ordering within the batch matters or when a downstream API supports bulk operations.
+- **`ChangeMessageBatchProcessor`** — adapter that wraps a `ChangeMessageDrivenRunner` so it can be scheduled by `ConcurrentWorkerStack`.
+- **`LockTimeoutAware`** — optional interface for runners that need to know the configured semaphore lock timeout (to self-regulate long operations).
+
+### `concurrent/` — Concurrent worker stack
+
+- **`ConcurrentWorkerStack`** — the canonical worker execution stack. Composes a cluster-wide semaphore + per-JVM thread pool + SQS long-poll loop.
+- **`ConcurrentManager` / `ConcurrentManagerImpl`** — singleton bean that tracks active workers across the JVM (passed to every stack via `.withSingleton(concurrentStackManager)`).
+- **`ConcurrentProgressCallback`** — `ProgressCallback` implementation that refreshes the semaphore lock while work is in flight. Workers must call `progressCallback.progressMade()` periodically or the lock expires and a second worker may pick up the same message.
+- **`WorkerJob`** — internal unit of scheduled work.
+
+### `sqs/` — SQS utilities
+
+- **`MessageUtils`** — helpers for reading/parsing `ChangeMessage` payloads from SQS `Message` objects.
+- **`JobCanceledException`** — throw from an `AsyncJobRunner` to mark a job cancelled by the user (distinct from a transient failure).
+- **`WorkerProgress`** — progress-tracking interface.
+
+## Recoverable vs permanent failure
+
+Every worker runs inside a try/catch that interprets the exception type:
+
+| Exception | Outcome |
+|-----------|---------|
+| `RecoverableMessageException` | Message returns to SQS for retry (increments receive count) |
+| `JobCanceledException` | Job marked CANCELED, message deleted |
+| Any other `Exception` / `Throwable` | Message deleted, no retry; logged |
+
+The `services/workers` layer is responsible for translating common transient exceptions (`LockReleaseFailedException`, `CannotAcquireLockException`, `DeadlockLoserDataAccessException`, `TableUnavailableException`) into `RecoverableMessageException` at the worker boundary. `lib-worker` itself does not catch these — it only reacts to the final `RecoverableMessageException`.
+
+## What lives where
+
+| Concern | Location |
+|---------|----------|
+| `AsyncJobRunner` interface | `services/workers/src/main/java/org/sagebionetworks/worker/` (NOT here) |
+| `AsyncJobRunnerAdapter` | `services/workers/` — wraps `AsyncJobRunner` so it can be a `MessageDrivenRunner` |
+| `WorkerTriggerBuilder` | `services/workers/src/main/java/org/sagebionetworks/worker/config/` |
+| `@Configuration` worker beans | `services/workers/src/main/java/org/sagebionetworks/worker/config/` |
+| `AsynchJobType` enum | `lib/jdomodels` (server) + `client/synapseJavaClient` (client) — registrations in both |
+
+If you're authoring a worker, start in `services/workers/CLAUDE.md`. Come here only to understand the framework primitives being composed.
+
+## Testing
+
+- Unit tests for framework classes mock the SQS client and the `ConcurrentManager`.
+- Framework is stable — most commits land in `services/workers` (consumers), not here.
+
+## Build
+
+```
+mvn clean install -pl lib/lib-worker -DskipTests
+```

--- a/services/repository-managers/CLAUDE.md
+++ b/services/repository-managers/CLAUDE.md
@@ -144,6 +144,51 @@ public class MyBootstrapper {
 }
 ```
 
+Bootstrappers use stable low IDs (1..N reserved for system rows); the `IdType` generator starts at 1000+ so there's a dedicated range for user-created rows. System rows are upserted idempotently via `INSERT ... ON DUPLICATE KEY UPDATE` so definitions can evolve without migration scripts. See `TextAnalyzerBootstrapper` for the reference pattern.
+
+### Authorization for organization-owned resources
+
+Three-layer gate for resources owned by an `Organization` (SynonymSet, ColumnAnalyzerOverride, TextAnalyzer, SearchConfiguration):
+
+```java
+AuthorizationUtils.disallowAnonymous(user);
+if (!authorizationManager.isSynapseEmployeeOrAdmin(user)) {
+    throw new UnauthorizedException("Only Sage employees or admins may X");
+}
+aclDao.canAccess(user, storedOrganizationId, ObjectType.ORGANIZATION, ACCESS_TYPE.CREATE)
+    .checkAuthorizationOrElseThrow();
+```
+
+The org ACL check must use the **stored** `organizationId` (loaded from the DB row), not the request's — so a caller cannot alter the request to sidestep the ACL. Admins bypass the org ACL but NOT the sage-employee gate unless explicitly allowed.
+
+### Anonymous user lookup
+
+When a manager needs to operate as "anonymous" (e.g., to enforce public-only access on a search index build), resolve the anonymous `UserInfo` via the realm of the triggering user:
+
+```java
+UserInfo anonymous = userManager.getUserInfo(triggeringUser.getRealmAnonymousUserId());
+```
+
+Do NOT reference `AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId()` in manager code. Each realm has its own anonymous principal; `getRealmAnonymousUserId()` returns the correct one for the caller's realm. `BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER` is only appropriate in auth filters, bootstrap code, and tests.
+
+### `@Lazy` to break full-WAR-context Spring cycles
+
+If a circular dependency surfaces only in the full Tomcat integration context (not in unit tests), add `@Lazy` on one injection point to break the cycle and leave a comment naming the two beans involved. Example: `TableManagerSupportImpl` lazily injects `columnModelManager` because the full cycle only manifests at IT startup. `@Lazy` defers the proxy until first use so Spring's bean graph resolution can complete.
+
+### Composition over inheritance for async request/response bodies
+
+Reusable payload types (e.g., `SearchQuery`, `SearchQueryResults`) should NOT `implements AsynchronousRequestBody` / `AsynchronousResponseBody`. Instead, wrap them in request/response objects that implement those interfaces (`SearchIndexQuery` composes `SearchQuery`). Why: the same payload type can then be composed into multiple endpoints (search index query today, entity search query later) without coupling the payload to the async job framework.
+
+### Switch / exception hygiene
+
+- `switch` on an enum must have an explicit `default` branch that throws `IllegalArgumentException("Unsupported X: " + value)`. Do not rely on fallthrough; adding an enum value without updating the switch is a bug.
+- Preserve the cause when re-throwing: `throw new IllegalArgumentException(msg, e)`, never bare `throw new IllegalArgumentException(msg)` if there is an underlying exception.
+- Log OR throw, not both. Low-level managers propagate; the outermost worker/manager logs once at the boundary.
+
+### Package-private for testability
+
+Private methods with meaningful branching (translation logic, mapping helpers, state transitions) should be package-private, not private, so unit tests can exercise them directly instead of only through the public entry point. This keeps test assertions focused.
+
 ### Helper Methods Should Return Useful Results
 Methods like `getOrCreate()` should return the found-or-created object so callers don't need a separate query:
 ```java
@@ -170,6 +215,81 @@ public void ensureOrganizationExists(String name) { ... }
   // Now you can: verify(manager).someInternalMethod(...)
   ```
 - **Pagination tests**: Always verify `NextPageToken` behavior — test that the response includes the correct next page token, not just the results list.
+- **`ArgumentCaptor` for forwarded arguments**: when the manager translates user input before delegating (column names, filters, schemas), capture what the collaborator receives and assert on the translated shape. This is where translation/escaping bugs surface.
+- **State-machine tests should cover every state**: use `@ParameterizedTest` + `@EnumSource` to drive behavior across all enum values rather than writing one test per state. A single method per state invites drift.
+- **External-service-backed managers need autowired tests**: managers that proxy AOSS (e.g., `OpenSearchManagerImpl`), S3, or SNS need a `*AutoWiredTest` against the real service. Pure mock tests don't prove the client API contract holds. Mock-only unit tests for these were replaced, not augmented.
+
+## Search & Indexing (SearchIndex lifecycle)
+
+Portal search is built on **OpenSearch Serverless (AOSS)**. `SearchIndex` is a Synapse Entity (`VersionableEntity` + `HasDefiningSql`) with a one-to-one AOSS index and a lifecycle managed by `SearchIndexLifecycleWorker`.
+
+### Components
+
+| Component | Purpose |
+|-----------|---------|
+| `SearchIndexMetadataProvider` | Entity-layer validation on CREATE/UPDATE. Pilot gate (Portal Managers + admins only) and `definingSQL` validation. |
+| `SearchConfigurationManager` | CRUD for `SearchConfiguration` (the composition of SynonymSets + ColumnAnalyzerOverrides + default analyzer). |
+| `SearchConfigurationResolver` | Resolves the effective configuration for a given SearchIndex at build + query time. |
+| `SearchIndexLifecycleManager` | Orchestrates build/rebuild/delete; owns state transitions. |
+| `SearchIndexQueryManager` | Authorization, status check, translation, delegation to OpenSearchManager for search + autocomplete. |
+| `OpenSearchManager` | Shared AOSS client seam (create/delete index, bulk index, search, autocomplete, analyzer validation). |
+| `TextAnalyzerBootstrapper` | Ensures 6 system analyzers (IDs 1-6) exist on startup via idempotent upsert. |
+
+### Configuration resolution (priority order)
+
+1. Entity's explicit `searchConfigurationId` (on `NODE_REVISION`).
+2. `SearchConfigurationListSetting` project setting on the parent container.
+3. Platform defaults (no synonyms, no overrides, column-type defaults).
+
+Effective analyzer per column:
+
+1. Per-column `indexAnalyzerId` from the SearchConfiguration's `ColumnAnalyzerOverride` list.
+2. `defaultAnalyzerId` on the SearchConfiguration.
+3. `ColumnTypeToOpenSearchMapping.getDefaultAnalyzerId(columnType)`.
+
+### Build-once semantics
+
+AOSS indexes are point-in-time snapshots. Entity metadata changes (name, `definingSQL`, `searchConfigurationId`) are persisted and take effect on the **next build during stack migration** — not immediately. To force an immediate rebuild in the current stack: delete the SearchIndex entity and create a new one.
+
+### Anonymous-user indexing
+
+`SearchIndexLifecycleManagerImpl` streams rows via `TableQueryManager.runQueryAsStream()` using the realm's anonymous user. This causes `addRowLevelFilter()` to apply benefactor ACLs, so only publicly-visible rows enter the AOSS index. Acquire the anonymous `UserInfo` via `userManager.getUserInfo(user.getRealmAnonymousUserId())` (see "Anonymous user lookup" in Common Patterns).
+
+### Pre-flight COUNT + 500K row cap
+
+Before creating the AOSS index, the worker runs a count-only query (`querySinglePage(runQuery=false, runCount=true)`). If the count exceeds 500,000, the build fails immediately with FAILED status and no AOSS index is created. `SearchIndexRowHandler.nextRow()` keeps a row-level guard as a TOCTOU safety net. Error messages are truncated to 3000 chars (`MAX_ERROR_MESSAGE_LENGTH`) before persisting to `SEARCH_INDEX_STATUS`.
+
+### State machine
+
+```
+[*] → CREATING → ACTIVE | FAILED (terminal)
+ACTIVE → DELETING → [*]
+```
+
+- Query against `CREATING` → `IllegalStateException("still building")` → worker translates to `RecoverableMessageException` so SQS retries until the state flips.
+- Query against `FAILED` → `IllegalArgumentException` forwarding the stored `errorMessage` verbatim (with a generic remediation hint if none is recorded).
+- FAILED is terminal — rebuild means delete + recreate the entity.
+
+### Schema derivation
+
+Only the columns in the `definingSQL`'s SELECT clause are mapped in the AOSS index. The schema is derived at build time by `QueryTranslator.getSchemaOfSelect()` inside the `RowHandlerProvider` callback (after SQL parsing, before row execution).
+
+### Analyzer IDs
+
+- **1-999**: reserved for system analyzers; IDs 1-6 are bootstrapped (`SCIENTIFIC`, `STANDARD`, `IDENTIFIER`, `KEYWORD`, `AUTOCOMPLETE`, `AUTOCOMPLETE_SEARCH`).
+- **1000+**: user-defined (from `IdType.TEXT_ANALYZER_ID`).
+- All analyzers register in OpenSearch as `synapse_analyzer_{id}`.
+- Synonyms are baked into AOSS at **build** time. They are NOT loaded at query time — only column analyzer overrides and TextAnalyzer definitions are loaded at query time for field routing.
+
+### Dual-field strategy
+
+- KEYWORD-analyzer columns: primary field is `keyword`; `.searchable` sub-field is `text` (for full-text search).
+- All other text columns: primary field is `text` with the configured analyzer; `.keyword` sub-field (for filter/facet/sort).
+- Highlight field names ending in `.searchable` are stripped in response conversion — the client never sees the sub-field suffix.
+
+### Cross-resource deletion protection
+
+Configuration resources (SynonymSet, ColumnAnalyzerOverride, TextAnalyzer) that are referenced by any `SearchConfiguration` cannot be deleted. The DB enforces this via `ON DELETE RESTRICT` foreign keys; DAOs catch `DataIntegrityViolationException` and re-throw as `IllegalArgumentException` with a user-facing message. Per-resource deletion endpoints for SynonymSet and ColumnAnalyzerOverride were intentionally **removed** — once created, they're permanent to prevent orphaned references. Cross-resource JSON-array lookups (e.g., "which configurations reference this synonym set?") use MySQL's `JSON_CONTAINS()`.
 
 ## Curation Grid (Curator)
 

--- a/services/repository/CLAUDE.md
+++ b/services/repository/CLAUDE.md
@@ -64,3 +64,9 @@ public class EntityController {
 - IT tests should cover all endpoints with basic happy-path verification. Deep branch coverage is handled by manager unit tests. Follow the pattern in existing IT tests (e.g., `ITGridControllerTest.java`).
 - Migration test: `MigratableTableDAOImplAutowireTest.testAllMigrationTypesRegistered()` — validates all `MigrationType` values have registered DBOs
 - **New controller endpoints**: Every new controller method needs a corresponding method in `SynapseClient`/`SynapseClientImpl` and an IT test in `integration-test/`.
+- **IT tests are expensive — push business-logic checks to the manager layer.** An IT test only proves HTTP wiring works (one happy-path per endpoint). Deep branch coverage, error paths, and edge cases belong in manager unit tests and `*DaoImplAutowiredTest`. If an assertion would pass with mocks, it does not belong in an IT test.
+- **UUID-suffix resource names in IT tests when there is no admin DELETE endpoint.** Fixed names fail with "same name already exists" on the second run against a populated dev DB. See `integration-test/CLAUDE.md` for the full pattern.
+
+## Stubbing endpoints for parallel UI development
+
+When the backend is blocking UI work, ship a stub-first PR: schemas + controllers that return mock data directly, with no service/manager/DAO chain behind them. This unblocks the UI against real endpoints and keeps the API contract stable. Replace the stub in a follow-up PR without changing the wire shape. See root `CLAUDE.md` → PR & Process Patterns.

--- a/services/workers/CLAUDE.md
+++ b/services/workers/CLAUDE.md
@@ -137,6 +137,10 @@ Creating a worker `@Bean` trigger in Java config is **not enough**. Workers requ
 
 2. **Register the trigger in the Quartz scheduler** by adding a `<ref bean="...Trigger"/>` entry to the `workerTriggersList` in `services/workers/src/main/resources/main-scheduler-spb.xml`. **If this step is missed, the worker will never run** — the bean exists but Quartz never schedules it. There will be no error at startup; the worker silently does nothing.
 
+### Companion Synapse-Stack-Builder PR (Critical)
+
+Every new SQS queue must be provisioned in the separate **Synapse-Stack-Builder** CloudFormation project (`sns-and-sqs-config.json`) **before** the worker PR is merged. Queue names are resolved at runtime via `stackConfig.getQueueName("BASE_NAME")`; if the queue doesn't exist in AWS, the worker fails at startup when it calls the SQS client. No compile-time check catches this. Same applies when adding a new `AsynchJobType` — its async queue must be added to Stack-Builder too. Link the companion PR in the Synapse PR description.
+
 ### Legacy XML Config (do not add new ones)
 
 Some older workers are still wired in per-worker `*-spb.xml` files under `src/main/resources/`, imported by `main-scheduler-spb.xml`. Migrate these to `@Configuration` classes when modifying them.
@@ -157,6 +161,15 @@ Common transient exceptions to catch and retry:
 - `DeadlockLoserDataAccessException`
 - `AmazonServiceException` (service errors)
 - `TemporarilyUnavailableException`
+- `TableUnavailableException` — reuse the existing `TableQueryManager.query` flow; do not reinvent table-readiness probes.
+
+### Catch `Throwable`, not `Exception`, when the worker must persist a failure state
+
+Workers whose outermost catch writes a `FAILED` status (e.g., `SearchIndexLifecycleWorker` writing to `SEARCH_INDEX_STATUS`) MUST catch `Throwable`, not `Exception`. Catching only `Exception` lets `OutOfMemoryError` and other `Error`s fall through to the SQS retry loop, where they will never resolve. Catching `Throwable` ensures the failure is recorded so operators can see the problem.
+
+### State-machine workers: translate `IllegalStateException` to `RecoverableMessageException`
+
+When a worker's job targets a resource still in a transitional state (e.g., a SearchIndex in `CREATING`, a table still building), the manager should throw `IllegalStateException` with a descriptive message. The worker catches it at the boundary and re-throws as `RecoverableMessageException` so SQS retries until the resource is ready. Do NOT poll inside the worker — let SQS backoff handle the wait.
 
 ## Worker Categories
 
@@ -166,7 +179,8 @@ Common transient exceptions to catch and retry:
 | `table/` | Message-driven | Table index management, materialized view updates |
 | `replication/` | Batch message | Entity replication to index database |
 | `file/` | Message-driven | File preview generation |
-| `search/` | Message-driven | Search index (OpenSearch) updates |
+| `search/` (lifecycle) | Message-driven | `SearchIndexLifecycleWorker` — builds/rebuilds/deletes AOSS indexes. Subscribes to the `ENTITY` SNS topic via the `SEARCH_INDEX_LIFECYCLE` SQS queue; filters by node type internally (`searchindex`). |
+| `search/` (query) | Async job | `SearchQueryWorker` — runs async search queries against AOSS. CREATING index → `RecoverableMessageException` so SQS retries until `ACTIVE`. |
 | `schema/` | Message-driven | JSON Schema validation |
 | `migration/` | Batch message | Data migration workers |
 | `log/` | Scheduled | S3 log collation |
@@ -196,3 +210,5 @@ This worker drives index rebuilding after migration:
 - Mock managers/DAOs, verify expected calls
 - Test both success paths and error handling (RecoverableMessageException vs permanent failure)
 - Test ObjectType/ChangeType filtering logic
+- **Parameterized exception-type tests** for transient-vs-permanent classification: use `@ParameterizedTest` + `@ValueSource(classes = {LockReleaseFailedException.class, CannotAcquireLockException.class, DeadlockLoserDataAccessException.class})` to assert every retryable type maps to `RecoverableMessageException`. Avoids duplicated near-identical test methods and makes adding a new retryable type a one-line change.
+- **Parameterized state-machine tests** for workers whose behavior varies by resource state (e.g., SearchIndex CREATING/ACTIVE/FAILED). One `@ParameterizedTest` covering every enum value is preferred over one method per state.


### PR DESCRIPTION
## Summary

Docs-only change that captures the durable conventions and patterns that surfaced while shipping the SearchIndex lifecycle series (PLFM-9509 through PLFM-9518).
These facts used to live only in PR review threads, meeting notes, and commit history — easy to lose.
Collecting them into the CLAUDE.md files means that future Claude-assisted sessions (and any human reader) start from a much higher baseline.

No code behavior changes.
No build or test changes.
No new dependencies.

## Why now

The SearchIndex work was nine stacked PRs over roughly a month.
Every review cycle landed a handful of small corrections on testing nuance, authorization patterns, lifecycle semantics, and cross-stack migration behavior — each individually small, but collectively the kind of guidance that's painful to rediscover on the next feature.
This PR pulls those lessons into the documentation that Claude sees on every future session.

## What changed

### Updated files

| File | Focus of additions |
|---|---|
| `CLAUDE.md` (root) | Stronger testing rules (no `any()` matchers, no `lenient()`, parameterized state-tables, max-length uniqueness, `@InjectMocks` + `@Spy`, `ArgumentCaptor`, assert custom messages). New `Search & Indexing` pointer section. New `PR & Process Patterns` section (companion Stack-Builder PR for every SQS queue, stub-first PRs, feature slicing, working-tree pr-description files). |
| `services/repository-managers/CLAUDE.md` | New `Search & Indexing (SearchIndex lifecycle)` section covering the manager components, configuration resolution priority, build-once semantics, anonymous-user indexing, pre-flight COUNT + 500K row cap, state machine, schema derivation, analyzer ID ranges, dual-field strategy, and cross-resource deletion protection. Added three-layer authorization for org-owned resources, anonymous-user lookup via `getRealmAnonymousUserId()`, `@Lazy` to break full-WAR-context Spring cycles, composition-over-inheritance for async request/response bodies, switch/exception hygiene, package-private-for-testability, and bootstrapper stable-ID-range conventions. |
| `services/workers/CLAUDE.md` | Catch `Throwable` (not `Exception`) in workers that must persist a FAILED status so `OutOfMemoryError` doesn't vanish into the retry loop. `IllegalStateException → RecoverableMessageException` translation at the worker boundary for state-machine workers. Reuse of `TableUnavailableException` instead of reinventing readiness probes. Companion Synapse-Stack-Builder PR is required before merging any worker that references a new queue. SearchIndex lifecycle and query workers added to the worker categories. Parameterized exception-type and state-machine test patterns. |
| `lib/jdomodels/CLAUDE.md` | Upsert via `INSERT ... ON DUPLICATE KEY UPDATE col = VALUES(col)` (bootstrappers, indexing-DB status tables). `NamedParameterJdbcTemplate` for `IN (...)` batch lookups. `Optional.ofNullable` for `JdbcTemplate` results. Explicit `default` branch when switching on `ColumnType`. `ColumnType → external system` mapping as an enum so adding a new type fails at compile time. One `MigrationType` per primary DBO clarification. Indexing-DB-tables-are-not-migrated note. Simple JSON array columns use `JSONArray` directly with `JSON_CONTAINS()` for cross-resource reference checks. |
| `services/repository/CLAUDE.md` | IT tests are expensive — business-logic assertions belong at the manager / autowired-DAO layer, not IT. UUID-suffix resource naming pattern when the resource has no admin DELETE endpoint. Stub-first controller pattern for unblocking UI work. |
| `lib/lib-auto-generated/CLAUDE.md` | Polymorphic JSON fields must commit to a shape: either declare every sub-type schema (so generated POJOs exist) or declare the property as `"type": "string"` (expecting a JSON string from the caller). Do not declare `Map<String, Object>` where the values are serialized JSON — it creates JSON-within-JSON that bypasses schema validation. |

### New files

| File | Why it exists |
|---|---|
| `integration-test/CLAUDE.md` | IT test conventions: `ITTestExtension` injects `SynapseAdminClient`/`SynapseClient` by parameter type and calls `clearAllLocks()` in `@BeforeAll`. UUID-suffix every resource name when there's no admin DELETE endpoint. Assume the dev DB is not clean — write idempotent tests. Documents the anonymous-user lifecycle setup (`DataType.OPEN_DATA` + `PUBLIC_GROUP.READ`). Spells out what IT tests are NOT for: deep branch coverage, business-logic assertions, or replacing `*AutowiredControllerTest`. |
| `client/synapseJavaClient/CLAUDE.md` | Every controller endpoint needs a matching client method and a matching IT test. Async job types must be registered on BOTH server (`lib/jdomodels`) and client (`client/synapseJavaClient`) with identical enum names. Signature convention for start/poll vs synchronous endpoints. Java 8 compile target constraints (no `List.of`, no `var`, no `Optional.isEmpty`, no `String.isBlank`). HTTP status → client exception mapping table. |
| `lib/lib-worker/CLAUDE.md` | Framework-primitive reference: `changes/` (change-message runners, batch processor), `concurrent/` (`ConcurrentWorkerStack`, `ConcurrentManager`, progress callback), `sqs/` (message utils, `JobCanceledException`). Recoverable-vs-permanent exception boundary. Cross-reference to `services/workers/` for where `AsyncJobRunner`, `AsyncJobRunnerAdapter`, and `WorkerTriggerBuilder` actually live (they are NOT in this module despite the framing). |

## Test plan

- [x] No code changes — no unit or integration tests required
- [x] Markdown renders correctly on GitHub (verified by inspection)
- [x] All file paths referenced in the new content resolve to real files in this branch
- [x] No stale ticket numbers or dates embedded in the content (the SearchIndex PR series is referenced only as collective context, not as temporal state)

## Review notes

Everything in the new content is meant to be a durable fact, convention, or pattern — not a temporary state or an announcement of recent work.
If a reviewer feels a specific line reads like it will go stale in three months, please flag it and I'll cut or rephrase it.