### PR TITLE
[PLFM-9622] Move index_not_found_exception retry into validateAnalyzerSettings

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/ITTextAnalyzerTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITTextAnalyzerTest.java
@@ -6,26 +6,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sagebionetworks.client.SynapseAdminClient;
-import org.sagebionetworks.client.exceptions.SynapseBadRequestException;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.repo.model.search.table.ListTextAnalyzersRequest;
 import org.sagebionetworks.repo.model.search.table.ListTextAnalyzersResponse;
 import org.sagebionetworks.repo.model.search.table.TextAnalyzer;
 import org.sagebionetworks.repo.model.search.table.TextAnalyzerSettings;
-import org.sagebionetworks.util.RetryException;
-import org.sagebionetworks.util.TimeUtils;
 
 @ExtendWith(ITTestExtension.class)
 public class ITTextAnalyzerTest {
-
-	private static final int VALIDATE_RETRY_MAX = 10;
-	private static final long VALIDATE_RETRY_INITIAL_MS = 1_000L;
 
 	private final SynapseAdminClient adminSynapse;
 
@@ -39,7 +32,7 @@ public class ITTextAnalyzerTest {
 	}
 
 	@Test
-	public void testCRUDWithTextAnalyzerSettings() throws Exception {
+	public void testCRUDWithTextAnalyzerSettings() throws SynapseException {
 		// The org.sagebionetworks organization is bootstrapped on startup
 		// List system analyzers to get the organization ID
 		ListTextAnalyzersRequest listRequest = new ListTextAnalyzersRequest();
@@ -61,7 +54,7 @@ public class ITTextAnalyzerTest {
 		toCreate.setSettings(settings);
 
 		// call under test
-		TextAnalyzer created = retryOnAossAnalyzeFlake(() -> adminSynapse.createTextAnalyzer(toCreate));
+		TextAnalyzer created = adminSynapse.createTextAnalyzer(toCreate);
 		assertNotNull(created.getId());
 		assertNotNull(created.getEtag());
 		assertEquals(toCreate.getName(), created.getName());
@@ -74,7 +67,7 @@ public class ITTextAnalyzerTest {
 
 		// call under test
 		fetched.setDescription("Updated description");
-		TextAnalyzer updated = retryOnAossAnalyzeFlake(() -> adminSynapse.updateTextAnalyzer(fetched));
+		TextAnalyzer updated = adminSynapse.updateTextAnalyzer(fetched);
 		assertEquals("Updated description", updated.getDescription());
 		assertNotNull(updated.getEtag());
 
@@ -85,19 +78,5 @@ public class ITTextAnalyzerTest {
 		assertNotNull(orgResponse.getResults());
 		assertTrue(orgResponse.getResults().stream().anyMatch(a -> created.getId().equals(a.getId())));
 
-	}
-
-	private static <T> T retryOnAossAnalyzeFlake(Callable<T> action) throws Exception {
-		return TimeUtils.waitForExponentialMaxRetry(VALIDATE_RETRY_MAX, VALIDATE_RETRY_INITIAL_MS, () -> {
-			try {
-				return action.call();
-			} catch (SynapseBadRequestException e) {
-				String message = e.getMessage();
-				if (message != null && message.contains("index_not_found_exception")) {
-					throw new RetryException(e);
-				}
-				throw e;
-			}
-		});
 	}
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -79,6 +79,8 @@ import org.sagebionetworks.repo.model.search.table.TextAnalyzer;
 import org.sagebionetworks.repo.model.search.table.TextAnalyzerSettings;
 import org.sagebionetworks.repo.model.search.KeyRange;
 import org.sagebionetworks.repo.model.search.KeyValues;
+import org.sagebionetworks.util.RetryException;
+import org.sagebionetworks.util.TimeUtils;
 import org.sagebionetworks.util.ValidateArgument;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
 
@@ -109,6 +111,8 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	private static final String SUB_FIELD_KEYWORD = "keyword";
 	private static final String SUB_FIELD_SEARCHABLE = "searchable";
 	private static final String INDEX_NOT_FOUND_EXCEPTION = "index_not_found_exception";
+	static final int ANALYZE_RETRY_MAX = 5;
+	static final long ANALYZE_RETRY_INITIAL_MS = 500L;
 	// AOSS reports a concurrent index-delete attempt with a reason text containing
 	// "concurrent deletes". Package-visible so callers can recognize and translate
 	// it into a recoverable SQS retry.
@@ -1201,22 +1205,38 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		List<CharFilter> charFilters = buildCharFilters(settings);
 
 		try {
-			openSearchClient.indices().analyze(req -> {
-				req.tokenizer(tokenizer);
-				req.text("The quick brown fox jumps over the lazy dog");
-				if (!tokenFilters.isEmpty()) {
-					req.filter(tokenFilters);
+			TimeUtils.waitForExponentialMaxRetry(ANALYZE_RETRY_MAX, ANALYZE_RETRY_INITIAL_MS, () -> {
+				try {
+					openSearchClient.indices().analyze(req -> {
+						req.tokenizer(tokenizer);
+						req.text("The quick brown fox jumps over the lazy dog");
+						if (!tokenFilters.isEmpty()) {
+							req.filter(tokenFilters);
+						}
+						if (!charFilters.isEmpty()) {
+							req.charFilter(charFilters);
+						}
+						return req;
+					});
+				} catch (OpenSearchException e) {
+					if (INDEX_NOT_FOUND_EXCEPTION.equals(e.error() != null ? e.error().type() : null)) {
+						throw new RetryException(e);
+					}
+					throw new IllegalArgumentException(
+						"Invalid analyzer configuration: " + describeError(e.error())
+						+ ". Check your tokenizer, token filters, and character filters.", e);
+				} catch (IOException e) {
+					throw new IllegalStateException(
+						"Unable to validate analyzer settings: the search service is temporarily unavailable. Please try again later.", e);
 				}
-				if (!charFilters.isEmpty()) {
-					req.charFilter(charFilters);
-				}
-				return req;
+				return null;
 			});
-		} catch (OpenSearchException e) {
-			throw new IllegalArgumentException(
-				"Invalid analyzer configuration: " + describeError(e.error())
-				+ ". Check your tokenizer, token filters, and character filters.", e);
-		} catch (IOException e) {
+		} catch (RetryException e) {
+			throw new IllegalStateException(
+				"Unable to validate analyzer settings: the search service is temporarily unavailable. Please try again later.", e.getCause());
+		} catch (IllegalArgumentException | IllegalStateException e) {
+			throw e;
+		} catch (Exception e) {
 			throw new IllegalStateException(
 				"Unable to validate analyzer settings: the search service is temporarily unavailable. Please try again later.", e);
 		}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplValidateTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplValidateTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -191,5 +193,42 @@ public class OpenSearchManagerImplValidateTest {
 		// call under test
 		assertThrows(IllegalArgumentException.class,
 			() -> manager.validateAnalyzerSettings(null));
+	}
+
+	@Test
+	public void testValidateRetriesOnIndexNotFoundThenSucceeds() throws IOException {
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		ErrorResponse indexNotFound = ErrorResponse.of(e -> e
+			.error(err -> err.type("index_not_found_exception").reason("no such index"))
+			.status(404));
+		when(indicesClient.analyze(any(AnalyzeRequest.class)))
+			.thenThrow(new OpenSearchException(indexNotFound))
+			.thenReturn(analyzeResponse);
+
+		TextAnalyzerSettings settings = new TextAnalyzerSettings();
+		settings.setTokenizer("standard");
+
+		// call under test — first attempt throws index_not_found, second succeeds
+		assertDoesNotThrow(() -> manager.validateAnalyzerSettings(settings));
+		verify(indicesClient, times(2)).analyze(any(AnalyzeRequest.class));
+	}
+
+	@Test
+	public void testValidateThrowsIllegalStateWhenIndexNotFoundExhaustsRetries() throws IOException {
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		ErrorResponse indexNotFound = ErrorResponse.of(e -> e
+			.error(err -> err.type("index_not_found_exception").reason("no such index"))
+			.status(404));
+		when(indicesClient.analyze(any(AnalyzeRequest.class)))
+			.thenThrow(new OpenSearchException(indexNotFound));
+
+		TextAnalyzerSettings settings = new TextAnalyzerSettings();
+		settings.setTokenizer("standard");
+
+		// call under test — all retries exhausted, must surface as IllegalStateException
+		IllegalStateException ex = assertThrows(IllegalStateException.class,
+			() -> manager.validateAnalyzerSettings(settings));
+		assertTrue(ex.getMessage().contains("temporarily unavailable"));
+		verify(indicesClient, times(OpenSearchManagerImpl.ANALYZE_RETRY_MAX)).analyze(any(AnalyzeRequest.class));
 	}
 }


### PR DESCRIPTION
## Problem

When creating or updating a `TextAnalyzer`, `OpenSearchManagerImpl.validateAnalyzerSettings` calls the AOSS `/_analyze` API synchronously to validate the tokenizer/filter configuration. AOSS occasionally returns `index_not_found_exception` transiently during this call — the system index simply hasn't fully initialized yet.

The IT test previously papered over this with a client-side `retryOnAossAnalyzeFlake` wrapper (up to 10 retries, 1 s initial backoff). That approach only helped the test; any real caller hitting the same transient condition would get a confusing HTTP 400 "Invalid analyzer configuration" error.

## Solution

Move the retry logic into `OpenSearchManagerImpl.validateAnalyzerSettings` itself:

- On `index_not_found_exception`: throw `RetryException` to trigger `TimeUtils.waitForExponentialMaxRetry` (up to **5 attempts**, **500 ms** initial backoff, 1.2× exponential)
- On any other `OpenSearchException` (bad tokenizer/filter config): still surfaces immediately as `IllegalArgumentException` → HTTP 400
- On `IOException` or exhausted retries: surfaces as `IllegalStateException` → HTTP 500 with a "temporarily unavailable" message

Every caller now benefits automatically. The IT test workaround is deleted.

## Changes

| File | Change |
|---|---|
| `OpenSearchManagerImpl.java` | Wrap the `/_analyze` call in `waitForExponentialMaxRetry`; retry only on `index_not_found_exception` |
| `OpenSearchManagerImplValidateTest.java` | Two new tests: retry-then-succeed and exhausted-retries → `IllegalStateException` |
| `ITTextAnalyzerTest.java` | Remove `retryOnAossAnalyzeFlake` wrapper and now-unused imports/constants |

## Test plan

- [ ] `mvn test -pl services/repository-managers -Dtest=OpenSearchManagerImplValidateTest` — all 13 unit tests pass
- [ ] IT test `ITTextAnalyzerTest` passes against a live stack without the retry wrapper