### PR TITLE
[PLFM-9604] Doc: STS token expires in 1 hour, not 12

### DIFF
--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/EntityController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/EntityController.java
@@ -1677,7 +1677,7 @@ public class EntityController {
 	/**
 	 * Gets the temporary S3 credentials from STS for the given entity. These
 	 * credentials are only good for the bucket and base key specified by the
-	 * returned credentials and expire 12 hours after this API is called.
+	 * returned credentials and expire 1 hour after this API is called.
 	 *
 	 * <p>
 	 * The specified entity must be a folder with an STS-enabled storage location.


### PR DESCRIPTION
Follow-up to [PLFM-9604](https://sagebionetworks.jira.com/browse/PLFM-9604) per [Bruce Hoff's review comment](https://sagebionetworks.jira.com/browse/PLFM-9604?focusedCommentId=321440).

## Change

The Javadoc on `EntityController.getTemporaryCredentialsForEntity` (`GET /entity/{id}/sts`) still claimed the returned credentials expire **12 hours** after this API is called:

```java
/**
 * Gets the temporary S3 credentials from STS for the given entity. These
 * credentials are only good for the bucket and base key specified by the
- * returned credentials and expire 12 hours after this API is called.
+ * returned credentials and expire 1 hour after this API is called.
 *
```

Update the doc to **1 hour**, which is the actual behavior on ECS-Fargate-hosted stacks.

## Why 1 hour

Synapse stacks now run on ECS Fargate. The Fargate task role's credentials are themselves STS-temp tokens (delivered by the ECS Task Metadata Service), so calling `sts:AssumeRole` with them is *role chaining* — and AWS hard-caps the resulting credential's `DurationSeconds` at **3,600 s (1 hour)** regardless of what we request or what the role's `MaxSessionDuration` is set to.

Synapse-Stack-Builder PR [Sage-Bionetworks/Synapse-Stack-Builder#853](https://github.com/Sage-Bionetworks/Synapse-Stack-Builder/pull/853) (also for [PLFM-9604](https://sagebionetworks.jira.com/browse/PLFM-9604)) injects `org.sagebionetworks.sts.duration.seconds=3600` into the Fargate task definition so the server stops requesting an unreachable 12-hour duration. This PR brings the API contract documentation into line with that behavior.

## Scope

- Doc-only. Single line change in one Javadoc comment.
- The `DEFAULT_DURATION_SECONDS = 12 * 60 * 60` constant in `StsManagerImpl.java:41` is left untouched — it's a code default and remains correct for any environment that doesn't trigger role chaining.

## Test plan

- [x] Comment-only change; no unit tests affected.
- [ ] After merge, regenerate API docs and confirm the published REST docs reflect the 1-hour expiration.

## Related

- [PLFM-9604](https://sagebionetworks.jira.com/browse/PLFM-9604) — root-cause ticket
- [Sage-Bionetworks/Synapse-Stack-Builder#853](https://github.com/Sage-Bionetworks/Synapse-Stack-Builder/pull/853) — the Stack-Builder fix that motivates this doc change
- [Bruce Hoff's review comment](https://sagebionetworks.jira.com/browse/PLFM-9604?focusedCommentId=321440)

[PLFM-9604]: https://sagebionetworks.jira.com/browse/PLFM-9604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLFM-9604]: https://sagebionetworks.jira.com/browse/PLFM-9604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ