### PR TITLE
[PLFM-9598] Honor CsvTableDescriptor.escapeCharacter in CSVWriter

### DIFF
--- a/lib/csv-utilities/src/main/java/au/com/bytecode/opencsv/CSVWriter.java
+++ b/lib/csv-utilities/src/main/java/au/com/bytecode/opencsv/CSVWriter.java
@@ -40,8 +40,10 @@ public class CSVWriter implements Closeable {
     private char quotechar;
     
     private char escapechar;
-    
+
     private String lineEnd;
+
+    private boolean escapeQuoteWithEscapeChar;
 
     private ResultSetHelper resultService = new ResultSetHelperService();
     
@@ -128,11 +130,40 @@ public class CSVWriter implements Closeable {
      * 			  the line feed terminator to use
      */
     public CSVWriter(Writer writer, char separator, char quotechar, char escapechar, String lineEnd) {
+        this(writer, separator, quotechar, escapechar, lineEnd, false);
+    }
+
+    /**
+     * Constructs CSVWriter with supplied separator, quote char, escape char, line ending, and a flag
+     * indicating whether the escape character should be used to escape embedded quote characters.
+     *
+     * <p>When {@code escapeQuoteWithEscapeChar} is {@code true} and a distinct escape character is
+     * supplied (i.e. it is neither {@link Constants#NO_ESCAPE_CHARACTER} nor equal to {@code quotechar}),
+     * an embedded {@code quotechar} is emitted as {@code escapechar + quotechar}. Otherwise, the writer
+     * preserves the original RFC 4180 behavior of doubling the quote character.</p>
+     *
+     * @param writer
+     *            the writer to an underlying CSV source.
+     * @param separator
+     *            the delimiter to use for separating entries
+     * @param quotechar
+     *            the character to use for quoted elements
+     * @param escapechar
+     *            the character to use for escaping quotechars or escapechars
+     * @param lineEnd
+     *            the line feed terminator to use
+     * @param escapeQuoteWithEscapeChar
+     *            when {@code true}, embedded quote characters are escaped using {@code escapechar}
+     *            instead of being doubled
+     */
+    public CSVWriter(Writer writer, char separator, char quotechar, char escapechar, String lineEnd,
+            boolean escapeQuoteWithEscapeChar) {
         this.rawWriter = writer;
         this.separator = separator;
         this.quotechar = quotechar;
         this.escapechar = escapechar;
         this.lineEnd = lineEnd;
+        this.escapeQuoteWithEscapeChar = escapeQuoteWithEscapeChar;
     }
     
     /**
@@ -224,17 +255,24 @@ public class CSVWriter implements Closeable {
 	protected StringBuilder processLine(String nextElement)
     {
 		StringBuilder sb = new StringBuilder(INITIAL_STRING_SIZE);
+		boolean useEscapeForQuote = escapeQuoteWithEscapeChar
+				&& escapechar != Constants.NO_ESCAPE_CHARACTER
+				&& escapechar != quotechar;
 	    for (int j = 0; j < nextElement.length(); j++) {
 	        char nextChar = nextElement.charAt(j);
 	        if (nextChar == quotechar) {
-	        	sb.append(quotechar).append(quotechar);
+	        	if (useEscapeForQuote) {
+	        		sb.append(escapechar).append(quotechar);
+	        	} else {
+	        		sb.append(quotechar).append(quotechar);
+	        	}
 	        } else if (escapechar != Constants.NO_ESCAPE_CHARACTER && nextChar == escapechar) {
 	        	sb.append(escapechar).append(escapechar);
 	        } else {
 	            sb.append(nextChar);
 	        }
 	    }
-	    
+
 	    return sb;
     }
 

--- a/lib/csv-utilities/src/test/java/au/com/bytecode/opencsv/CSVWriterTest.java
+++ b/lib/csv-utilities/src/test/java/au/com/bytecode/opencsv/CSVWriterTest.java
@@ -119,6 +119,62 @@ public class CSVWriterTest {
 		assertEquals("'This is a \\\\ \" ''multiline'' entry','so is \n this'\n", output);
 	}
 
+	@Test
+	public void testWriteNextWithEscapeQuoteFlagAndDistinctEscapeChar() throws IOException {
+		// quote=' escape=/ — embedded ' should be emitted as /' rather than ''
+		StringWriter sw = new StringWriter();
+		try (CSVWriter csvw = new CSVWriter(sw, ',', '\'', '/', "\n", true)) {
+			csvw.writeNext(new String[] { "it's_test.csv" });
+		}
+		// call under test
+		assertEquals("'it/'s_test.csv'\n", sw.toString());
+	}
+
+	@Test
+	public void testWriteNextWithEscapeQuoteFlagAndEscapeCharInData() throws IOException {
+		// escape char itself appearing in data should still be doubled when the flag is on
+		StringWriter sw = new StringWriter();
+		try (CSVWriter csvw = new CSVWriter(sw, ',', '\'', '/', "\n", true)) {
+			csvw.writeNext(new String[] { "a/b'c" });
+		}
+		// call under test
+		assertEquals("'a//b/'c'\n", sw.toString());
+	}
+
+	@Test
+	public void testWriteNextWithEscapeQuoteFlagButEscapeEqualsQuote() throws IOException {
+		// when the supplied escape char equals the quote char, the flag has no effect — RFC 4180 doubling
+		StringWriter sw = new StringWriter();
+		try (CSVWriter csvw = new CSVWriter(sw, ',', '\'', '\'', "\n", true)) {
+			csvw.writeNext(new String[] { "it's" });
+		}
+		// call under test
+		assertEquals("'it''s'\n", sw.toString());
+	}
+
+	@Test
+	public void testWriteNextWithEscapeQuoteFlagButNoEscapeChar() throws IOException {
+		// when escape char is NO_ESCAPE_CHARACTER, the flag has no effect — RFC 4180 doubling
+		StringWriter sw = new StringWriter();
+		try (CSVWriter csvw = new CSVWriter(sw, ',', '\'', Constants.NO_ESCAPE_CHARACTER, "\n", true)) {
+			csvw.writeNext(new String[] { "it's" });
+		}
+		// call under test
+		assertEquals("'it''s'\n", sw.toString());
+	}
+
+	@Test
+	public void testFiveArgConstructorPreservesLegacyDoubling() throws IOException {
+		// the 5-arg constructor must keep today's behavior — doubles the quote even when an escape
+		// character is supplied (this guards every existing direct caller)
+		StringWriter sw = new StringWriter();
+		try (CSVWriter csvw = new CSVWriter(sw, ',', '\'', '/', "\n")) {
+			csvw.writeNext(new String[] { "it's_test.csv" });
+		}
+		// call under test
+		assertEquals("'it''s_test.csv'\n", sw.toString());
+	}
+
 	/**
 	 * Tests parsing individual lines.
 	 *

--- a/lib/lib-utils/src/main/java/org/sagebionetworks/util/csv/CSVWriterProviderImpl.java
+++ b/lib/lib-utils/src/main/java/org/sagebionetworks/util/csv/CSVWriterProviderImpl.java
@@ -15,6 +15,7 @@ public class CSVWriterProviderImpl implements CSVWriterProvider {
         char quotechar = Constants.DEFAULT_QUOTE_CHARACTER;
         char escape = Constants.DEFAULT_ESCAPE_CHARACTER;
         String lineEnd = Constants.DEFAULT_LINE_END;
+        boolean escapeSupplied = false;
         if (csvTableDescriptor != null) {
             if (csvTableDescriptor.getSeparator() != null) {
                 if (csvTableDescriptor.getSeparator().length() != 1) {
@@ -33,12 +34,19 @@ public class CSVWriterProviderImpl implements CSVWriterProvider {
                     throw new IllegalArgumentException("CsvTableDescriptor.escapeCharacter must be exactly one character.");
                 }
                 escape = csvTableDescriptor.getEscapeCharacter().charAt(0);
+                escapeSupplied = true;
             }
             if (csvTableDescriptor.getLineEnd() != null) {
                 lineEnd = csvTableDescriptor.getLineEnd();
             }
         }
-        // Create the reader.
+        // When the descriptor explicitly supplies an escape character, opt the writer into using
+        // it to escape embedded quote characters (e.g. quote=' and escape=/ → /'). When the
+        // descriptor leaves escapeCharacter unset, preserve the legacy RFC 4180 quote-doubling
+        // behavior so existing CSV consumers see byte-for-byte identical output.
+        if (escapeSupplied) {
+            return new CSVWriter(writer, separator, quotechar, escape, lineEnd, true);
+        }
         return new CSVWriter(writer, separator, quotechar, escape, lineEnd);
     }
 

--- a/lib/lib-utils/src/test/java/org/sagebionetworks/util/csv/CSVWriterProviderImplTest.java
+++ b/lib/lib-utils/src/test/java/org/sagebionetworks/util/csv/CSVWriterProviderImplTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.IOException;
 import java.io.StringWriter;
 
 import org.junit.jupiter.api.Test;
@@ -113,5 +114,50 @@ public class CSVWriterProviderImplTest {
             csvWriterProvider.createWriter(reader, csvTableDescriptor);
         }).getMessage();
         assertEquals("CsvTableDescriptor.quoteCharacter must be exactly one character.", message);
+    }
+
+    @Test
+    public void testCreateCSVWriterWithExplicitEscapeUsesEscapeForQuote() throws IOException {
+        // descriptor explicitly sets escapeCharacter — the writer must use it to escape embedded quote chars
+        CsvTableDescriptor csvTableDescriptor = new CsvTableDescriptor()
+                .setQuoteCharacter("'")
+                .setEscapeCharacter("/");
+        StringWriter sw = new StringWriter();
+        // call under test
+        try (CSVWriter csvWriter = csvWriterProvider.createWriter(sw, csvTableDescriptor)) {
+            csvWriter.writeNext(new String[] { "it's_test.csv" });
+        }
+        assertEquals("'it/'s_test.csv'" + Constants.DEFAULT_LINE_END, sw.toString());
+    }
+
+    @Test
+    public void testCreateCSVWriterWithoutExplicitEscapePreservesLegacyDoubling() throws IOException {
+        // descriptor leaves escapeCharacter null — embedded quote must still be doubled (RFC 4180),
+        // matching the byte-for-byte output every existing CSV consumer depends on
+        CsvTableDescriptor csvTableDescriptor = new CsvTableDescriptor().setQuoteCharacter("'");
+        StringWriter sw = new StringWriter();
+        // call under test
+        try (CSVWriter csvWriter = csvWriterProvider.createWriter(sw, csvTableDescriptor)) {
+            csvWriter.writeNext(new String[] { "it's_test.csv" });
+        }
+        assertEquals("'it''s_test.csv'" + Constants.DEFAULT_LINE_END, sw.toString());
+    }
+
+    @Test
+    public void testCreateCSVWriterWithNullDescriptorPreservesLegacyDoubling() throws IOException {
+        // null descriptor — defaults across the board. Default quote char is '"', so an embedded
+        // '"' must be doubled (RFC 4180). Built from a char constant rather than escaped string
+        // literals so the assertion stays readable.
+        //   input:    she said "hi"
+        //   expected: "she said ""hi"""
+        char q = Constants.DEFAULT_QUOTE_CHARACTER;
+        String input = "she said " + q + "hi" + q;
+        String expected = "" + q + "she said " + q + q + "hi" + q + q + q + Constants.DEFAULT_LINE_END;
+        StringWriter sw = new StringWriter();
+        // call under test
+        try (CSVWriter csvWriter = csvWriterProvider.createWriter(sw, null)) {
+            csvWriter.writeNext(new String[] { input });
+        }
+        assertEquals(expected, sw.toString());
     }
 }


### PR DESCRIPTION
## Summary

Fixes [PLFM-9598](https://sagebionetworks.jira.com/browse/PLFM-9598). The vendored OpenCSV `CSVWriter.processLine` always RFC-4180 doubled the quote character and never used the supplied escape char, so a `CsvTableDescriptor` with `quoteCharacter="'"` and `escapeCharacter="/"` produced `'it''s_test.csv'` instead of the expected `'it/'s_test.csv'`. The same defect affected every endpoint that accepts a `CsvTableDescriptor` (download list manifest, table CSV download, grid CSV exporter).

## Changes

- `CSVWriter`: new 6-arg constructor with an `escapeQuoteWithEscapeChar` flag. When the flag is on and the supplied escape char is distinct from the quote char (and not `NO_ESCAPE_CHARACTER`), embedded quote chars are emitted as `escape + quote` instead of being doubled. Existing 1/2/3/4/5-arg constructors delegate with `flag=false` so every direct caller keeps byte-for-byte identical output.
- `CSVWriterProviderImpl`: flips the flag to `true` only when the descriptor explicitly sets `escapeCharacter`. Descriptors that leave it null hit the legacy 5-arg path unchanged.

## Blast radius

- Descriptors that supply `escapeCharacter`: behavior is now correct (this is the bug fix).
- Descriptors with `escapeCharacter` null, null descriptors, and direct callers of any pre-existing `CSVWriter` constructor (`TabCsvPreviewGenerator`, `StorageReportCSVDownloadWorker`, `TableManagerSupportImpl`, test utilities): byte-for-byte identical output to the prior stack.

## Test plan

- [x] `CSVWriterTest`: 5 new tests cover distinct escape char (the bug scenario), escape char equals quote char, `NO_ESCAPE_CHARACTER`, escape char appearing in data, and a guard that the legacy 5-arg constructor still doubles. All 22 tests green.
- [x] `CSVWriterProviderImplTest`: 3 new tests cover descriptor with explicit `escapeCharacter` (round-trip through the writer), descriptor with `escapeCharacter` null (legacy doubling preserved), and null descriptor (legacy doubling preserved). All 11 tests green.
- [x] `DownloadListManagerImplTest`: all 115 tests green — no regression.
- [ ] End-to-end smoke: `POST /download/list/manifest/async/start` with `CsvTableDescriptor { quoteCharacter: "'", escapeCharacter: "/" }` against a list containing `it's_test.csv`; verify the manifest contains `'it/'s_test.csv'`.

[PLFM-9598]: https://sagebionetworks.jira.com/browse/PLFM-9598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ