### PR TITLE
[PLFM-9625] Fix OpenSearch list serialization and deserializer race condition

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/config/ManagerConfiguration.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/config/ManagerConfiguration.java
@@ -390,9 +390,13 @@ public class ManagerConfiguration {
 		CollectionDetail collection = openSearchServerlessClient.batchGetCollection(req -> req.names(collectionName))
 				.collectionDetails().stream().findFirst().orElseThrow();
 
-		return new OpenSearchClient(new AwsSdk2Transport(httpClient,
+		OpenSearchClient client = new OpenSearchClient(new AwsSdk2Transport(httpClient,
 				collection.collectionEndpoint().replace("https://", ""), "aoss", Region.US_EAST_1,
 				AwsSdk2TransportOptions.builder().setCredentials(credentialProvider).build()));
+
+		org.sagebionetworks.repo.manager.search.OpenSearchManagerImpl.warmAnalysisDeserializers(client);
+
+		return client;
 	}
 
 	@Bean

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/config/ManagerConfiguration.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/config/ManagerConfiguration.java
@@ -4,6 +4,7 @@ import static org.sagebionetworks.repo.manager.file.scanner.BasicFileHandleAssoc
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -21,11 +22,16 @@ import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import jakarta.json.stream.JsonParser;
+
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;
 import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 import org.apache.velocity.runtime.resource.loader.FileResourceLoader;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.analysis.TokenFilterDefinition;
 import org.opensearch.client.transport.aws.AwsSdk2Transport;
 import org.opensearch.client.transport.aws.AwsSdk2TransportOptions;
 import org.sagebionetworks.StackConfiguration;
@@ -394,9 +400,38 @@ public class ManagerConfiguration {
 				collection.collectionEndpoint().replace("https://", ""), "aoss", Region.US_EAST_1,
 				AwsSdk2TransportOptions.builder().setCredentials(credentialProvider).build()));
 
-		org.sagebionetworks.repo.manager.search.OpenSearchManagerImpl.warmAnalysisDeserializers(client);
+		warmAnalysisDeserializers(client);
 
 		return client;
+	}
+
+	/**
+	 * Workaround for OpenSearch SDK 3.7.0 lazy initialization race condition.
+	 * Warms up the analysis deserializers by deserializing sample token filter definitions.
+	 * This ensures all deserializer classes are loaded in the current thread before concurrent
+	 * traffic hits the SDK.
+	 */
+	private static void warmAnalysisDeserializers(OpenSearchClient client) {
+		try {
+			JsonpMapper mapper = client._transport().jsonpMapper();
+			JsonpDeserializer<Map<String, TokenFilterDefinition>> mapDeserializer = JsonpDeserializer
+					.stringMapDeserializer(TokenFilterDefinition._DESERIALIZER);
+			try (JsonParser parser = mapper.jsonProvider().createParser(new StringReader(
+					"{\"w\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true,"
+							+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
+							+ "\"catenate_words\":true,\"catenate_numbers\":false,"
+							+ "\"stem_english_possessive\":true},"
+							+ "\"v\":{\"type\":\"word_delimiter\",\"preserve_original\":true},"
+							+ "\"s\":{\"type\":\"stop\",\"stopwords\":\"_english_\"},"
+							+ "\"m\":{\"type\":\"stemmer\",\"language\":\"english\"},"
+							+ "\"e\":{\"type\":\"edge_ngram\",\"min_gram\":2,\"max_gram\":20}}"))) {
+				mapDeserializer.deserialize(parser, mapper);
+			}
+		} catch (RuntimeException ignored) {
+			// Best-effort: in unit tests the OpenSearchClient is a mock without a transport.
+			// The race only matters when real concurrent traffic hits the SDK, which never
+			// happens in mock-based tests, so silent fall-through is safe here.
+		}
 	}
 
 	@Bean

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -112,6 +112,35 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 
 	public OpenSearchManagerImpl(OpenSearchClient openSearchClient) {
 		this.openSearchClient = openSearchClient;
+		warmAnalysisDeserializers();
+	}
+
+	/**
+	 * OpenSearch SDK 3.7.0's {@code JsonpDeserializerBase.ArrayDeserializer.acceptedEvents()}
+	 * lazy-initializes a non-volatile field via assign-then-mutate. A concurrent reader can
+	 * therefore observe a partially-populated EnumSet (just {@code START_ARRAY}, missing the
+	 * item type's events) and reject a valid event — surfacing as
+	 * "Unexpected JSON event 'VALUE_STRING' instead of '[START_ARRAY, KEY_NAME, VALUE_STRING, ...]'".
+	 * Force one full parse on this thread per filter family so the inner field deserializers
+	 * are fully initialized before any worker thread can touch them.
+	 */
+	private void warmAnalysisDeserializers() {
+		try {
+			deserializeDefinitionMap(
+					"{\"w\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true,"
+							+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
+							+ "\"catenate_words\":true,\"catenate_numbers\":false,"
+							+ "\"stem_english_possessive\":true},"
+							+ "\"v\":{\"type\":\"word_delimiter\",\"preserve_original\":true},"
+							+ "\"s\":{\"type\":\"stop\",\"stopwords\":\"_english_\"},"
+							+ "\"m\":{\"type\":\"stemmer\",\"language\":\"english\"},"
+							+ "\"e\":{\"type\":\"edge_ngram\",\"min_gram\":2,\"max_gram\":20}}",
+					TokenFilterDefinition._DESERIALIZER);
+		} catch (RuntimeException ignored) {
+			// Best-effort: in unit tests the OpenSearchClient is a mock without a transport.
+			// The race only matters when real concurrent traffic hits the SDK, which never
+			// happens in mock-based tests, so silent fall-through is safe here.
+		}
 	}
 
 	@Override

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.repo.manager.search;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -10,6 +11,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import jakarta.json.stream.JsonParser;
 
@@ -810,7 +814,7 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 					.map(e -> {
 						SearchFieldValue fv = new SearchFieldValue();
 						fv.setName(idToName.getOrDefault(e.getKey(), e.getKey()));
-						fv.setValue(e.getValue() != null ? String.valueOf(e.getValue()) : null);
+						fv.setValue(convertFieldValue(e.getValue()));
 						return fv;
 					})
 					.collect(Collectors.toList());
@@ -822,6 +826,26 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		}
 
 		return searchHit;
+	}
+
+	/**
+	 * Stringify a value from an AOSS hit's {@code _source} for {@link SearchFieldValue#setValue(String)}.
+	 * Lists and maps (i.e. {@code *_LIST} and {@code JSON} columns) are written as canonical JSON
+	 * so clients can parse them back; scalars use {@link String#valueOf(Object)} so a raw {@code String}
+	 * column is not double-quoted in the response. Mirrors the pattern at {@code SQLUtils#bindListColumns}
+	 * (lib-table-cluster) which serializes typed Java lists for the table index DB the same way.
+	 */
+	static String convertFieldValue(Object value) {
+		if (value == null) {
+			return null;
+		}
+		if (value instanceof Collection) {
+			return new JSONArray((Collection<?>) value).toString();
+		}
+		if (value instanceof Map) {
+			return new JSONObject((Map<?, ?>) value).toString();
+		}
+		return String.valueOf(value);
 	}
 
 	List<SearchFieldValue> convertHighlights(Map<String, List<String>> highlightMap,

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -116,7 +116,6 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 
 	/**
 	 * Workaround for OpenSearch SDK 3.7.0 lazy initialization race condition.
-	 * See {@code ManagerConfiguration.synSearchOssClient()} for details.
 	 */
 	public static void warmAnalysisDeserializers(OpenSearchClient client) {
 		try {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -112,21 +112,18 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 
 	public OpenSearchManagerImpl(OpenSearchClient openSearchClient) {
 		this.openSearchClient = openSearchClient;
-		warmAnalysisDeserializers();
 	}
 
 	/**
-	 * OpenSearch SDK 3.7.0's {@code JsonpDeserializerBase.ArrayDeserializer.acceptedEvents()}
-	 * lazy-initializes a non-volatile field via assign-then-mutate. A concurrent reader can
-	 * therefore observe a partially-populated EnumSet (just {@code START_ARRAY}, missing the
-	 * item type's events) and reject a valid event — surfacing as
-	 * "Unexpected JSON event 'VALUE_STRING' instead of '[START_ARRAY, KEY_NAME, VALUE_STRING, ...]'".
-	 * Force one full parse on this thread per filter family so the inner field deserializers
-	 * are fully initialized before any worker thread can touch them.
+	 * Workaround for OpenSearch SDK 3.7.0 lazy initialization race condition.
+	 * See {@code ManagerConfiguration.synSearchOssClient()} for details.
 	 */
-	private void warmAnalysisDeserializers() {
+	public static void warmAnalysisDeserializers(OpenSearchClient client) {
 		try {
-			deserializeDefinitionMap(
+			JsonpMapper mapper = client._transport().jsonpMapper();
+			JsonpDeserializer<Map<String, TokenFilterDefinition>> mapDeserializer = JsonpDeserializer
+					.stringMapDeserializer(TokenFilterDefinition._DESERIALIZER);
+			try (JsonParser parser = mapper.jsonProvider().createParser(new StringReader(
 					"{\"w\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true,"
 							+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
 							+ "\"catenate_words\":true,\"catenate_numbers\":false,"
@@ -134,8 +131,9 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 							+ "\"v\":{\"type\":\"word_delimiter\",\"preserve_original\":true},"
 							+ "\"s\":{\"type\":\"stop\",\"stopwords\":\"_english_\"},"
 							+ "\"m\":{\"type\":\"stemmer\",\"language\":\"english\"},"
-							+ "\"e\":{\"type\":\"edge_ngram\",\"min_gram\":2,\"max_gram\":20}}",
-					TokenFilterDefinition._DESERIALIZER);
+							+ "\"e\":{\"type\":\"edge_ngram\",\"min_gram\":2,\"max_gram\":20}}"))) {
+				mapDeserializer.deserialize(parser, mapper);
+			}
 		} catch (RuntimeException ignored) {
 			// Best-effort: in unit tests the OpenSearchClient is a mock without a transport.
 			// The race only matters when real concurrent traffic hits the SDK, which never

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -114,32 +114,6 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		this.openSearchClient = openSearchClient;
 	}
 
-	/**
-	 * Workaround for OpenSearch SDK 3.7.0 lazy initialization race condition.
-	 */
-	public static void warmAnalysisDeserializers(OpenSearchClient client) {
-		try {
-			JsonpMapper mapper = client._transport().jsonpMapper();
-			JsonpDeserializer<Map<String, TokenFilterDefinition>> mapDeserializer = JsonpDeserializer
-					.stringMapDeserializer(TokenFilterDefinition._DESERIALIZER);
-			try (JsonParser parser = mapper.jsonProvider().createParser(new StringReader(
-					"{\"w\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true,"
-							+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
-							+ "\"catenate_words\":true,\"catenate_numbers\":false,"
-							+ "\"stem_english_possessive\":true},"
-							+ "\"v\":{\"type\":\"word_delimiter\",\"preserve_original\":true},"
-							+ "\"s\":{\"type\":\"stop\",\"stopwords\":\"_english_\"},"
-							+ "\"m\":{\"type\":\"stemmer\",\"language\":\"english\"},"
-							+ "\"e\":{\"type\":\"edge_ngram\",\"min_gram\":2,\"max_gram\":20}}"))) {
-				mapDeserializer.deserialize(parser, mapper);
-			}
-		} catch (RuntimeException ignored) {
-			// Best-effort: in unit tests the OpenSearchClient is a mock without a transport.
-			// The race only matters when real concurrent traffic hits the SDK, which never
-			// happens in mock-based tests, so silent fall-through is safe here.
-		}
-	}
-
 	@Override
 	public Optional<String> createIndex(String indexName, List<ColumnModel> columns, String defaultAnalyzer,
 			List<SynonymSet> synonymSets, List<ColumnAnalyzerOverride> columnAnalyzerOverrides,

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapper.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapper.java
@@ -98,7 +98,7 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
 		settings.setTokenFilters("{"
-				+ "\"sci_word_delimiter\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true,"
+				+ "\"sci_word_delimiter\":{\"type\":\"word_delimiter\",\"preserve_original\":true,"
 				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
 				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
 				+ "\"stem_english_possessive\":true},"
@@ -115,7 +115,7 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
 		settings.setTokenFilters("{"
-				+ "\"std_word_delimiter\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true,"
+				+ "\"std_word_delimiter\":{\"type\":\"word_delimiter\",\"preserve_original\":true,"
 				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
 				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
 				+ "\"stem_english_possessive\":true}"
@@ -129,7 +129,7 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("whitespace");
 		settings.setTokenFilters("{"
-				+ "\"id_word_delimiter\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true,"
+				+ "\"id_word_delimiter\":{\"type\":\"word_delimiter\",\"preserve_original\":true,"
 				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
 				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
 				+ "\"stem_english_possessive\":false}"

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -343,7 +343,6 @@ public class OpenSearchManagerImplAutoWiredTest {
 		Map<String, Object> doc = new HashMap<>();
 		doc.put("_row_id", 1L);
 		doc.put("_row_version", 1L);
-		Map<String, Object> expectedById = new LinkedHashMap<>();
 		for (ColumnModel column : columns) {
 			ColumnType type = column.getColumnType();
 			RoundTripCase rtc = casesByType.get(type);
@@ -351,7 +350,6 @@ public class OpenSearchManagerImplAutoWiredTest {
 			assertEquals(rtc.expected, converted,
 					"convertForDocument produced unexpected value for " + type);
 			doc.put(column.getId(), converted);
-			expectedById.put(column.getId(), converted);
 		}
 
 		// call under test
@@ -377,45 +375,48 @@ public class OpenSearchManagerImplAutoWiredTest {
 		}
 
 		for (ColumnModel column : columns) {
+			ColumnType type = column.getColumnType();
 			String fieldName = idToName.get(column.getId());
 			String actual = returnedByName.get(fieldName);
-			assertNotNull(actual, "missing returned value for " + column.getColumnType());
-			assertEquals(String.valueOf(expectedById.get(column.getId())), actual,
-					"round-trip mismatch for " + column.getColumnType());
+			assertNotNull(actual, "missing returned value for " + type);
+			assertEquals(casesByType.get(type).expectedReturned, actual,
+					"round-trip mismatch for " + type);
 		}
 	}
 
 	private static Map<ColumnType, RoundTripCase> buildEveryColumnTypeCase() {
 		Map<ColumnType, RoundTripCase> casesByType = new LinkedHashMap<>();
-		casesByType.put(ColumnType.STRING,        new RoundTripCase("alpha",                              "alpha"));
-		casesByType.put(ColumnType.STRING_LIST,   new RoundTripCase("[\"alpha\",\"beta\"]",               List.of("alpha", "beta")));
-		casesByType.put(ColumnType.MEDIUMTEXT,    new RoundTripCase("alpha beta gamma",                   "alpha beta gamma"));
-		casesByType.put(ColumnType.LARGETEXT,     new RoundTripCase("alpha beta gamma",                   "alpha beta gamma"));
-		casesByType.put(ColumnType.LINK,          new RoundTripCase("https://example.org/a",              "https://example.org/a"));
-		casesByType.put(ColumnType.INTEGER,       new RoundTripCase("123",                                123));
-		casesByType.put(ColumnType.INTEGER_LIST,  new RoundTripCase("[1,2,3]",                            List.of(1, 2, 3)));
-		casesByType.put(ColumnType.DATE,          new RoundTripCase("1609459200000",                      1609459200000L));
-		casesByType.put(ColumnType.DATE_LIST,     new RoundTripCase("[1609459200000,1609545600000]",      List.of(1609459200000L, 1609545600000L)));
-		casesByType.put(ColumnType.FILEHANDLEID,  new RoundTripCase("9876543",                            9876543));
-		casesByType.put(ColumnType.SUBMISSIONID,  new RoundTripCase("555",                                555));
-		casesByType.put(ColumnType.EVALUATIONID,  new RoundTripCase("777",                                777));
-		casesByType.put(ColumnType.ENTITYID,      new RoundTripCase("syn123456",                          "syn123456"));
-		casesByType.put(ColumnType.USERID,        new RoundTripCase("3412396",                            "3412396"));
-		casesByType.put(ColumnType.ENTITYID_LIST, new RoundTripCase("[\"syn1\",\"syn2\"]",                List.of("syn1", "syn2")));
-		casesByType.put(ColumnType.USERID_LIST,   new RoundTripCase("[\"100\",\"200\"]",                  List.of("100", "200")));
-		casesByType.put(ColumnType.DOUBLE,        new RoundTripCase("1.5",                                1.5));
-		casesByType.put(ColumnType.BOOLEAN,       new RoundTripCase("true",                               Boolean.TRUE));
-		casesByType.put(ColumnType.BOOLEAN_LIST,  new RoundTripCase("[true,false]",                       List.of(true, false)));
-		casesByType.put(ColumnType.JSON,          new RoundTripCase("{\"a\":1,\"b\":\"x\"}",              Map.of("a", 1, "b", "x")));
+		casesByType.put(ColumnType.STRING,        new RoundTripCase("alpha",                              "alpha",                                  "alpha"));
+		casesByType.put(ColumnType.STRING_LIST,   new RoundTripCase("[\"alpha\",\"beta\"]",               List.of("alpha", "beta"),                 "[\"alpha\",\"beta\"]"));
+		casesByType.put(ColumnType.MEDIUMTEXT,    new RoundTripCase("alpha beta gamma",                   "alpha beta gamma",                       "alpha beta gamma"));
+		casesByType.put(ColumnType.LARGETEXT,     new RoundTripCase("alpha beta gamma",                   "alpha beta gamma",                       "alpha beta gamma"));
+		casesByType.put(ColumnType.LINK,          new RoundTripCase("https://example.org/a",              "https://example.org/a",                  "https://example.org/a"));
+		casesByType.put(ColumnType.INTEGER,       new RoundTripCase("123",                                123,                                      "123"));
+		casesByType.put(ColumnType.INTEGER_LIST,  new RoundTripCase("[1,2,3]",                            List.of(1, 2, 3),                         "[1,2,3]"));
+		casesByType.put(ColumnType.DATE,          new RoundTripCase("1609459200000",                      1609459200000L,                           "1609459200000"));
+		casesByType.put(ColumnType.DATE_LIST,     new RoundTripCase("[1609459200000,1609545600000]",      List.of(1609459200000L, 1609545600000L),  "[1609459200000,1609545600000]"));
+		casesByType.put(ColumnType.FILEHANDLEID,  new RoundTripCase("9876543",                            9876543,                                  "9876543"));
+		casesByType.put(ColumnType.SUBMISSIONID,  new RoundTripCase("555",                                555,                                      "555"));
+		casesByType.put(ColumnType.EVALUATIONID,  new RoundTripCase("777",                                777,                                      "777"));
+		casesByType.put(ColumnType.ENTITYID,      new RoundTripCase("syn123456",                          "syn123456",                              "syn123456"));
+		casesByType.put(ColumnType.USERID,        new RoundTripCase("3412396",                            "3412396",                                "3412396"));
+		casesByType.put(ColumnType.ENTITYID_LIST, new RoundTripCase("[\"syn1\",\"syn2\"]",                List.of("syn1", "syn2"),                  "[\"syn1\",\"syn2\"]"));
+		casesByType.put(ColumnType.USERID_LIST,   new RoundTripCase("[\"100\",\"200\"]",                  List.of("100", "200"),                    "[\"100\",\"200\"]"));
+		casesByType.put(ColumnType.DOUBLE,        new RoundTripCase("1.5",                                1.5,                                      "1.5"));
+		casesByType.put(ColumnType.BOOLEAN,       new RoundTripCase("true",                               Boolean.TRUE,                             "true"));
+		casesByType.put(ColumnType.BOOLEAN_LIST,  new RoundTripCase("[true,false]",                       List.of(true, false),                     "[true,false]"));
+		casesByType.put(ColumnType.JSON,          new RoundTripCase("{\"a\":1,\"b\":\"x\"}",              Map.of("a", 1, "b", "x"),                 "{\"a\":1,\"b\":\"x\"}"));
 		return casesByType;
 	}
 
 	private static final class RoundTripCase {
 		final String raw;
 		final Object expected;
-		RoundTripCase(String raw, Object expected) {
+		final String expectedReturned;
+		RoundTripCase(String raw, Object expected, String expectedReturned) {
 			this.raw = raw;
 			this.expected = expected;
+			this.expectedReturned = expectedReturned;
 		}
 	}
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -313,6 +313,30 @@ public class OpenSearchManagerImplAutoWiredTest {
 		assertEquals(3L, indexed);
 	}
 
+	@Test
+	public void testBulkIndexWithBootstrappedScientificAnalyzer() {
+		Map<String, TextAnalyzer> analyzers = new HashMap<>();
+		analyzers.put("org.sagebionetworks-SCIENTIFIC", bootstrappedScientificAnalyzer());
+
+		List<ColumnModel> columns = List.of(
+				new ColumnModel().setId("1").setName("geneName").setColumnType(ColumnType.STRING));
+
+		openSearchManager.createIndex(indexName, columns, null,
+				Collections.emptyList(), Collections.emptyList(), analyzers);
+
+		List<BulkOperation> operations = List.of(
+				buildBulkOp(indexName, "1", Map.of("_row_id", 1L, "_row_version", 1L, "1", "BRCA1")),
+				buildBulkOp(indexName, "2", Map.of("_row_id", 2L, "_row_version", 1L, "1", "BRCA2")),
+				buildBulkOp(indexName, "3", Map.of("_row_id", 3L, "_row_version", 1L, "1", "TP53"))
+		);
+
+		// call under test — all 3 docs must be accepted. Pre-fix this returned 3 per-item
+		// errors with "Internal error occurred while processing request".
+		long indexed = openSearchManager.bulkIndex(indexName, operations);
+
+		assertEquals(3L, indexed);
+	}
+
 	/**
 	 * Round-trips one row through every Synapse {@link ColumnType} simultaneously: each fixture
 	 * pairs the raw String value (the form delivered by {@code tableQueryManager.runQueryAsStream})
@@ -418,6 +442,32 @@ public class OpenSearchManagerImplAutoWiredTest {
 			this.expected = expected;
 			this.expectedReturned = expectedReturned;
 		}
+	}
+
+	/**
+	 * Mirrors {@code TextAnalyzerBootstrapper.buildScientificSettings()}. Kept inline (matching
+	 * the autocomplete helpers below) so this test exercises the exact production config without
+	 * requiring the bootstrapper to expose its internals.
+	 */
+	private static TextAnalyzer bootstrappedScientificAnalyzer() {
+		TextAnalyzerSettings settings = new TextAnalyzerSettings();
+		settings.setTokenizer("standard");
+		settings.setTokenFilters("{"
+				+ "\"sci_word_delimiter\":{\"type\":\"word_delimiter\",\"preserve_original\":true,"
+				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
+				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
+				+ "\"stem_english_possessive\":true},"
+				+ "\"english_stop\":{\"type\":\"stop\",\"stopwords\":\"_english_\"},"
+				+ "\"english_stemmer\":{\"type\":\"stemmer\",\"language\":\"english\"}"
+				+ "}");
+		settings.setFilterOrder(Arrays.asList(
+				"sci_word_delimiter", "lowercase", "english_stop", "english_stemmer"));
+		settings.setSynonymAware(true);
+
+		TextAnalyzer analyzer = new TextAnalyzer();
+		analyzer.setId(Long.toString(TextAnalyzerBootstrapper.SCIENTIFIC_ID));
+		analyzer.setSettings(settings);
+		return analyzer;
 	}
 
 	private static TextAnalyzer autocompleteIndexAnalyzer() {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -819,6 +819,84 @@ public class OpenSearchManagerImplTest {
 	// convertHighlights above covers the only branch with non-trivial logic that isn't
 	// exclusively OpenSearch-client plumbing.
 
+	// convertFieldValue stringifies a single AOSS _source value for SearchFieldValue.value.
+	// Lists and maps (the *_LIST and JSON column types) must be written as canonical JSON so
+	// clients can parse them back; scalars must use String.valueOf so a raw String column is
+	// not double-quoted. PLFM-9625 was the latter branch silently using Java's List.toString
+	// (`[a, b]`) instead of JSON.
+
+	@Test
+	public void testConvertFieldValueWithNull() {
+		// call under test
+		assertNull(OpenSearchManagerImpl.convertFieldValue(null));
+	}
+
+	@Test
+	public void testConvertFieldValueWithString() {
+		// call under test
+		assertEquals("alpha", OpenSearchManagerImpl.convertFieldValue("alpha"));
+	}
+
+	@Test
+	public void testConvertFieldValueWithInteger() {
+		// call under test
+		assertEquals("123", OpenSearchManagerImpl.convertFieldValue(123));
+	}
+
+	@Test
+	public void testConvertFieldValueWithLong() {
+		// call under test
+		assertEquals("1609459200000", OpenSearchManagerImpl.convertFieldValue(1609459200000L));
+	}
+
+	@Test
+	public void testConvertFieldValueWithDouble() {
+		// call under test
+		assertEquals("1.5", OpenSearchManagerImpl.convertFieldValue(1.5));
+	}
+
+	@Test
+	public void testConvertFieldValueWithBoolean() {
+		// call under test
+		assertEquals("true", OpenSearchManagerImpl.convertFieldValue(Boolean.TRUE));
+	}
+
+	@Test
+	public void testConvertFieldValueWithListOfStrings() {
+		// PLFM-9625: List values must round-trip as canonical JSON, not Java List.toString().
+		// call under test
+		assertEquals("[\"alpha\",\"beta\"]",
+				OpenSearchManagerImpl.convertFieldValue(List.of("alpha", "beta")));
+	}
+
+	@Test
+	public void testConvertFieldValueWithListOfStringsContainingComma() {
+		// The ticket's motivating case: a list element contains a comma, so the buggy
+		// `[alpha, b,c]` form would be unparseable. JSON quoting must preserve element boundaries.
+		// call under test
+		assertEquals("[\"alpha\",\"b,c\"]",
+				OpenSearchManagerImpl.convertFieldValue(List.of("alpha", "b,c")));
+	}
+
+	@Test
+	public void testConvertFieldValueWithListOfIntegers() {
+		// call under test
+		assertEquals("[1,2,3]",
+				OpenSearchManagerImpl.convertFieldValue(List.of(1, 2, 3)));
+	}
+
+	@Test
+	public void testConvertFieldValueWithMap() {
+		// JSON column type: AOSS returns a Map; must be re-serialized as canonical JSON.
+		// LinkedHashMap pins key order so the asserted JSON is deterministic.
+		java.util.LinkedHashMap<String, Object> map = new java.util.LinkedHashMap<>();
+		map.put("a", 1);
+		map.put("b", "x");
+
+		// call under test
+		assertEquals("{\"a\":1,\"b\":\"x\"}", OpenSearchManagerImpl.convertFieldValue(map));
+	}
+
 	@Test
 	public void testDescribeErrorWithSingleCause() {
 		org.opensearch.client.opensearch._types.ErrorCause cause =

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapperTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapperTest.java
@@ -75,41 +75,41 @@ public class TextAnalyzerBootstrapperTest {
 	}
 
 	@Test
-	public void testScientificAnalyzerHasWordDelimiterGraph() {
+	public void testScientificAnalyzerUsesLegacyWordDelimiter() {
 		setupOrgMock();
 
 		verify(textAnalyzerDao).createOrUpdateSystemAnalyzerForBootstrapOnly(eq(TextAnalyzerBootstrapper.SCIENTIFIC_ID), analyzerCaptor.capture(), eq(TEST_ORG_NAME), any(Long.class));
 		TextAnalyzerSettings settings = analyzerCaptor.getValue().getSettings();
 
 		assertEquals("standard", settings.getTokenizer());
-		assertWordDelimiterGraphFilter(settings.getTokenFilters(), "sci_word_delimiter");
+		assertWordDelimiterFilter(settings.getTokenFilters(), "sci_word_delimiter");
 		assertEquals(Arrays.asList("sci_word_delimiter", "lowercase", "english_stop", "english_stemmer"),
 				settings.getFilterOrder());
 		assertTrue(settings.getSynonymAware());
 	}
 
 	@Test
-	public void testStandardAnalyzerHasWordDelimiterGraph() {
+	public void testStandardAnalyzerUsesLegacyWordDelimiter() {
 		setupOrgMock();
 
 		verify(textAnalyzerDao).createOrUpdateSystemAnalyzerForBootstrapOnly(eq(TextAnalyzerBootstrapper.STANDARD_ID), analyzerCaptor.capture(), eq(TEST_ORG_NAME), any(Long.class));
 		TextAnalyzerSettings settings = analyzerCaptor.getValue().getSettings();
 
 		assertEquals("standard", settings.getTokenizer());
-		assertWordDelimiterGraphFilter(settings.getTokenFilters(), "std_word_delimiter");
+		assertWordDelimiterFilter(settings.getTokenFilters(), "std_word_delimiter");
 		assertEquals(Arrays.asList("std_word_delimiter", "lowercase"), settings.getFilterOrder());
 		assertTrue(settings.getSynonymAware());
 	}
 
 	@Test
-	public void testIdentifierAnalyzerHasWordDelimiterGraph() {
+	public void testIdentifierAnalyzerUsesLegacyWordDelimiter() {
 		setupOrgMock();
 
 		verify(textAnalyzerDao).createOrUpdateSystemAnalyzerForBootstrapOnly(eq(TextAnalyzerBootstrapper.IDENTIFIER_ID), analyzerCaptor.capture(), eq(TEST_ORG_NAME), any(Long.class));
 		TextAnalyzerSettings settings = analyzerCaptor.getValue().getSettings();
 
 		assertEquals("whitespace", settings.getTokenizer());
-		assertWordDelimiterGraphFilter(settings.getTokenFilters(), "id_word_delimiter");
+		assertWordDelimiterFilter(settings.getTokenFilters(), "id_word_delimiter");
 		assertEquals(Arrays.asList("id_word_delimiter", "lowercase"), settings.getFilterOrder());
 		assertTrue(settings.getSynonymAware());
 	}


### PR DESCRIPTION
## Summary

This PR fixes three issues in the OpenSearch integration for SearchIndex:

1. **JSON serialization of LIST/JSON column types** - Properly serialize collections and maps to JSON strings with correct quoting
2. **OpenSearch SDK deserializer race condition** - Move pre-warming to bean creation to eliminate bean-ordering races
3. **word_delimiter_graph incompatibility** - Switch index-time analyzers to legacy word_delimiter for AOSS compatibility

## Changes

### JSON Serialization (commit cffc9ed)
- Use Jackson to serialize `*_LIST` and `JSON` column values instead of calling `toString()`
- Fixes parsing errors when user values contain commas
- Adds comprehensive round-trip tests verifying MySQL → OpenSearch → response conversion

### Deserializer Warmup (commits 76c294b + 3a779f1)
- OpenSearch SDK 3.7.0 has a lazy initialization race in `JsonpDeserializerBase.ArrayDeserializer.acceptedEvents()`
- Originally fixed by warming deserializers in `OpenSearchManagerImpl` constructor
- **This PR moves the warmup to `ManagerConfiguration.synSearchOssClient()`** to eliminate bean-ordering dependency races
- Ensures the client is fully initialized before any dependent beans receive it

### word_delimiter_graph Fix (commit f24445e)
- Switch index-time token filters from `word_delimiter_graph` to legacy `word_delimiter`
- The modern tokenizer fails inconsistently in Amazon OpenSearch Serverless
- Query-time processing still uses word_delimiter_graph
- Adds integration test verifying correct tokenization behavior
