### PR TITLE
[PLFM-9622] Switch validateAnalyzerSettings to ephemeral index pattern

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -9,18 +9,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import jakarta.json.stream.JsonParser;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
-import org.opensearch.client.opensearch._types.analysis.CharFilter;
 import org.opensearch.client.opensearch._types.analysis.CharFilterDefinition;
-import org.opensearch.client.opensearch._types.analysis.TokenFilter;
 import org.opensearch.client.opensearch._types.analysis.TokenFilterDefinition;
-import org.opensearch.client.opensearch._types.analysis.Tokenizer;
 import org.opensearch.client.opensearch._types.analysis.TokenizerDefinition;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.ErrorCause;
@@ -70,6 +70,8 @@ import org.sagebionetworks.repo.model.search.table.TextAnalyzer;
 import org.sagebionetworks.repo.model.search.table.TextAnalyzerSettings;
 import org.sagebionetworks.repo.model.search.KeyRange;
 import org.sagebionetworks.repo.model.search.KeyValues;
+import org.sagebionetworks.util.RetryException;
+import org.sagebionetworks.util.TimeUtils;
 import org.sagebionetworks.util.ValidateArgument;
 
 import org.springframework.stereotype.Service;
@@ -81,6 +83,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class OpenSearchManagerImpl implements OpenSearchManager {
 
+	private static final Logger log = LogManager.getLogger(OpenSearchManagerImpl.class);
+
 	private static final String SYSTEM_FIELD_ROW_ID = "_row_id";
 	private static final String SYSTEM_FIELD_ROW_VERSION = "_row_version";
 	private static final String SUB_FIELD_KEYWORD = "keyword";
@@ -88,6 +92,15 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	private static final String INDEX_NOT_FOUND_EXCEPTION = "index_not_found_exception";
 	private static final String ANALYZER_PREFIX = "synapse_analyzer_";
 	private static final String SYNONYM_FILTER_NAME = "synapse_synonyms";
+	private static final String VALIDATION_INDEX_PREFIX = "validation-temp-";
+	private static final String VALIDATION_ANALYZER_ID = "validation";
+
+	// AOSS's control plane is eventually consistent across the envoy proxy fleet, so a delete
+	// issued immediately after a create can race and surface index_not_found_exception while
+	// the create is still propagating. 15 retries with 250ms initial + 1.2x backoff totals
+	// ~18s, enough to ride out propagation without leaving billed zombie indices.
+	private static final int CLEANUP_MAX_RETRIES = 15;
+	private static final long CLEANUP_INITIAL_BACKOFF_MS = 250L;
 
 	private static final int DEFAULT_LIMIT = 25;
 	private static final int MAX_LIMIT = 100;
@@ -1027,92 +1040,58 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	public void validateAnalyzerSettings(TextAnalyzerSettings settings) {
 		ValidateArgument.required(settings, "settings");
 
-		Tokenizer tokenizer = buildTokenizer(settings);
-		List<TokenFilter> tokenFilters = buildTokenFilters(settings);
-		List<CharFilter> charFilters = buildCharFilters(settings);
+		TextAnalyzer synthetic = new TextAnalyzer();
+		synthetic.setId(VALIDATION_ANALYZER_ID);
+		synthetic.setSettings(settings);
 
+		String tempIndexName = VALIDATION_INDEX_PREFIX + UUID.randomUUID();
 		try {
-			openSearchClient.indices().analyze(req -> {
-				req.tokenizer(tokenizer);
-				req.text("The quick brown fox jumps over the lazy dog");
-				if (!tokenFilters.isEmpty()) {
-					req.filter(tokenFilters);
-				}
-				if (!charFilters.isEmpty()) {
-					req.charFilter(charFilters);
-				}
-				return req;
-			});
+			CreateIndexRequest request = CreateIndexRequest.of(requestBuilder -> requestBuilder
+					.index(tempIndexName)
+					.settings(settingsBuilder -> settingsBuilder.analysis(analysisBuilder -> {
+						try {
+							registerAnalyzer(analysisBuilder, synthetic, false);
+						} catch (RuntimeException parseException) {
+							throw new IllegalArgumentException(
+									"Invalid analyzer configuration: " + parseException.getMessage(), parseException);
+						}
+						return analysisBuilder;
+					})));
+
+			openSearchClient.indices().create(request);
 		} catch (OpenSearchException e) {
 			throw new IllegalArgumentException(
-				"Invalid analyzer configuration: " + e.error().reason()
-				+ ". Check your tokenizer, token filters, and character filters.", e);
+					"Invalid analyzer configuration: " + describeError(e.error())
+					+ ". Check your tokenizer, token filters, and character filters.", e);
 		} catch (IOException e) {
 			throw new IllegalStateException(
-				"Unable to validate analyzer settings: the search service is temporarily unavailable. Please try again later.", e);
+					"Unable to validate analyzer settings: the search service is temporarily unavailable. Please try again later.", e);
+		} finally {
+			deleteValidationIndexWithRetry(tempIndexName);
 		}
 	}
 
-	private Tokenizer buildTokenizer(TextAnalyzerSettings settings) {
+	private void deleteValidationIndexWithRetry(String tempIndexName) {
 		try {
-			if (settings.getTokenizerConfig() != null && !settings.getTokenizerConfig().isEmpty()) {
-				TokenizerDefinition def = deserializeDefinition(settings.getTokenizerConfig(), TokenizerDefinition._DESERIALIZER);
-				return Tokenizer.of(t -> t.definition(def));
-			}
-			String tokenizerName = settings.getTokenizer() != null ? settings.getTokenizer() : "standard";
-			return Tokenizer.of(t -> t.name(tokenizerName));
-		} catch (Exception e) {
-			throw new IllegalArgumentException("Invalid tokenizer configuration: " + e.getMessage(), e);
+			TimeUtils.waitForExponentialMaxRetry(CLEANUP_MAX_RETRIES, CLEANUP_INITIAL_BACKOFF_MS, () -> {
+				try {
+					openSearchClient.indices().delete(deleteBuilder -> deleteBuilder.index(tempIndexName));
+					return null;
+				} catch (OpenSearchException openSearchException) {
+					if (openSearchException.error() != null
+							&& INDEX_NOT_FOUND_EXCEPTION.equals(openSearchException.error().type())) {
+						throw new RetryException(openSearchException);
+					}
+					throw openSearchException;
+				}
+			});
+		} catch (RetryException retryExhausted) {
+			log.error(
+					"Failed to clean up temporary AOSS index after retries. Orphaned index: {}",
+					tempIndexName, retryExhausted.getCause());
+		} catch (Exception cleanupException) {
+			log.error("Failed to delete temporary validation index: {}", tempIndexName, cleanupException);
 		}
 	}
 
-	private List<TokenFilter> buildTokenFilters(TextAnalyzerSettings settings) {
-		Map<String, TokenFilterDefinition> tokenFilterDefs = Collections.emptyMap();
-		try {
-			if (settings.getTokenFilters() != null && !settings.getTokenFilters().isEmpty()) {
-				tokenFilterDefs = deserializeDefinitionMap(settings.getTokenFilters(), TokenFilterDefinition._DESERIALIZER);
-			}
-		} catch (Exception e) {
-			throw new IllegalArgumentException("Invalid tokenFilters JSON: " + e.getMessage(), e);
-		}
-
-		List<TokenFilter> tokenFilters = new ArrayList<>();
-		if (settings.getFilterOrder() == null) {
-			return tokenFilters;
-		}
-		for (String filterName : settings.getFilterOrder()) {
-			TokenFilterDefinition def = tokenFilterDefs.get(filterName);
-			if (def != null) {
-				tokenFilters.add(TokenFilter.of(f -> f.definition(def)));
-			} else {
-				tokenFilters.add(TokenFilter.of(f -> f.name(filterName)));
-			}
-		}
-		return tokenFilters;
-	}
-
-	private List<CharFilter> buildCharFilters(TextAnalyzerSettings settings) {
-		Map<String, CharFilterDefinition> charFilterDefs = Collections.emptyMap();
-		try {
-			if (settings.getCharFilters() != null && !settings.getCharFilters().isEmpty()) {
-				charFilterDefs = deserializeDefinitionMap(settings.getCharFilters(), CharFilterDefinition._DESERIALIZER);
-			}
-		} catch (Exception e) {
-			throw new IllegalArgumentException("Invalid charFilters JSON: " + e.getMessage(), e);
-		}
-
-		List<CharFilter> charFilters = new ArrayList<>();
-		if (settings.getCharFilterOrder() == null) {
-			return charFilters;
-		}
-		for (String filterName : settings.getCharFilterOrder()) {
-			CharFilterDefinition def = charFilterDefs.get(filterName);
-			if (def != null) {
-				charFilters.add(CharFilter.of(f -> f.definition(def)));
-			} else {
-				charFilters.add(CharFilter.of(f -> f.name(filterName)));
-			}
-		}
-		return charFilters;
-	}
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -2,6 +2,7 @@ package org.sagebionetworks.repo.manager.search;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -233,6 +234,8 @@ public class OpenSearchManagerImplAutoWiredTest {
 				() -> openSearchManager.validateAnalyzerSettings(settings));
 		assertTrue(ex.getMessage().contains("Invalid analyzer configuration"),
 				"Expected 'Invalid analyzer configuration' in message, got: " + ex.getMessage());
+		assertFalse(ex.getMessage().contains("index_not_found_exception"),
+				"AOSS routing error must not reach the caller, got: " + ex.getMessage());
 	}
 
 	@Test
@@ -246,17 +249,32 @@ public class OpenSearchManagerImplAutoWiredTest {
 				() -> openSearchManager.validateAnalyzerSettings(settings));
 		assertTrue(ex.getMessage().contains("Invalid analyzer configuration"),
 				"Expected 'Invalid analyzer configuration' in message, got: " + ex.getMessage());
+		assertFalse(ex.getMessage().contains("index_not_found_exception"),
+				"AOSS routing error must not reach the caller, got: " + ex.getMessage());
 	}
 
 	@Test
 	public void testValidateAnalyzerSettingsWithCustomFilters() {
-		TextAnalyzerSettings settings = new TextAnalyzerSettings();
-		settings.setTokenizer("standard");
-		settings.setTokenFilters("{\"my_stop\":{\"type\":\"stop\",\"stopwords\":\"_english_\"}}");
-		settings.setFilterOrder(Arrays.asList("my_stop", "lowercase"));
+		TextAnalyzerSettings valid = new TextAnalyzerSettings();
+		valid.setTokenizer("standard");
+		valid.setTokenFilters("{\"my_stop\":{\"type\":\"stop\",\"stopwords\":\"_english_\"}}");
+		valid.setFilterOrder(Arrays.asList("my_stop", "lowercase"));
 
 		// call under test
-		assertDoesNotThrow(() -> openSearchManager.validateAnalyzerSettings(settings));
+		assertDoesNotThrow(() -> openSearchManager.validateAnalyzerSettings(valid));
+
+		TextAnalyzerSettings invalid = new TextAnalyzerSettings();
+		invalid.setTokenizer("standard");
+		invalid.setTokenFilters("{\"bad_ngram\":{\"type\":\"edge_ngram\",\"min_gram\":10,\"max_gram\":2}}");
+		invalid.setFilterOrder(Arrays.asList("bad_ngram"));
+
+		// call under test
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> openSearchManager.validateAnalyzerSettings(invalid));
+		assertTrue(ex.getMessage().contains("Invalid analyzer configuration"),
+				"Expected 'Invalid analyzer configuration' in message, got: " + ex.getMessage());
+		assertFalse(ex.getMessage().contains("index_not_found_exception"),
+				"AOSS routing error must not reach the caller, got: " + ex.getMessage());
 	}
 
 	/**

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplValidateTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplValidateTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -19,8 +21,10 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.OpenSearchException;
-import org.opensearch.client.opensearch.indices.AnalyzeRequest;
-import org.opensearch.client.opensearch.indices.AnalyzeResponse;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.CreateIndexResponse;
+import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
+import org.opensearch.client.opensearch.indices.DeleteIndexResponse;
 import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
 import org.sagebionetworks.repo.model.search.table.TextAnalyzerSettings;
 
@@ -32,7 +36,9 @@ public class OpenSearchManagerImplValidateTest {
 	@Mock
 	private OpenSearchIndicesClient indicesClient;
 	@Mock
-	private AnalyzeResponse analyzeResponse;
+	private CreateIndexResponse createResponse;
+	@Mock
+	private DeleteIndexResponse deleteResponse;
 	@Mock
 	private OpenSearchTransport transport;
 
@@ -43,9 +49,15 @@ public class OpenSearchManagerImplValidateTest {
 		manager = new OpenSearchManagerImpl(openSearchClient);
 	}
 
-	private void setupAnalyzeSuccess() throws IOException {
+	private void setupCreateSuccess() throws IOException {
 		when(openSearchClient.indices()).thenReturn(indicesClient);
-		when(indicesClient.analyze(any(AnalyzeRequest.class))).thenReturn(analyzeResponse);
+		when(indicesClient.create(any(CreateIndexRequest.class))).thenReturn(createResponse);
+		when(indicesClient.delete(any(DeleteIndexRequest.class))).thenReturn(deleteResponse);
+	}
+
+	private void setupCleanupOnly() throws IOException {
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		when(indicesClient.delete(any(DeleteIndexRequest.class))).thenReturn(deleteResponse);
 	}
 
 	private void setupJsonpMapper() {
@@ -55,18 +67,21 @@ public class OpenSearchManagerImplValidateTest {
 
 	@Test
 	public void testValidateWithStandardTokenizerSuccess() throws IOException {
-		setupAnalyzeSuccess();
+		setupCreateSuccess();
 
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
 
 		// call under test
 		assertDoesNotThrow(() -> manager.validateAnalyzerSettings(settings));
+
+		verify(indicesClient, times(1)).create(any(CreateIndexRequest.class));
+		verify(indicesClient, times(1)).delete(any(DeleteIndexRequest.class));
 	}
 
 	@Test
 	public void testValidateWithFiltersSuccess() throws IOException {
-		setupAnalyzeSuccess();
+		setupCreateSuccess();
 		setupJsonpMapper();
 
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
@@ -76,11 +91,14 @@ public class OpenSearchManagerImplValidateTest {
 
 		// call under test
 		assertDoesNotThrow(() -> manager.validateAnalyzerSettings(settings));
+
+		verify(indicesClient, times(1)).create(any(CreateIndexRequest.class));
+		verify(indicesClient, times(1)).delete(any(DeleteIndexRequest.class));
 	}
 
 	@Test
 	public void testValidateWithCustomTokenizerConfig() throws IOException {
-		setupAnalyzeSuccess();
+		setupCreateSuccess();
 		setupJsonpMapper();
 
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
@@ -89,11 +107,14 @@ public class OpenSearchManagerImplValidateTest {
 
 		// call under test
 		assertDoesNotThrow(() -> manager.validateAnalyzerSettings(settings));
+
+		verify(indicesClient, times(1)).create(any(CreateIndexRequest.class));
+		verify(indicesClient, times(1)).delete(any(DeleteIndexRequest.class));
 	}
 
 	@Test
 	public void testValidateWithCharFilters() throws IOException {
-		setupAnalyzeSuccess();
+		setupCreateSuccess();
 		setupJsonpMapper();
 
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
@@ -103,16 +124,22 @@ public class OpenSearchManagerImplValidateTest {
 
 		// call under test
 		assertDoesNotThrow(() -> manager.validateAnalyzerSettings(settings));
+
+		verify(indicesClient, times(1)).create(any(CreateIndexRequest.class));
+		verify(indicesClient, times(1)).delete(any(DeleteIndexRequest.class));
 	}
 
 	@Test
 	public void testValidateWithMinimalSettings() throws IOException {
-		setupAnalyzeSuccess();
+		setupCreateSuccess();
 
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 
 		// call under test
 		assertDoesNotThrow(() -> manager.validateAnalyzerSettings(settings));
+
+		verify(indicesClient, times(1)).create(any(CreateIndexRequest.class));
+		verify(indicesClient, times(1)).delete(any(DeleteIndexRequest.class));
 	}
 
 	@Test
@@ -121,8 +148,9 @@ public class OpenSearchManagerImplValidateTest {
 		ErrorResponse errorResponse = ErrorResponse.of(e -> e
 			.error(err -> err.type("illegal_argument_exception").reason("Unknown tokenizer type [foobar]"))
 			.status(400));
-		when(indicesClient.analyze(any(AnalyzeRequest.class)))
+		when(indicesClient.create(any(CreateIndexRequest.class)))
 			.thenThrow(new OpenSearchException(errorResponse));
+		when(indicesClient.delete(any(DeleteIndexRequest.class))).thenReturn(deleteResponse);
 
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("foobar");
@@ -132,13 +160,18 @@ public class OpenSearchManagerImplValidateTest {
 			() -> manager.validateAnalyzerSettings(settings));
 		assertTrue(ex.getMessage().contains("Unknown tokenizer type [foobar]"));
 		assertTrue(ex.getMessage().contains("Invalid analyzer configuration"));
+
+		verify(indicesClient, times(1)).create(any(CreateIndexRequest.class));
+		// finally block must still attempt cleanup
+		verify(indicesClient, times(1)).delete(any(DeleteIndexRequest.class));
 	}
 
 	@Test
 	public void testValidateThrowsIllegalStateOnIOException() throws IOException {
 		when(openSearchClient.indices()).thenReturn(indicesClient);
-		when(indicesClient.analyze(any(AnalyzeRequest.class)))
+		when(indicesClient.create(any(CreateIndexRequest.class)))
 			.thenThrow(new IOException("Connection refused"));
+		when(indicesClient.delete(any(DeleteIndexRequest.class))).thenReturn(deleteResponse);
 
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
@@ -147,10 +180,34 @@ public class OpenSearchManagerImplValidateTest {
 		IllegalStateException ex = assertThrows(IllegalStateException.class,
 			() -> manager.validateAnalyzerSettings(settings));
 		assertTrue(ex.getMessage().contains("temporarily unavailable"));
+
+		verify(indicesClient, times(1)).delete(any(DeleteIndexRequest.class));
 	}
 
 	@Test
-	public void testValidateThrowsOnMalformedTokenFiltersJson() {
+	public void testValidateSwallowsCleanupException() throws IOException {
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		when(indicesClient.create(any(CreateIndexRequest.class))).thenReturn(createResponse);
+		ErrorResponse errorResponse = ErrorResponse.of(e -> e
+			.error(err -> err.type("authorization_exception").reason("not authorized"))
+			.status(403));
+		when(indicesClient.delete(any(DeleteIndexRequest.class)))
+			.thenThrow(new OpenSearchException(errorResponse));
+
+		TextAnalyzerSettings settings = new TextAnalyzerSettings();
+		settings.setTokenizer("standard");
+
+		// call under test
+		assertDoesNotThrow(() -> manager.validateAnalyzerSettings(settings));
+
+		verify(indicesClient, times(1)).delete(any(DeleteIndexRequest.class));
+	}
+
+	@Test
+	public void testValidateThrowsOnMalformedTokenFiltersJson() throws IOException {
+		setupCleanupOnly();
+		setupJsonpMapper();
+
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
 		settings.setTokenFilters("not valid json");
@@ -159,11 +216,14 @@ public class OpenSearchManagerImplValidateTest {
 		// call under test
 		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
 			() -> manager.validateAnalyzerSettings(settings));
-		assertTrue(ex.getMessage().contains("Invalid tokenFilters JSON"));
+		assertTrue(ex.getMessage().contains("Invalid analyzer configuration"));
 	}
 
 	@Test
-	public void testValidateThrowsOnMalformedCharFiltersJson() {
+	public void testValidateThrowsOnMalformedCharFiltersJson() throws IOException {
+		setupCleanupOnly();
+		setupJsonpMapper();
+
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
 		settings.setCharFilters("not valid json");
@@ -172,18 +232,21 @@ public class OpenSearchManagerImplValidateTest {
 		// call under test
 		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
 			() -> manager.validateAnalyzerSettings(settings));
-		assertTrue(ex.getMessage().contains("Invalid charFilters JSON"));
+		assertTrue(ex.getMessage().contains("Invalid analyzer configuration"));
 	}
 
 	@Test
-	public void testValidateThrowsOnMalformedTokenizerConfig() {
+	public void testValidateThrowsOnMalformedTokenizerConfig() throws IOException {
+		setupCleanupOnly();
+		setupJsonpMapper();
+
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizerConfig("not valid json");
 
 		// call under test
 		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
 			() -> manager.validateAnalyzerSettings(settings));
-		assertTrue(ex.getMessage().contains("Invalid tokenizer configuration"));
+		assertTrue(ex.getMessage().contains("Invalid analyzer configuration"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- AOSS Serverless's envoy routing layer rejects cluster-level `_analyze` requests with `index_not_found_exception`, which was making `OpenSearchManagerImplAutoWiredTest.testValidateAnalyzerSettingsWithCustomFilters` **fail on the occasional CI run.**
- Replaces `validateAnalyzerSettings` with the **Ephemeral Index Pattern**: build a synthetic `TextAnalyzer` from the user's settings, run a synchronous `CreateIndex` on a `validation-temp-<uuid>` index via the existing `registerAnalyzer(...)` path, then `DeleteIndex` in `finally`. AOSS validates the analyzer chain at create time.
- Cleanup `DeleteIndex` is wrapped in `TimeUtils.waitForExponentialMaxRetry` (15 retries × 1.2× backoff from 250 ms ≈ 18 s budget) and **only** retries on `index_not_found_exception` — AOSS's control plane is eventually consistent across the envoy fleet, so a delete issued immediately after the create can race the propagation. Without retry we'd leak billed zombie indices. Any other exception fails fast and is logged.
- Tightens the two sibling validate tests (`testValidateAnalyzerSettingsWithInvalidTokenizer`, `testValidateAnalyzerSettingsWithInvalidFilter`) so they no longer pass for the wrong reason against AOSS routing failures (they previously asserted only the wrapper string, which our error wrapper prepends regardless of root cause).

## Test plan

- [x] `mvn test -pl services/repository-managers -Dtest=OpenSearchManagerImplValidateTest` — 12/12 pass (~2 s)
- [x] `mvn test -pl services/repository-managers -Dtest=TextAnalyzerManagerImplTest` — 27/27 pass (caller sanity check)
- [x] `mvn test -pl services/repository-managers -Dtest=OpenSearchManagerImplAutoWiredTest#testValidateAnalyzerSettings*` — 3/3 pass against real AOSS (~80 s; including the previously failing `testValidateAnalyzerSettingsWithCustomFilters`, which now exercises both a valid and an AOSS-rejected analyzer JSON)
- [ ] Full CI run on this branch