### PR TITLE
[PLFM-9630] Retry failed subset of bulk-index batch within worker

### DIFF
--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/KeyRange.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/KeyRange.json
@@ -1,18 +1,18 @@
 {
-	"description": "A range filter. Matches rows where min <= value <= max. At least one of either 'min' or 'max' must be set for this range to be valid.",
+	"description": "A range filter over one column. Matches rows where the column value falls between min and max, inclusive on both ends. At least one of min or max must be set (omit either bound for an open-ended range). Values are strings and are parsed per the column type: integer / double columns accept numeric literals; date columns accept ISO-8601 strings. Runs in non-scoring context.",
 	"properties": {
 		"key": {
 			"required": true,
 			"type": "string",
-			"description": "The column name to filter on."
+			"description": "The column name to filter on. Must be a column present on the SearchIndex's schema."
 		},
 		"min": {
 			"type": "string",
-			"description": "The minimum value in the range (inclusive). At least one of either 'min' or 'max' must be set."
+			"description": "Minimum value (inclusive). Omit for an open-ended lower bound. At least one of min / max must be set."
 		},
 		"max": {
 			"type": "string",
-			"description": "The maximum value in the range (inclusive). At least one of either 'min' or 'max' must be set."
+			"description": "Maximum value (inclusive). Omit for an open-ended upper bound. At least one of min / max must be set."
 		}
 	}
 }

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/KeyValues.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/KeyValues.json
@@ -1,20 +1,20 @@
 {
-	"description": "A multi-value filter (IN clause). Matches rows where the key column contains any of the listed values.",
+	"description": "A multi-value IN-clause filter over a single column. A row matches when the column's value equals any entry in 'values' (or, with not=true, matches none of them). Values are compared exactly against the column's stored keyword tokens — for text columns this means matching the post-analysis form (typically lowercased). Runs in non-scoring context: a matching row is included unconditionally, without contributing to relevance. Useful for faceted navigation where the user has selected one or more bucket values.",
 	"properties": {
 		"key": {
 			"type": "string",
-			"description": "The column name to filter on."
+			"description": "The column name to filter on. Must be a column present on the SearchIndex's schema."
 		},
 		"values": {
 			"type": "array",
-			"description": "The values to match.",
+			"description": "Values to match. Case-sensitive, compared against the stored keyword sub-field — for text columns analyzed with a lowercase filter, supply lowercased values here. Numeric and date columns accept their string representations (e.g. '42', '2026-05-09').",
 			"items": {
 				"type": "string"
 			}
 		},
 		"not": {
 			"type": "boolean",
-			"description": "If true, excludes matching values instead. Default: false."
+			"description": "When true, inverts the filter semantics: rows matching any value are excluded (NOT IN). Default: false."
 		}
 	}
 }

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/SearchQuery.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/SearchQuery.json
@@ -1,85 +1,85 @@
 {
-	"description": "A structured search query against an OpenSearch index. Composed into request objects (e.g., SearchIndexQuery) that wrap it with context such as which index to target.",
+	"description": "A structured search query against a Synapse SearchIndex, composed of a main full-text query, zero or more structured filters, optional facet aggregations, and response-shaping options (sort, highlight, pagination). Most callers will set at least queryText (or leave it empty for a catalog-style MATCH_ALL browse) and possibly queryType + queryFields. Filters, facets, sort, and returnFields are independent layers — any combination is valid. Filters run in non-scoring context: they narrow the result set without influencing relevance.",
 	"properties": {
 		"queryType": {
-			"description": "Full-text query type. Default: SIMPLE_QUERY_STRING.",
+			"description": "The full-text query model applied to queryText. Default: SIMPLE_QUERY_STRING (safe for untrusted user input). See SearchQueryType for a per-value explanation of scoring model, accepted parameters, and when to use each. When queryText is null or empty, queryType is automatically coerced to MATCH_ALL regardless of this setting.",
 			"$ref": "org.sagebionetworks.repo.model.search.SearchQueryType"
 		},
 		"queryText": {
 			"type": "string",
-			"description": "The search text. Null or empty matches all documents."
+			"description": "The text to search for. Interpretation depends on queryType: SIMPLE_QUERY_STRING parses operators like +, -, |, \"...\", ~, *, (); MATCH / MULTI_MATCH analyze it into tokens and run each against the indexed tokens; MATCH_PHRASE treats it as an ordered phrase; PREFIX treats the final token as a prefix; WILDCARD treats * and ? as glob wildcards. Null or empty triggers MATCH_ALL."
 		},
 		"queryFields": {
 			"type": "array",
-			"description": "Column names with optional boost (e.g., 'studyName^3'). Empty means all indexed fields.",
+			"description": "Columns to search, with optional per-field boost using 'field^N' syntax (e.g. 'title^3' weighs title matches three times as much as unboosted fields). Empty or null means all indexed fields. Required for MATCH, MATCH_PHRASE, and WILDCARD (single field); optional for MULTI_MATCH and PREFIX (multi-field); ignored by SIMPLE_QUERY_STRING when empty (searches every indexed field).",
 			"items": {
 				"type": "string"
 			}
 		},
 		"termsFilters": {
 			"type": "array",
-			"description": "Multi-value filters (IN clause).",
+			"description": "Multi-value IN-clause filters. Each entry restricts a column to a specified set of values; set 'not: true' on an entry to express NOT IN. Runs in non-scoring context against the column's keyword sub-field, so filter values must match stored tokens exactly (case-sensitive for text columns analyzed with lowercase filters — compare your values to what the analyzer produced).",
 			"items": {
 				"$ref": "org.sagebionetworks.repo.model.search.KeyValues"
 			}
 		},
 		"rangeFilters": {
 			"type": "array",
-			"description": "Range filters with min and max.",
+			"description": "Inclusive range filters on numeric or date columns. Each entry restricts a column to min <= value <= max; either bound may be omitted for open-ended ranges. Values are strings and are parsed per the column type (integer, double, date). Runs in non-scoring context.",
 			"items": {
 				"$ref": "org.sagebionetworks.repo.model.search.KeyRange"
 			}
 		},
 		"existsFilters": {
 			"type": "array",
-			"description": "Columns that must have a non-null value.",
+			"description": "Column names that must have a non-null value in the matched documents. Useful for narrowing to rows that have been fully annotated. Runs in non-scoring context.",
 			"items": {
 				"type": "string"
 			}
 		},
 		"notExistsFilters": {
 			"type": "array",
-			"description": "Columns that must be null or missing.",
+			"description": "Column names that must be null or missing in the matched documents. Inverse of existsFilters; useful for surfacing under-annotated rows. Runs in non-scoring context.",
 			"items": {
 				"type": "string"
 			}
 		},
 		"fuzziness": {
 			"type": "string",
-			"description": "Typo tolerance: 'AUTO', '0', '1', or '2'."
+			"description": "Typo tolerance expressed as a Levenshtein edit distance. Accepted values: 'AUTO' (recommended — 0 edits for tokens <=2 chars, 1 edit for 3-5 chars, 2 edits for >=6 chars), '0' (disabled, exact), '1', '2'. Only meaningful for queryType=MATCH or MULTI_MATCH — OpenSearch silently ignores fuzziness on other query types. See SearchQueryType for the right alternative per type (e.g. per-term '~' syntax in queryText for SIMPLE_QUERY_STRING, or an edge-ngram analyzer for PREFIX autocomplete)."
 		},
 		"facetRequests": {
 			"type": "array",
-			"description": "Columns to aggregate as facets.",
+			"description": "Columns to aggregate as facet buckets alongside the primary hit results. Each entry produces one terms aggregation; use maxValueCount to cap the bucket count, and sortField/sortDirection to order buckets by count or by key. Returned in SearchQueryResults.facets only when the caller opts into the FACETS response part.",
 			"items": {
 				"$ref": "org.sagebionetworks.repo.model.search.FacetRequest"
 			}
 		},
 		"returnFields": {
 			"type": "array",
-			"description": "Columns to include in results. Empty means all columns.",
+			"description": "Columns to include in each hit's field list. Empty or null returns every indexed column on the matched documents. Narrowing this to the columns the caller actually displays reduces response size and transport cost, especially for wide SearchIndexes.",
 			"items": {
 				"type": "string"
 			}
 		},
 		"sort": {
 			"type": "array",
-			"description": "Sort order. Default: relevance descending.",
+			"description": "Result ordering. Each entry specifies a column name (or the special '_score' pseudo-column, which sorts by relevance) and an ASC/DESC direction. When omitted, results are sorted by relevance descending (_score DESC). Sort columns must be stored as keyword or numeric sub-fields — for text columns this is handled automatically by routing through the keyword sub-field.",
 			"items": {
 				"$ref": "org.sagebionetworks.repo.model.search.SortField"
 			}
 		},
 		"highlight": {
 			"type": "boolean",
-			"description": "Whether to return highlighted snippets. Default: false."
+			"description": "When true, each hit's field list includes HTML-tagged excerpts showing where the query matched. Uses OpenSearch's default highlighter with <em> tags around matched terms. Default: false. Ignored by autocomplete endpoint."
 		},
 		"offset": {
 			"type": "integer",
-			"description": "Zero-based pagination offset. Default: 0."
+			"description": "Zero-based pagination offset into the hit list. Default: 0. For deep pagination (offset > ~10,000), prefer reshaping the query with filters and sort to narrow the result set rather than scrolling."
 		},
 		"limit": {
 			"type": "integer",
-			"description": "Results per page. Default: 25. Max: 100."
+			"description": "Maximum number of hits to return per page. Default: 25. Maximum: 100 (larger values are silently capped). Set to 0 in combination with FACETS-only response parts to retrieve only aggregate counts."
 		}
 	}
 }

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/SearchQueryType.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/SearchQueryType.json
@@ -1,34 +1,34 @@
 {
-	"description": "The type of full-text query to execute against a search index.",
+	"description": "The type of full-text query to execute against a search index. Each type has a distinct analyzer behavior, scoring model, and accepted parameters — pick the one whose semantics match the caller's intent rather than the one that happens to return results. Fuzziness compatibility is documented per type; passing fuzziness with an incompatible type is rejected with HTTP 400.",
 	"type": "string",
 	"enum": [
 		{
 			"name": "SIMPLE_QUERY_STRING",
-			"description": "Default. Supports +, -, |, quotes, ~, *, () operators. Best for user-facing search boxes."
+			"description": "Default. Parses queryText using a user-facing mini-syntax that tolerates malformed input instead of failing: '+' (AND), '|' (OR), '-' (negate), '\"...\"' (phrase), '*' (prefix), '(...)' (grouping), '~N' (per-term fuzziness or phrase slop). Intended for free-form search boxes where users type whatever they want. What you get: safe parsing (bad syntax degrades to token search, never a 400), per-term fuzzy via '~', and automatic analyzer application to every token. Do not set the top-level 'fuzziness' parameter — it is not applied to this type (use '~' inside queryText instead). Avoid when you need precise control over operator semantics; use MATCH or MULTI_MATCH then."
 		},
 		{
 			"name": "MATCH",
-			"description": "Standard full-text match. Best for programmatic queries."
+			"description": "Single-field full-text match. Analyzes queryText with the field's configured analyzer, then ORs the resulting tokens (default). What you get: the canonical full-text search primitive, with full support for the top-level 'fuzziness' parameter (AUTO / 0 / 1 / 2). Use when you're searching one specific column and want predictable scoring. Requires 'queryFields' with exactly one field. Not for phrase matching (use MATCH_PHRASE) and not for cross-field search (use MULTI_MATCH)."
 		},
 		{
 			"name": "MULTI_MATCH",
-			"description": "Matches across multiple fields with configurable boost."
+			"description": "Full-text match across multiple fields simultaneously, with per-field boost via 'field^N' syntax in queryFields. Analyzes queryText once, then runs the analyzed tokens against every listed field and combines scores. What you get: cross-field search with boost control and top-level 'fuzziness'. Use when you want one query to hit title, description, tags, etc. with different weights. This is the workhorse for most user-facing search boxes once you need boost control."
 		},
 		{
 			"name": "MATCH_PHRASE",
-			"description": "Exact phrase matching. Terms must appear in order and adjacent."
+			"description": "Exact phrase match on a single field. Analyzes queryText, then requires the resulting tokens to appear in the document in the same order and adjacent. What you get: phrase semantics — '\"machine learning\"' only matches docs containing those two words next to each other, never 'learning about machines'. Use for quoted-phrase search and for strict multi-word matches. Does NOT accept 'fuzziness' (phrase queries cannot be fuzzy at the character level). Requires 'queryFields' with exactly one field."
 		},
 		{
 			"name": "PREFIX",
-			"description": "Prefix matching for autocomplete and type-ahead."
+			"description": "Type-ahead / autocomplete query across multiple fields. Internally mapped to multi_match with 'bool_prefix' scoring: every analyzed token in queryText becomes a term match EXCEPT the final token, which becomes a prefix match. What you get: responsive autocomplete — typing 'mach lear' matches documents containing 'machine learning' without waiting for the user to finish typing. Use for search-as-you-type inputs. Does NOT accept 'fuzziness' (that would multiply candidate expansions past practical limits); if you need typo tolerance in autocomplete, configure an edge-ngram analyzer on the indexed field via ColumnAnalyzerOverride. Fields are optional (defaults to all indexed fields)."
 		},
 		{
 			"name": "WILDCARD",
-			"description": "Supports * and ? wildcards. Use sparingly."
+			"description": "Pattern match on a single field using '*' (zero or more chars) and '?' (exactly one char). Does NOT analyze queryText — the pattern is matched against the stored keyword tokens as-is. What you get: direct control over the matched string, independent of tokenization. Use for structured ID/code columns where the user knows the shape ('GSE*', 'chr?:*-*'). Requires 'queryFields' with exactly one field. Does NOT accept 'fuzziness' (use '?' in queryText for single-char tolerance) and is case-sensitive by default. Avoid leading wildcards on large indices — they force a full scan."
 		},
 		{
 			"name": "MATCH_ALL",
-			"description": "Returns all documents. Used automatically when queryText is null or empty."
+			"description": "Returns every document in the index, subject to any filters. Auto-selected when queryText is null or empty, regardless of the caller's declared queryType — so an empty search box naturally returns the full catalog. What you get: browse-mode behavior with filters/facets/sort applied to the entire index. Use explicitly when you want paginated full-index results (e.g., building a catalog view with no text query). Does NOT accept 'fuzziness' (nothing to be fuzzy against). All documents receive a constant score of 1.0; use an explicit 'sort' when you want ordering other than relevance."
 		}
 	]
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManager.java
@@ -14,6 +14,7 @@ import org.sagebionetworks.repo.model.search.SearchQueryPart;
 import org.sagebionetworks.repo.model.search.table.SynonymSet;
 import org.sagebionetworks.repo.model.search.table.TextAnalyzer;
 import org.sagebionetworks.repo.model.search.table.TextAnalyzerSettings;
+import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
 
 /**
  * Manager interface for OpenSearch Serverless (AOSS) operations.
@@ -56,6 +57,19 @@ public interface OpenSearchManager {
 	 * @return The number of documents successfully indexed
 	 */
 	long bulkIndex(String indexName, List<BulkOperation> operations);
+
+	/**
+	 * Block until {@code indexName} accepts writes. AOSS acknowledges {@code createIndex}
+	 * and the index is queryable before the shards are actually ready to accept documents,
+	 * so a query-based readiness check is not reliable — the only reliable probe is a real
+	 * write. Writes a sentinel document with {@code _row_id = -1} and, on success, deletes
+	 * it before returning.
+	 *
+	 * @param indexName The OpenSearch index name
+	 * @throws RecoverableMessageException when the probe does not succeed within the retry
+	 *         budget, so the SearchIndex lifecycle message goes back on SQS for a later attempt
+	 */
+	void waitForIndexWritable(String indexName) throws RecoverableMessageException;
 
 	/**
 	 * Execute a search query against the OpenSearch index. The {@code options} set controls

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -12,22 +12,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
-
-import jakarta.json.stream.JsonParser;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
-import org.opensearch.client.opensearch._types.analysis.CharFilter;
-import org.opensearch.client.opensearch._types.analysis.CharFilterDefinition;
-import org.opensearch.client.opensearch._types.analysis.TokenFilter;
-import org.opensearch.client.opensearch._types.analysis.TokenFilterDefinition;
-import org.opensearch.client.opensearch._types.analysis.Tokenizer;
-import org.opensearch.client.opensearch._types.analysis.TokenizerDefinition;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.ErrorCause;
 import org.opensearch.client.opensearch._types.FieldSort;
@@ -39,6 +30,12 @@ import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.analysis.CharFilter;
+import org.opensearch.client.opensearch._types.analysis.CharFilterDefinition;
+import org.opensearch.client.opensearch._types.analysis.TokenFilter;
+import org.opensearch.client.opensearch._types.analysis.TokenFilterDefinition;
+import org.opensearch.client.opensearch._types.analysis.Tokenizer;
+import org.opensearch.client.opensearch._types.analysis.TokenizerDefinition;
 import org.opensearch.client.opensearch._types.mapping.DynamicMapping;
 import org.opensearch.client.opensearch._types.mapping.Property;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
@@ -46,6 +43,8 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.TextQueryType;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.DeleteRequest;
+import org.opensearch.client.opensearch.core.IndexRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
@@ -54,37 +53,38 @@ import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.opensearch.indices.CreateIndexResponse;
 import org.opensearch.client.opensearch.indices.IndexSettingsAnalysis;
+import org.sagebionetworks.repo.model.search.FacetRequest;
+import org.sagebionetworks.repo.model.search.FacetSortField;
+import org.sagebionetworks.repo.model.search.KeyRange;
+import org.sagebionetworks.repo.model.search.KeyValues;
+import org.sagebionetworks.repo.model.search.SearchFieldValue;
+import org.sagebionetworks.repo.model.search.SearchHit;
+import org.sagebionetworks.repo.model.search.SearchQuery;
+import org.sagebionetworks.repo.model.search.SearchQueryPart;
+import org.sagebionetworks.repo.model.search.SearchQueryResults;
+import org.sagebionetworks.repo.model.search.SearchQueryType;
+import org.sagebionetworks.repo.model.search.SortDirection;
+import org.sagebionetworks.repo.model.search.SortField;
+import org.sagebionetworks.repo.model.search.table.ColumnAnalyzerOverride;
+import org.sagebionetworks.repo.model.search.table.ColumnAnalyzerOverrideEntry;
+import org.sagebionetworks.repo.model.search.table.SynonymRule;
+import org.sagebionetworks.repo.model.search.table.SynonymRuleType;
+import org.sagebionetworks.repo.model.search.table.SynonymSet;
+import org.sagebionetworks.repo.model.search.table.TextAnalyzer;
+import org.sagebionetworks.repo.model.search.table.TextAnalyzerSettings;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
 import org.sagebionetworks.repo.model.table.FacetColumnResult;
 import org.sagebionetworks.repo.model.table.FacetColumnResultValueCount;
 import org.sagebionetworks.repo.model.table.FacetColumnResultValues;
 import org.sagebionetworks.repo.model.table.FacetType;
-import org.sagebionetworks.repo.model.search.table.ColumnAnalyzerOverride;
-import org.sagebionetworks.repo.model.search.table.ColumnAnalyzerOverrideEntry;
-import org.sagebionetworks.repo.model.search.FacetRequest;
-import org.sagebionetworks.repo.model.search.FacetSortField;
-import org.sagebionetworks.repo.model.search.SearchFieldValue;
-import org.sagebionetworks.repo.model.search.SearchHit;
-import org.sagebionetworks.repo.model.search.SearchQuery;
-import org.sagebionetworks.repo.model.search.SearchQueryType;
-import org.sagebionetworks.repo.model.search.SearchQueryResults;
-import org.sagebionetworks.repo.model.search.SortDirection;
-import org.sagebionetworks.repo.model.search.SortField;
-import org.sagebionetworks.repo.model.search.table.SynonymRule;
-import org.sagebionetworks.repo.model.search.table.SynonymRuleType;
-import org.sagebionetworks.repo.model.search.SearchQueryPart;
-import org.sagebionetworks.repo.model.search.table.SynonymSet;
-import org.sagebionetworks.repo.model.search.table.TextAnalyzer;
-import org.sagebionetworks.repo.model.search.table.TextAnalyzerSettings;
-import org.sagebionetworks.repo.model.search.KeyRange;
-import org.sagebionetworks.repo.model.search.KeyValues;
 import org.sagebionetworks.util.RetryException;
 import org.sagebionetworks.util.TimeUtils;
 import org.sagebionetworks.util.ValidateArgument;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
-
 import org.springframework.stereotype.Service;
+
+import jakarta.json.stream.JsonParser;
 
 /**
  * Implementation of {@link OpenSearchManager} that wraps the OpenSearch Java client
@@ -112,6 +112,13 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	// Non-final so unit tests can lower the values and avoid real-wall-clock sleeps.
 	static int BULK_INDEX_MAX_RETRIES = 10;
 	static long BULK_INDEX_INITIAL_BACKOFF_MS = 10000L;
+
+	// Readiness probe for a freshly-created index. AOSS acknowledges createIndex and is
+	// queryable before shards are ready to accept writes, so the only reliable probe is
+	// an actual write. Same budget as the bulk-index retry for consistency.
+	static int INDEX_WRITABLE_MAX_RETRIES = 10;
+	static long INDEX_WRITABLE_INITIAL_BACKOFF_MS = 10000L;
+	static final String READINESS_PROBE_DOC_ID = "__readiness_probe__";
 
 	private static final String SYSTEM_FIELD_ROW_ID = "_row_id";
 	private static final String SYSTEM_FIELD_ROW_VERSION = "_row_version";
@@ -281,6 +288,56 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	}
 
 	@Override
+	public void waitForIndexWritable(String indexName) throws RecoverableMessageException {
+		// Fixed sentinel id so repeated probe writes on the same index overwrite the same
+		// document rather than accumulating copies — one delete at the end is sufficient.
+		Map<String, Object> sentinel = new HashMap<>();
+		sentinel.put(SYSTEM_FIELD_ROW_ID, -1L);
+		sentinel.put(SYSTEM_FIELD_ROW_VERSION, -1L);
+		final int[] attempt = {0};
+		try {
+			TimeUtils.waitForExponentialMaxRetry(INDEX_WRITABLE_MAX_RETRIES, INDEX_WRITABLE_INITIAL_BACKOFF_MS,
+					() -> {
+						attempt[0]++;
+						try {
+							openSearchClient.index(IndexRequest.of(r -> r
+									.index(indexName)
+									.id(READINESS_PROBE_DOC_ID)
+									.document(sentinel)));
+							return Boolean.TRUE;
+						} catch (OpenSearchException e) {
+							LOG.warn("Index {} not yet writable (attempt {}/{}): {}",
+									indexName, attempt[0], INDEX_WRITABLE_MAX_RETRIES, describeError(e.error()));
+							throw new RetryException(e);
+						} catch (IOException e) {
+							LOG.warn("Index {} not yet writable (attempt {}/{}): {}",
+									indexName, attempt[0], INDEX_WRITABLE_MAX_RETRIES, e.getMessage());
+							throw new RetryException(e);
+						}
+					});
+		} catch (RetryException e) {
+			LOG.error("Index {} did not accept writes after {} attempts", indexName, INDEX_WRITABLE_MAX_RETRIES);
+			throw new RecoverableMessageException(
+					"AOSS index " + indexName + " did not accept writes within the retry budget",
+					e.getCause());
+		} catch (RuntimeException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new RuntimeException("Failed readiness probe for search index: " + indexName, e);
+		}
+		// Remove the sentinel so real indexing never observes it. Cleanup failures are
+		// non-fatal: the sentinel's _row_id = -1 cannot collide with real row ids.
+		try {
+			openSearchClient.delete(DeleteRequest.of(r -> r
+					.index(indexName)
+					.id(READINESS_PROBE_DOC_ID)));
+		} catch (OpenSearchException | IOException e) {
+			LOG.warn("Failed to delete readiness probe document from index {}: {}",
+					indexName, e.getMessage());
+		}
+	}
+
+	@Override
 	public long bulkIndex(String indexName, List<BulkOperation> operations) {
 		if (operations.isEmpty()) {
 			return 0L;
@@ -309,61 +366,125 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	}
 
 	/**
-	 * Submits the currently-outstanding operations once. Returns the total success count if the
-	 * attempt fully succeeds; throws {@link RuntimeException} for any permanent failure (no
-	 * further retries); throws {@link RetryException} when only transient failures remain so
-	 * {@link TimeUtils#waitForExponentialMaxRetry} backs off and re-invokes with the trimmed
-	 * subset of still-failing operations.
+	 * Runs a single retry iteration. Dispatches to either the batch or per-document path based on
+	 * {@link BulkRetryState#perDocumentMode}. Returns {@code totalOps} when the attempt fully
+	 * succeeds; throws {@link RuntimeException} for a permanent failure (no further retries);
+	 * throws {@link RetryException} when only transient failures remain so
+	 * {@link TimeUtils#waitForExponentialMaxRetry} backs off and invokes us again.
 	 */
 	private long attemptBulk(String indexName, BulkRetryState state, int totalOps) throws RetryException {
 		state.attempt++;
-		BulkResponse response = executeBulk(indexName, state.remaining);
+		if (state.perDocumentMode) {
+			attemptPerDocument(indexName, state, totalOps);
+		} else {
+			attemptBatch(indexName, state, totalOps);
+		}
+		return (long) totalOps;
+	}
 
+	/** Submits all outstanding ops in a single bulk request and decides what happens next. */
+	private void attemptBatch(String indexName, BulkRetryState state, int totalOps) throws RetryException {
+		BulkResponse response = executeBulk(indexName, state.remaining);
 		// Per the OpenSearch bulk API contract, errors=false means every item succeeded.
 		// https://opensearch.org/blog/error-logs/error-log-bulkindexerror-the-batch-failure/
 		if (!response.errors()) {
-			return (long) totalOps;
+			return;
 		}
+		BulkItemClassification c = classifyItems(indexName, response.items(), state.remaining);
+		if (c.hasPermanentFailures()) {
+			throw new RuntimeException(buildPermanentFailureMessage(
+					attemptFailureSummary(indexName, totalOps, c), c.permanentSamples));
+		}
+		// Only retryable failures. Flip to per-document mode so the next attempt (and all
+		// subsequent ones within this bulkIndex call) submit one op per request — a single
+		// slow shard should not cause the whole batch to be rejected again.
+		logRetryableAttempt(indexName, state, c, state.remaining.size());
+		LOG.warn("Switching bulk index to {} to per-document mode for remaining {} document(s)",
+				indexName, c.retryableItems.size());
+		state.perDocumentMode = true;
+		state.advanceTo(c.nextRemaining, c.retryableItems);
+		throw new RetryException(attemptFailureSummary(indexName, totalOps, c));
+	}
 
-		List<BulkOperation> nextRemaining = new ArrayList<>();
-		List<BulkResponseItem> retryableItems = new ArrayList<>();
-		List<String> permanentSamples = new ArrayList<>();
-		int permanentFailures = 0;
-		List<BulkResponseItem> items = response.items();
+	/**
+	 * Submits each outstanding op in its own single-item bulk request, removing each from
+	 * {@link BulkRetryState#remaining} as soon as the client returns. If any request throws
+	 * a retryable envelope-level error, {@code state.remaining} already holds exactly the ops
+	 * that were never submitted — the next attempt picks up there without resubmitting the ones
+	 * that already landed.
+	 */
+	private void attemptPerDocument(String indexName, BulkRetryState state, int totalOps) throws RetryException {
+		List<BulkResponseItem> items = new ArrayList<>(state.remaining.size());
+		List<BulkOperation> submitted = new ArrayList<>(state.remaining.size());
+		while (!state.remaining.isEmpty()) {
+			BulkOperation op = state.remaining.get(0);
+			// executeBulk may throw RetryException (envelope 429/5xx, IOException) or
+			// RuntimeException (envelope 4xx). Either propagates; nothing else to do here
+			// because the loop already advanced state.remaining past the ops it finished.
+			BulkResponse single = executeBulk(indexName, Collections.singletonList(op));
+			items.addAll(single.items());
+			submitted.add(op);
+			state.remaining.remove(0);
+		}
+		// Every outstanding op was submitted without an envelope-level error. Now classify the
+		// item-level outcomes just like the batch path does.
+		BulkItemClassification c = classifyItems(indexName, items, submitted);
+		if (c.hasPermanentFailures()) {
+			throw new RuntimeException(buildPermanentFailureMessage(
+					attemptFailureSummary(indexName, totalOps, c), c.permanentSamples));
+		}
+		if (c.retryableItems.isEmpty()) {
+			return;
+		}
+		logRetryableAttempt(indexName, state, c, submitted.size());
+		state.advanceTo(c.nextRemaining, c.retryableItems);
+		throw new RetryException(attemptFailureSummary(indexName, totalOps, c));
+	}
+
+	/**
+	 * Partitions bulk response items into (ok, retryable, permanent), emits an ERROR log per
+	 * permanent failure, and captures up to {@link #MAX_FAILURE_SAMPLES} descriptors for the
+	 * exception message. The returned classification is the input to the caller's retry decision.
+	 * {@code items} and {@code ops} must be the same length and aligned by index.
+	 */
+	private BulkItemClassification classifyItems(String indexName, List<BulkResponseItem> items,
+			List<BulkOperation> ops) {
+		BulkItemClassification c = new BulkItemClassification();
 		for (int i = 0; i < items.size(); i++) {
 			BulkResponseItem item = items.get(i);
 			if (item.error() == null) {
 				continue;
 			}
 			if (isRetryableItemStatus(item.status())) {
-				retryableItems.add(item);
-				nextRemaining.add(state.remaining.get(i));
+				c.retryableItems.add(item);
+				c.nextRemaining.add(ops.get(i));
 			} else {
-				permanentFailures++;
+				c.permanentFailures++;
 				String descriptor = describeBulkItemFailure(item);
 				LOG.error("Bulk index item failed in {}: {}", indexName, descriptor);
-				if (permanentSamples.size() < MAX_FAILURE_SAMPLES) {
-					permanentSamples.add(descriptor);
+				if (c.permanentSamples.size() < MAX_FAILURE_SAMPLES) {
+					c.permanentSamples.add(descriptor);
 				}
 			}
 		}
+		return c;
+	}
 
-		int totalFailures = retryableItems.size() + permanentFailures;
-		String summary = String.format(
-				"Bulk index to %s failed: %d document(s) rejected out of %d (%d retryable, %d permanent)",
-				indexName, totalFailures, totalOps, retryableItems.size(), permanentFailures);
-
-		if (permanentFailures > 0) {
-			throw new RuntimeException(buildPermanentFailureMessage(summary, permanentSamples));
-		}
-
-		// Only transient failures remain. Log one WARN per attempt (not per item) so sustained
-		// throttling doesn't explode log volume; per-item ERROR descriptors are emitted only if
-		// retries are ultimately exhausted.
+	/**
+	 * One WARN per attempt (not per item) so sustained throttling does not explode log volume;
+	 * per-item ERROR descriptors are emitted only if retries are ultimately exhausted.
+	 */
+	private void logRetryableAttempt(String indexName, BulkRetryState state,
+			BulkItemClassification c, int attemptSize) {
 		LOG.warn("Bulk index attempt {}/{} for {}: {} retryable of {}; backing off",
-				state.attempt, BULK_INDEX_MAX_RETRIES, indexName, retryableItems.size(), state.remaining.size());
-		state.advanceTo(nextRemaining, retryableItems);
-		throw new RetryException(summary);
+				state.attempt, BULK_INDEX_MAX_RETRIES, indexName, c.retryableItems.size(), attemptSize);
+	}
+
+	private static String attemptFailureSummary(String indexName, int totalOps, BulkItemClassification c) {
+		int totalFailures = c.retryableItems.size() + c.permanentFailures;
+		return String.format(
+				"Bulk index to %s failed: %d document(s) rejected out of %d (%d retryable, %d permanent)",
+				indexName, totalFailures, totalOps, c.retryableItems.size(), c.permanentFailures);
 	}
 
 	/**
@@ -389,11 +510,27 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		}
 	}
 
+	/** Output of {@link #classifyItems} — used by both the batch and per-document paths. */
+	private static final class BulkItemClassification {
+		final List<BulkOperation> nextRemaining = new ArrayList<>();
+		final List<BulkResponseItem> retryableItems = new ArrayList<>();
+		final List<String> permanentSamples = new ArrayList<>();
+		int permanentFailures;
+
+		boolean hasPermanentFailures() {
+			return permanentFailures > 0;
+		}
+	}
+
 	/** Mutable state threaded through {@link #attemptBulk} across retry iterations. */
 	private static final class BulkRetryState {
 		final List<BulkOperation> remaining;
 		final List<BulkResponseItem> lastRetryableItems = new ArrayList<>();
 		int attempt;
+		// Flips true the first time a batch returns with only retryable (429/5xx) failures.
+		// Once set, every subsequent attempt submits one op per bulk request so a single slow
+		// shard doesn't cause the whole batch to be rejected again.
+		boolean perDocumentMode;
 
 		BulkRetryState(List<BulkOperation> operations) {
 			this.remaining = new ArrayList<>(operations);

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -111,7 +111,7 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	// instead of bouncing the whole change message back to SQS on every partial failure.
 	// Non-final so unit tests can lower the values and avoid real-wall-clock sleeps.
 	static int BULK_INDEX_MAX_RETRIES = 10;
-	static long BULK_INDEX_INITIAL_BACKOFF_MS = 1000L;
+	static long BULK_INDEX_INITIAL_BACKOFF_MS = 10000L;
 
 	private static final String SYSTEM_FIELD_ROW_ID = "_row_id";
 	private static final String SYSTEM_FIELD_ROW_VERSION = "_row_version";

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -107,7 +107,7 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	static final String TRUNCATION_MARKER = "...[truncated]";
 
 	// Intra-batch retry for transient AOSS rejections (429 / 5xx on a subset of items).
-	// Resubmit only the failed subset with exponential backoff so the batch can drain
+	// Resubmit only the incomplete subset with exponential backoff so the batch can drain
 	// instead of bouncing the whole change message back to SQS on every partial failure.
 	// Non-final so unit tests can lower the values and avoid real-wall-clock sleeps.
 	static int BULK_INDEX_MAX_RETRIES = 10;
@@ -343,20 +343,29 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 			return 0L;
 		}
 		final int totalOps = operations.size();
-		final BulkRetryState state = new BulkRetryState(operations);
+		// Ops still needing to be submitted. Attempt 1 sends the whole list as one bulk request;
+		// later attempts iterate this list and send each op as its own single-op bulk request
+		// so a single slow shard can't reject the whole batch.
+		final List<BulkOperation> incomplete = new ArrayList<>(operations);
+		// Most recent classification's retryable items — used for final ERROR-per-item diagnostics
+		// when retries are exhausted.
+		final List<BulkResponseItem> lastRetryable = new ArrayList<>();
+		final int[] attempt = {0};
 
 		try {
-			return TimeUtils.waitForExponentialMaxRetry(BULK_INDEX_MAX_RETRIES, BULK_INDEX_INITIAL_BACKOFF_MS,
-					() -> attemptBulk(indexName, state, totalOps));
+			TimeUtils.waitForExponentialMaxRetry(BULK_INDEX_MAX_RETRIES, BULK_INDEX_INITIAL_BACKOFF_MS, () -> {
+				attempt[0]++;
+				runAttempt(indexName, totalOps, attempt[0], incomplete, lastRetryable);
+				return Boolean.TRUE;
+			});
+			return totalOps;
 		} catch (RetryException e) {
-			// Retries exhausted. Emit per-item ERROR descriptors for the last attempt's failures so
-			// per-doc diagnostics remain in the logs when we surface the recoverable error.
-			for (BulkResponseItem item : state.lastRetryableItems) {
+			for (BulkResponseItem item : lastRetryable) {
 				LOG.error("Bulk index item failed in {}: {}", indexName, describeBulkItemFailure(item));
 			}
 			throw new RecoverableMessageException(String.format(
 					"Bulk index to %s failed after %d attempts: %d document(s) still retryable out of %d",
-					indexName, BULK_INDEX_MAX_RETRIES, state.lastRetryableItems.size(), totalOps),
+					indexName, BULK_INDEX_MAX_RETRIES, incomplete.size(), totalOps),
 					e.getCause());
 		} catch (RuntimeException e) {
 			throw e;
@@ -366,78 +375,56 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	}
 
 	/**
-	 * Runs a single retry iteration. Dispatches to either the batch or per-document path based on
-	 * {@link BulkRetryState#perDocumentMode}. Returns {@code totalOps} when the attempt fully
-	 * succeeds; throws {@link RuntimeException} for a permanent failure (no further retries);
-	 * throws {@link RetryException} when only transient failures remain so
+	 * Runs one retry iteration. Attempt 1 submits {@code incomplete} as a single bulk request;
+	 * later attempts submit each op in {@code incomplete} as its own single-op bulk request.
+	 * Mutates {@code incomplete} and {@code lastRetryable} in place to reflect the set of ops
+	 * still incomplete after this attempt. Returns normally when everything has been indexed, throws
+	 * {@link RuntimeException} on any permanent failure, or throws {@link RetryException} so
 	 * {@link TimeUtils#waitForExponentialMaxRetry} backs off and invokes us again.
 	 */
-	private long attemptBulk(String indexName, BulkRetryState state, int totalOps) throws RetryException {
-		state.attempt++;
-		if (state.perDocumentMode) {
-			attemptPerDocument(indexName, state, totalOps);
+	private void runAttempt(String indexName, int totalOps, int attempt,
+			List<BulkOperation> incomplete, List<BulkResponseItem> lastRetryable) throws RetryException {
+		List<BulkResponseItem> items;
+		List<BulkOperation> opsSubmitted;
+		if (attempt == 1) {
+			BulkResponse response = executeBulk(indexName, incomplete);
+			if (!response.errors()) {
+				incomplete.clear();
+				lastRetryable.clear();
+				return;
+			}
+			items = response.items();
+			opsSubmitted = new ArrayList<>(incomplete);
+			incomplete.clear();
 		} else {
-			attemptBatch(indexName, state, totalOps);
+			// Per-op: remove each op from `incomplete` only AFTER executeBulk returns. If
+			// executeBulk throws an envelope RetryException mid-iteration, the current op + any
+			// not-yet-iterated ops remain in `incomplete` so the next attempt resubmits them
+			// without reprocessing the ops that already landed.
+			items = new ArrayList<>(incomplete.size());
+			opsSubmitted = new ArrayList<>(incomplete.size());
+			while (!incomplete.isEmpty()) {
+				BulkOperation op = incomplete.get(0);
+				BulkResponse single = executeBulk(indexName, Collections.singletonList(op));
+				items.addAll(single.items());
+				opsSubmitted.add(op);
+				incomplete.remove(0);
+			}
 		}
-		return (long) totalOps;
-	}
 
-	/** Submits all outstanding ops in a single bulk request and decides what happens next. */
-	private void attemptBatch(String indexName, BulkRetryState state, int totalOps) throws RetryException {
-		BulkResponse response = executeBulk(indexName, state.remaining);
-		// Per the OpenSearch bulk API contract, errors=false means every item succeeded.
-		// https://opensearch.org/blog/error-logs/error-log-bulkindexerror-the-batch-failure/
-		if (!response.errors()) {
-			return;
-		}
-		BulkItemClassification c = classifyItems(indexName, response.items(), state.remaining);
+		BulkItemClassification c = classifyItems(indexName, items, opsSubmitted);
 		if (c.hasPermanentFailures()) {
 			throw new RuntimeException(buildPermanentFailureMessage(
 					attemptFailureSummary(indexName, totalOps, c), c.permanentSamples));
 		}
-		// Only retryable failures. Flip to per-document mode so the next attempt (and all
-		// subsequent ones within this bulkIndex call) submit one op per request — a single
-		// slow shard should not cause the whole batch to be rejected again.
-		logRetryableAttempt(indexName, state, c, state.remaining.size());
-		LOG.warn("Switching bulk index to {} to per-document mode for remaining {} document(s)",
-				indexName, c.retryableItems.size());
-		state.perDocumentMode = true;
-		state.advanceTo(c.nextRemaining, c.retryableItems);
-		throw new RetryException(attemptFailureSummary(indexName, totalOps, c));
-	}
-
-	/**
-	 * Submits each outstanding op in its own single-item bulk request, removing each from
-	 * {@link BulkRetryState#remaining} as soon as the client returns. If any request throws
-	 * a retryable envelope-level error, {@code state.remaining} already holds exactly the ops
-	 * that were never submitted — the next attempt picks up there without resubmitting the ones
-	 * that already landed.
-	 */
-	private void attemptPerDocument(String indexName, BulkRetryState state, int totalOps) throws RetryException {
-		List<BulkResponseItem> items = new ArrayList<>(state.remaining.size());
-		List<BulkOperation> submitted = new ArrayList<>(state.remaining.size());
-		while (!state.remaining.isEmpty()) {
-			BulkOperation op = state.remaining.get(0);
-			// executeBulk may throw RetryException (envelope 429/5xx, IOException) or
-			// RuntimeException (envelope 4xx). Either propagates; nothing else to do here
-			// because the loop already advanced state.remaining past the ops it finished.
-			BulkResponse single = executeBulk(indexName, Collections.singletonList(op));
-			items.addAll(single.items());
-			submitted.add(op);
-			state.remaining.remove(0);
-		}
-		// Every outstanding op was submitted without an envelope-level error. Now classify the
-		// item-level outcomes just like the batch path does.
-		BulkItemClassification c = classifyItems(indexName, items, submitted);
-		if (c.hasPermanentFailures()) {
-			throw new RuntimeException(buildPermanentFailureMessage(
-					attemptFailureSummary(indexName, totalOps, c), c.permanentSamples));
-		}
-		if (c.retryableItems.isEmpty()) {
+		incomplete.addAll(c.nextRemaining);
+		lastRetryable.clear();
+		lastRetryable.addAll(c.retryableItems);
+		if (incomplete.isEmpty()) {
 			return;
 		}
-		logRetryableAttempt(indexName, state, c, submitted.size());
-		state.advanceTo(c.nextRemaining, c.retryableItems);
+		LOG.warn("Bulk index attempt {}/{} for {}: {} retryable of {}; backing off",
+				attempt, BULK_INDEX_MAX_RETRIES, indexName, c.retryableItems.size(), opsSubmitted.size());
 		throw new RetryException(attemptFailureSummary(indexName, totalOps, c));
 	}
 
@@ -468,16 +455,6 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 			}
 		}
 		return c;
-	}
-
-	/**
-	 * One WARN per attempt (not per item) so sustained throttling does not explode log volume;
-	 * per-item ERROR descriptors are emitted only if retries are ultimately exhausted.
-	 */
-	private void logRetryableAttempt(String indexName, BulkRetryState state,
-			BulkItemClassification c, int attemptSize) {
-		LOG.warn("Bulk index attempt {}/{} for {}: {} retryable of {}; backing off",
-				state.attempt, BULK_INDEX_MAX_RETRIES, indexName, c.retryableItems.size(), attemptSize);
 	}
 
 	private static String attemptFailureSummary(String indexName, int totalOps, BulkItemClassification c) {
@@ -519,28 +496,6 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 
 		boolean hasPermanentFailures() {
 			return permanentFailures > 0;
-		}
-	}
-
-	/** Mutable state threaded through {@link #attemptBulk} across retry iterations. */
-	private static final class BulkRetryState {
-		final List<BulkOperation> remaining;
-		final List<BulkResponseItem> lastRetryableItems = new ArrayList<>();
-		int attempt;
-		// Flips true the first time a batch returns with only retryable (429/5xx) failures.
-		// Once set, every subsequent attempt submits one op per bulk request so a single slow
-		// shard doesn't cause the whole batch to be rejected again.
-		boolean perDocumentMode;
-
-		BulkRetryState(List<BulkOperation> operations) {
-			this.remaining = new ArrayList<>(operations);
-		}
-
-		void advanceTo(List<BulkOperation> nextRemaining, List<BulkResponseItem> retryableItems) {
-			remaining.clear();
-			remaining.addAll(nextRemaining);
-			lastRetryableItems.clear();
-			lastRetryableItems.addAll(retryableItems);
 		}
 	}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -111,7 +111,7 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	// instead of bouncing the whole change message back to SQS on every partial failure.
 	// Non-final so unit tests can lower the values and avoid real-wall-clock sleeps.
 	static int BULK_INDEX_MAX_RETRIES = 10;
-	static long BULK_INDEX_INITIAL_BACKOFF_MS = 10000L;
+	static long BULK_INDEX_INITIAL_BACKOFF_MS = 1000L;
 
 	private static final String SYSTEM_FIELD_ROW_ID = "_row_id";
 	private static final String SYSTEM_FIELD_ROW_VERSION = "_row_version";

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -622,7 +622,7 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	}
 
 	@SuppressWarnings("rawtypes")
-	private SearchQueryResults callSearchApi(String indexName, BoolQuery.Builder boolBuilder,
+	SearchQueryResults callSearchApi(String indexName, BoolQuery.Builder boolBuilder,
 			int offset, int limit, Map<String, Aggregation> aggregations,
 			Map<String, HighlightField> highlightFields, List<String> returnFields,
 			List<SortOptions> sortOptions, Map<String, String> idToName,
@@ -636,8 +636,10 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 				req.from(offset);
 				// size=0 when hits aren't requested — saves source fetch + transport cost
 				req.size(returnHits ? limit : 0);
-				// Disable total-hit tracking when the caller doesn't need the count
-				if (!returnTotalHits) {
+				if (returnTotalHits) {
+					// Use a count value instead of enabled(true) — the boolean form caps at 10k
+					req.trackTotalHits(t -> t.count(Integer.MAX_VALUE));
+				} else {
 					req.trackTotalHits(t -> t.enabled(false));
 				}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -79,6 +79,8 @@ import org.sagebionetworks.repo.model.search.table.TextAnalyzer;
 import org.sagebionetworks.repo.model.search.table.TextAnalyzerSettings;
 import org.sagebionetworks.repo.model.search.KeyRange;
 import org.sagebionetworks.repo.model.search.KeyValues;
+import org.sagebionetworks.util.RetryException;
+import org.sagebionetworks.util.TimeUtils;
 import org.sagebionetworks.util.ValidateArgument;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
 
@@ -103,6 +105,13 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	static final int MAX_FAILURE_SAMPLES = 5;
 	static final int MAX_BULK_ERROR_MESSAGE_CHARS = 2500;
 	static final String TRUNCATION_MARKER = "...[truncated]";
+
+	// Intra-batch retry for transient AOSS rejections (429 / 5xx on a subset of items).
+	// Resubmit only the failed subset with exponential backoff so the batch can drain
+	// instead of bouncing the whole change message back to SQS on every partial failure.
+	// Non-final so unit tests can lower the values and avoid real-wall-clock sleeps.
+	static int BULK_INDEX_MAX_RETRIES = 10;
+	static long BULK_INDEX_INITIAL_BACKOFF_MS = 1000L;
 
 	private static final String SYSTEM_FIELD_ROW_ID = "_row_id";
 	private static final String SYSTEM_FIELD_ROW_VERSION = "_row_version";
@@ -276,53 +285,125 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		if (operations.isEmpty()) {
 			return 0L;
 		}
+		final int totalOps = operations.size();
+		final BulkRetryState state = new BulkRetryState(operations);
 
 		try {
-			BulkResponse response = openSearchClient.bulk(
-					BulkRequest.of(req -> req.operations(operations)));
-
-			// Per the OpenSearch bulk API contract, errors=false means every item succeeded —
-			// skip iterating items in that case.
-			// https://opensearch.org/blog/error-logs/error-log-bulkindexerror-the-batch-failure/
-			if (!response.errors()) {
-				return (long) response.items().size();
+			return TimeUtils.waitForExponentialMaxRetry(BULK_INDEX_MAX_RETRIES, BULK_INDEX_INITIAL_BACKOFF_MS,
+					() -> attemptBulk(indexName, state, totalOps));
+		} catch (RetryException e) {
+			// Retries exhausted. Emit per-item ERROR descriptors for the last attempt's failures so
+			// per-doc diagnostics remain in the logs when we surface the recoverable error.
+			for (BulkResponseItem item : state.lastRetryableItems) {
+				LOG.error("Bulk index item failed in {}: {}", indexName, describeBulkItemFailure(item));
 			}
-			int retryableFailures = 0;
-			int permanentFailures = 0;
-			List<String> permanentSamples = new ArrayList<>();
-			for (var item : response.items()) {
-				if (item.error() == null) {
-					continue;
-				}
+			throw new RecoverableMessageException(String.format(
+					"Bulk index to %s failed after %d attempts: %d document(s) still retryable out of %d",
+					indexName, BULK_INDEX_MAX_RETRIES, state.lastRetryableItems.size(), totalOps),
+					e.getCause());
+		} catch (RuntimeException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to bulk index to search index: " + indexName, e);
+		}
+	}
+
+	/**
+	 * Submits the currently-outstanding operations once. Returns the total success count if the
+	 * attempt fully succeeds; throws {@link RuntimeException} for any permanent failure (no
+	 * further retries); throws {@link RetryException} when only transient failures remain so
+	 * {@link TimeUtils#waitForExponentialMaxRetry} backs off and re-invokes with the trimmed
+	 * subset of still-failing operations.
+	 */
+	private long attemptBulk(String indexName, BulkRetryState state, int totalOps) throws RetryException {
+		state.attempt++;
+		BulkResponse response = executeBulk(indexName, state.remaining);
+
+		// Per the OpenSearch bulk API contract, errors=false means every item succeeded.
+		// https://opensearch.org/blog/error-logs/error-log-bulkindexerror-the-batch-failure/
+		if (!response.errors()) {
+			return (long) totalOps;
+		}
+
+		List<BulkOperation> nextRemaining = new ArrayList<>();
+		List<BulkResponseItem> retryableItems = new ArrayList<>();
+		List<String> permanentSamples = new ArrayList<>();
+		int permanentFailures = 0;
+		List<BulkResponseItem> items = response.items();
+		for (int i = 0; i < items.size(); i++) {
+			BulkResponseItem item = items.get(i);
+			if (item.error() == null) {
+				continue;
+			}
+			if (isRetryableItemStatus(item.status())) {
+				retryableItems.add(item);
+				nextRemaining.add(state.remaining.get(i));
+			} else {
+				permanentFailures++;
 				String descriptor = describeBulkItemFailure(item);
 				LOG.error("Bulk index item failed in {}: {}", indexName, descriptor);
-				if (isRetryableItemStatus(item.status())) {
-					retryableFailures++;
-				} else {
-					permanentFailures++;
-					if (permanentSamples.size() < MAX_FAILURE_SAMPLES) {
-						permanentSamples.add(descriptor);
-					}
+				if (permanentSamples.size() < MAX_FAILURE_SAMPLES) {
+					permanentSamples.add(descriptor);
 				}
 			}
+		}
 
-			int totalFailures = retryableFailures + permanentFailures;
-			String summary = String.format(
-					"Bulk index to %s failed: %d document(s) rejected out of %d (%d retryable, %d permanent)",
-					indexName, totalFailures, operations.size(), retryableFailures, permanentFailures);
-			if (permanentFailures == 0) {
-				throw new RecoverableMessageException(summary);
-			}
+		int totalFailures = retryableItems.size() + permanentFailures;
+		String summary = String.format(
+				"Bulk index to %s failed: %d document(s) rejected out of %d (%d retryable, %d permanent)",
+				indexName, totalFailures, totalOps, retryableItems.size(), permanentFailures);
+
+		if (permanentFailures > 0) {
 			throw new RuntimeException(buildPermanentFailureMessage(summary, permanentSamples));
+		}
+
+		// Only transient failures remain. Log one WARN per attempt (not per item) so sustained
+		// throttling doesn't explode log volume; per-item ERROR descriptors are emitted only if
+		// retries are ultimately exhausted.
+		LOG.warn("Bulk index attempt {}/{} for {}: {} retryable of {}; backing off",
+				state.attempt, BULK_INDEX_MAX_RETRIES, indexName, retryableItems.size(), state.remaining.size());
+		state.advanceTo(nextRemaining, retryableItems);
+		throw new RetryException(summary);
+	}
+
+	/**
+	 * Executes a single bulk request. Envelope-level 429/5xx and IOExceptions are translated to
+	 * {@link RetryException} so the outer retry loop backs off; envelope-level 4xx becomes a
+	 * permanent {@link RuntimeException}.
+	 */
+	private BulkResponse executeBulk(String indexName, List<BulkOperation> ops) throws RetryException {
+		// Snapshot the list so the BulkRequest isn't mutated when retry state is advanced in place
+		// between attempts.
+		List<BulkOperation> snapshot = new ArrayList<>(ops);
+		try {
+			return openSearchClient.bulk(BulkRequest.of(req -> req.operations(snapshot)));
 		} catch (OpenSearchException e) {
 			String detail = "Failed to bulk index to search index: " + indexName
 					+ " (" + describeError(e.error()) + ")";
 			if (isRetryableItemStatus(e.status())) {
-				throw new RecoverableMessageException(detail, e);
+				throw new RetryException(detail, e);
 			}
 			throw new RuntimeException(detail, e);
 		} catch (IOException e) {
-			throw new RecoverableMessageException("Failed to bulk index to search index: " + indexName, e);
+			throw new RetryException("Failed to bulk index to search index: " + indexName, e);
+		}
+	}
+
+	/** Mutable state threaded through {@link #attemptBulk} across retry iterations. */
+	private static final class BulkRetryState {
+		final List<BulkOperation> remaining;
+		final List<BulkResponseItem> lastRetryableItems = new ArrayList<>();
+		int attempt;
+
+		BulkRetryState(List<BulkOperation> operations) {
+			this.remaining = new ArrayList<>(operations);
+		}
+
+		void advanceTo(List<BulkOperation> nextRemaining, List<BulkResponseItem> retryableItems) {
+			remaining.clear();
+			remaining.addAll(nextRemaining);
+			lastRetryableItems.clear();
+			lastRetryableItems.addAll(retryableItems);
 		}
 	}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManager.java
@@ -7,7 +7,6 @@ import org.sagebionetworks.repo.model.table.TableFailedException;
 import org.sagebionetworks.repo.model.table.TableUnavailableException;
 import org.sagebionetworks.util.progress.ProgressCallback;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
-import org.sagebionetworks.workers.util.semaphore.LockUnavilableException;
 
 /**
  * Manager for search index lifecycle operations (create, update, delete).
@@ -24,8 +23,7 @@ public interface SearchIndexLifecycleManager {
 	 * @param entityId         The SearchIndex entity ID
 	 * @param userId           The user who triggered the change
 	 */
-	void handleCreate(ProgressCallback progressCallback, String entityId, Long userId)
-			throws RecoverableMessageException, TableUnavailableException, TableFailedException, LockUnavilableException;
+	void handleCreate(ProgressCallback progressCallback, String entityId, Long userId) throws Exception;
 
 	/**
 	 * Handle an update event for a SearchIndex entity. Unconditionally deletes and rebuilds
@@ -35,17 +33,16 @@ public interface SearchIndexLifecycleManager {
 	 * @param entityId         The SearchIndex entity ID
 	 * @param userId           The user who triggered the change
 	 */
-	void handleUpdate(ProgressCallback progressCallback, String entityId, Long userId)
-			throws RecoverableMessageException, TableUnavailableException, TableFailedException, LockUnavilableException;
+	void handleUpdate(ProgressCallback progressCallback, String entityId, Long userId) throws Exception;
 
 	/**
-	 * Handle a delete event for a SearchIndex entity. If the index is currently being built
-	 * (CREATING), throws RecoverableMessageException to retry later. Otherwise deletes the
-	 * AOSS index and the status row.
+	 * Handle a delete event for a SearchIndex entity. Acquires the per-entity write lock
+	 * to serialize with any concurrent build, then deletes the AOSS index and the status row.
 	 *
-	 * @param entityId The SearchIndex entity ID
+	 * @param progressCallback Progress callback used to hold the per-entity lock
+	 * @param entityId         The SearchIndex entity ID
 	 */
-	void handleDelete(String entityId) throws RecoverableMessageException;
+	void handleDelete(ProgressCallback progressCallback, String entityId) throws Exception;
 
 	/**
 	 * Resolve every SELECT-list column in {@code definingSql} — including literals

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
@@ -236,17 +236,8 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 					.withRunCount(true)
 					.withReturnSelectColumns(false)
 					.withReturnFacets(false);
-			QueryResultBundle countResult;
-			try {
-				countResult = tableQueryManager.querySinglePage(
-						progressCallback, anonymousUser, query, countOnly);
-			} catch (RuntimeException e) {
-				if (e.getCause() instanceof LockUnavilableException) {
-					throw (LockUnavilableException) e.getCause();
-				}
-				throw e;
-			}
-
+			QueryResultBundle countResult = tableQueryManager.querySinglePage(
+					progressCallback, anonymousUser, query, countOnly);
 			Long rowCount = countResult.getQueryCount();
 			if (rowCount != null && rowCount > MAX_ROWS) {
 				throw new IllegalStateException(
@@ -263,17 +254,11 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 			}
 			openSearchManager.createIndex(indexName, selectedColumns, defaultAnalyzer,
 					synonymSets, overrides, analyzers);
-			try {
-				tableQueryManager.runQueryAsStream(progressCallback, anonymousUser, query,
-						(QueryTranslations translations) -> new SearchIndexRowHandler(
-								indexName, selectColumns, openSearchManager),
-						ACCESS_TYPE.READ);
-			} catch (RuntimeException e) {
-				if (e.getCause() instanceof LockUnavilableException) {
-					throw (LockUnavilableException) e.getCause();
-				}
-				throw e;
-			}
+
+			tableQueryManager.runQueryAsStream(progressCallback, anonymousUser, query,
+					(QueryTranslations translations) -> new SearchIndexRowHandler(
+							indexName, selectColumns, openSearchManager),
+					ACCESS_TYPE.READ);
 
 			statusDao.createOrUpdate(new SearchIndexStatus()
 					.setSearchIndexId(entityId)
@@ -294,6 +279,15 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 				throw new RecoverableMessageException(
 						"Concurrent delete in progress while building search index for entity "
 								+ entityId, e);
+			}
+			// Defensive: a LockUnavilableException wrapped inside another exception is
+			// still a transient writer-contention signal, not a build defect. Surface
+			// the original so the worker re-queues the message instead of marking the
+			// SearchIndex permanently FAILED.
+			if (e.getCause() instanceof LockUnavilableException) {
+				LockUnavilableException lockEx = (LockUnavilableException) e.getCause();
+				LOG.warn("Lock unavailable for entity {}, retrying: {}", entityId, lockEx.getMessage());
+				throw lockEx;
 			}
 			LOG.error("Failed to build search index for entity: " + entityId, e);
 			String errorMessage = e.getMessage();

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
@@ -236,8 +236,17 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 					.withRunCount(true)
 					.withReturnSelectColumns(false)
 					.withReturnFacets(false);
-			QueryResultBundle countResult = tableQueryManager.querySinglePage(
-					progressCallback, anonymousUser, query, countOnly);
+			QueryResultBundle countResult;
+			try {
+				countResult = tableQueryManager.querySinglePage(
+						progressCallback, anonymousUser, query, countOnly);
+			} catch (RuntimeException e) {
+				if (e.getCause() instanceof LockUnavilableException) {
+					throw (LockUnavilableException) e.getCause();
+				}
+				throw e;
+			}
+
 			Long rowCount = countResult.getQueryCount();
 			if (rowCount != null && rowCount > MAX_ROWS) {
 				throw new IllegalStateException(
@@ -254,11 +263,17 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 			}
 			openSearchManager.createIndex(indexName, selectedColumns, defaultAnalyzer,
 					synonymSets, overrides, analyzers);
-
-			tableQueryManager.runQueryAsStream(progressCallback, anonymousUser, query,
-					(QueryTranslations translations) -> new SearchIndexRowHandler(
-							indexName, selectColumns, openSearchManager),
-					ACCESS_TYPE.READ);
+			try {
+				tableQueryManager.runQueryAsStream(progressCallback, anonymousUser, query,
+						(QueryTranslations translations) -> new SearchIndexRowHandler(
+								indexName, selectColumns, openSearchManager),
+						ACCESS_TYPE.READ);
+			} catch (RuntimeException e) {
+				if (e.getCause() instanceof LockUnavilableException) {
+					throw (LockUnavilableException) e.getCause();
+				}
+				throw e;
+			}
 
 			statusDao.createOrUpdate(new SearchIndexStatus()
 					.setSearchIndexId(entityId)

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
@@ -73,7 +73,7 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 	private static final String INDEX_PREFIX = "search-index-";
 	private static final String LOCK_KEY_PREFIX = "search-index-build:";
 	private static final int MAX_ERROR_MESSAGE_LENGTH = 3000;
-	private static final int BATCH_SIZE = 100;
+	private static final int BATCH_SIZE = 1000;
 	private static final long MAX_ROWS = 500_000L;
 	private static final ObjectMapper SEARCH_DOC_MAPPER = new ObjectMapper();
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
@@ -53,6 +53,9 @@ import org.sagebionetworks.util.ValidateArgument;
 import org.sagebionetworks.util.progress.ProgressCallback;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
 import org.sagebionetworks.workers.util.semaphore.LockUnavilableException;
+import org.sagebionetworks.workers.util.semaphore.WriteLock;
+import org.sagebionetworks.workers.util.semaphore.WriteLockRequest;
+import org.sagebionetworks.workers.util.semaphore.WriteReadSemaphore;
 import org.springframework.stereotype.Service;
 
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
@@ -68,6 +71,7 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 
 	private static final Logger LOG = LogManager.getLogger(SearchIndexLifecycleManagerImpl.class);
 	private static final String INDEX_PREFIX = "search-index-";
+	private static final String LOCK_KEY_PREFIX = "search-index-build:";
 	private static final int MAX_ERROR_MESSAGE_LENGTH = 3000;
 	private static final int BATCH_SIZE = 1000;
 	private static final long MAX_ROWS = 500_000L;
@@ -115,6 +119,7 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 	private final TextAnalyzerDao textAnalyzerDao;
 	private final TableManagerSupport tableManagerSupport;
 	private final ColumnModelManager columnModelManager;
+	private final WriteReadSemaphore writeReadSemaphore;
 
 	public SearchIndexLifecycleManagerImpl(ConnectionFactory connectionFactory,
 			OpenSearchManager openSearchManager,
@@ -124,7 +129,8 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 			SynonymSetDao synonymSetDao, ColumnAnalyzerOverrideDao columnAnalyzerOverrideDao,
 			TextAnalyzerDao textAnalyzerDao,
 			TableManagerSupport tableManagerSupport,
-			ColumnModelManager columnModelManager) {
+			ColumnModelManager columnModelManager,
+			WriteReadSemaphore writeReadSemaphore) {
 		this.connectionFactory = connectionFactory;
 		this.openSearchManager = openSearchManager;
 		this.searchConfigurationResolver = searchConfigurationResolver;
@@ -136,6 +142,7 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 		this.textAnalyzerDao = textAnalyzerDao;
 		this.tableManagerSupport = tableManagerSupport;
 		this.columnModelManager = columnModelManager;
+		this.writeReadSemaphore = writeReadSemaphore;
 	}
 
 	@Override
@@ -160,23 +167,35 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 	}
 
 	@Override
-	public void handleCreate(ProgressCallback progressCallback, String entityId, Long userId)
-			throws RecoverableMessageException, TableUnavailableException, TableFailedException, LockUnavilableException {
-		buildIndex(progressCallback, entityId, userId, true);
+	public void handleCreate(ProgressCallback progressCallback, String entityId, Long userId) throws Exception {
+		ValidateArgument.required(entityId, "entityId");
+		ValidateArgument.required(userId, "userId");
+		try (WriteLock lock = writeReadSemaphore.getWriteLock(
+				new WriteLockRequest(progressCallback, "SearchIndexLifecycleManager.buildIndex", LOCK_KEY_PREFIX + entityId))) {
+			buildIndex(progressCallback, entityId, userId, true);
+		} catch (LockUnavilableException e) {
+			throw new RecoverableMessageException(
+					"Search index " + entityId + " is already being built by another worker", e);
+		}
 	}
 
 	@Override
-	public void handleUpdate(ProgressCallback progressCallback, String entityId, Long userId)
-			throws RecoverableMessageException, TableUnavailableException, TableFailedException, LockUnavilableException {
-		// In the MVP updates are unconditionally replacing the index on all changes regardless of what the change is.
-		buildIndex(progressCallback, entityId, userId, true);
+	public void handleUpdate(ProgressCallback progressCallback, String entityId, Long userId) throws Exception {
+		ValidateArgument.required(entityId, "entityId");
+		ValidateArgument.required(userId, "userId");
+		try (WriteLock lock = writeReadSemaphore.getWriteLock(
+				new WriteLockRequest(progressCallback, "SearchIndexLifecycleManager.buildIndex", LOCK_KEY_PREFIX + entityId))) {
+			// In the MVP updates are unconditionally replacing the index on all changes regardless of what the change is.
+			buildIndex(progressCallback, entityId, userId, true);
+		} catch (LockUnavilableException e) {
+			throw new RecoverableMessageException(
+					"Search index " + entityId + " is already being built by another worker", e);
+		}
 	}
 
 	private void buildIndex(ProgressCallback progressCallback, String entityId, Long userId,
 			boolean deleteExistingFirst)
-			throws RecoverableMessageException, TableUnavailableException, TableFailedException, LockUnavilableException {
-		ValidateArgument.required(entityId, "entityId");
-		ValidateArgument.required(userId, "userId");
+			throws Exception {
 		SearchIndexStatusDao statusDao = connectionFactory.getSearchIndexStatusDao();
 		try {
 			UserInfo user = userManager.getUserInfo(userId);
@@ -244,7 +263,7 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 			statusDao.createOrUpdate(new SearchIndexStatus()
 					.setSearchIndexId(entityId)
 					.setState(SearchIndexState.ACTIVE));
-		} catch (RecoverableMessageException | TableUnavailableException | TableFailedException | LockUnavilableException e) {
+		} catch (RecoverableMessageException | TableUnavailableException | TableFailedException e) {
 			// Propagate transient/infrastructure exceptions to the worker so it can
 			// convert them into RecoverableMessageException (table unavailable / lock)
 			// or permanent failure (table failed). Do not record FAILED here — the
@@ -281,26 +300,26 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 	}
 
 	@Override
-	public void handleDelete(String entityId) throws RecoverableMessageException {
+	public void handleDelete(ProgressCallback progressCallback, String entityId) throws Exception {
 		ValidateArgument.required(entityId, "entityId");
 		Long searchIndexId = KeyFactory.stringToKey(entityId);
-		SearchIndexStatusDao statusDao = connectionFactory.getSearchIndexStatusDao();
-
-		Optional<SearchIndexState> stateOpt = statusDao.getState(searchIndexId);
-		if (stateOpt.isEmpty()) {
-			// No status row — already cleaned up, nothing to do
-			return;
-		}
-		if (stateOpt.get() == SearchIndexState.CREATING) {
-			// Cannot interrupt an in-flight build — retry the delete later.
+		try (WriteLock lock = writeReadSemaphore.getWriteLock(
+				new WriteLockRequest(progressCallback, "SearchIndexLifecycleManager.handleDelete", LOCK_KEY_PREFIX + entityId))) {
+			SearchIndexStatusDao statusDao = connectionFactory.getSearchIndexStatusDao();
+			Optional<SearchIndexState> stateOpt = statusDao.getState(searchIndexId);
+			if (stateOpt.isEmpty()) {
+				// No status row — already cleaned up, nothing to do
+				return;
+			}
+			try {
+				openSearchManager.deleteIndex(getIndexName(entityId));
+				statusDao.delete(searchIndexId);
+			} catch (Throwable e) {
+				LOG.error("Failed to delete search index for entity: " + entityId, e);
+			}
+		} catch (LockUnavilableException e) {
 			throw new RecoverableMessageException(
-					"Search index " + entityId + " is still building. Will retry delete later.");
-		}
-		try {
-			openSearchManager.deleteIndex(getIndexName(entityId));
-			statusDao.delete(searchIndexId);
-		} catch (Throwable e) {
-			LOG.error("Failed to delete search index for entity: " + entityId, e);
+					"Search index " + entityId + " is locked by another worker", e);
 		}
 	}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
@@ -255,6 +255,11 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 			openSearchManager.createIndex(indexName, selectedColumns, defaultAnalyzer,
 					synonymSets, overrides, analyzers);
 
+			// AOSS acknowledges createIndex and returns an already-queryable index before its
+			// shards are actually ready to accept writes. Block until a real sentinel write
+			// succeeds so the bulk stream below does not race against index_not_found_exception.
+			openSearchManager.waitForIndexWritable(indexName);
+
 			tableQueryManager.runQueryAsStream(progressCallback, anonymousUser, query,
 					(QueryTranslations translations) -> new SearchIndexRowHandler(
 							indexName, selectColumns, openSearchManager),

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
@@ -73,7 +73,7 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 	private static final String INDEX_PREFIX = "search-index-";
 	private static final String LOCK_KEY_PREFIX = "search-index-build:";
 	private static final int MAX_ERROR_MESSAGE_LENGTH = 3000;
-	private static final int BATCH_SIZE = 1000;
+	private static final int BATCH_SIZE = 100;
 	private static final long MAX_ROWS = 500_000L;
 	private static final ObjectMapper SEARCH_DOC_MAPPER = new ObjectMapper();
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
@@ -263,7 +263,7 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 			statusDao.createOrUpdate(new SearchIndexStatus()
 					.setSearchIndexId(entityId)
 					.setState(SearchIndexState.ACTIVE));
-		} catch (RecoverableMessageException | TableUnavailableException | TableFailedException e) {
+		} catch (RecoverableMessageException | TableUnavailableException | TableFailedException | LockUnavilableException e) {
 			// Propagate transient/infrastructure exceptions to the worker so it can
 			// convert them into RecoverableMessageException (table unavailable / lock)
 			// or permanent failure (table failed). Do not record FAILED here — the

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -533,7 +533,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 						BulkOperation.of(op -> op.index(idx -> idx
 								.index(indexName).id(sentinelDocId).document(sentinel)))));
 				return true;
-			} catch (RecoverableMessageException | RuntimeException notReady) {
+			} catch (RuntimeException notReady) {
 				return false;
 			}
 		});

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -49,8 +49,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
 public class OpenSearchManagerImplAutoWiredTest {
 
-	private static final long POLL_MAX_MS = 30_000L;
-	private static final long POLL_INTERVAL_MS = 1_000L;
+	private static final long POLL_MAX_MS = 600_000L;
+	private static final long POLL_INTERVAL_MS = 2_000L;
 
 	private static final int VALIDATE_RETRY_MAX = 10;
 	private static final long VALIDATE_RETRY_INITIAL_MS = 1_000L;
@@ -523,23 +523,23 @@ public class OpenSearchManagerImplAutoWiredTest {
 	}
 
 	// ---- Polling helpers ----
-
 	private void waitForIndexReachable() {
-		SearchQuery probe = new SearchQuery();
-		probe.setQueryType(SearchQueryType.MATCH_ALL);
-		probe.setLimit(0L);
-		probe.setOffset(0L);
+		String sentinelDocId = "__readiness_probe__";
+		Map<String, Object> sentinel = Map.of("_row_id", -1L, "_row_version", -1L);
 		boolean success = TimeUtils.waitForExponential(POLL_MAX_MS, POLL_INTERVAL_MS, null, (v) -> {
 			try {
-				openSearchManager.search(indexName, probe, Collections.emptyList(),
-						null, Collections.emptyList(), defaultAnalyzers,
-						EnumSet.of(SearchQueryPart.TOTAL_HITS));
+				openSearchManager.bulkIndex(indexName, List.of(
+						BulkOperation.of(op -> op.index(idx -> idx
+								.index(indexName).id(sentinelDocId).document(sentinel)))));
 				return true;
-			} catch (IllegalStateException notReady) {
+			} catch (RecoverableMessageException | RuntimeException notReady) {
 				return false;
 			}
 		});
-		assertTrue(success, "Timed out waiting for AOSS index " + indexName + " to become reachable");
+		assertTrue(success, "Timed out waiting for AOSS index " + indexName + " to accept writes");
+		// Remove the sentinel so subsequent search assertions don't count it as a hit.
+		openSearchManager.bulkIndex(indexName, List.of(
+				BulkOperation.of(op -> op.delete(d -> d.index(indexName).id(sentinelDocId)))));
 	}
 
 	private <T> T retryOnAossAnalyzeFlake(Callable<T> action) throws Exception {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -50,8 +50,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
 public class OpenSearchManagerImplAutoWiredTest {
 
-	private static final long POLL_MAX_MS = 600_000L;
-	private static final long POLL_INTERVAL_MS = 2_000L;
+	private static final long POLL_MAX_MS = 30_000L;
+	private static final long POLL_INTERVAL_MS = 1_000L;
 
 	private static final int VALIDATE_RETRY_MAX = 10;
 	private static final long VALIDATE_RETRY_INITIAL_MS = 1_000L;

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -35,6 +35,7 @@ import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
 import org.sagebionetworks.util.RetryException;
 import org.sagebionetworks.util.TimeUtils;
+import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -101,7 +101,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 				new ColumnModel().setId("1").setName("name").setColumnType(ColumnType.STRING));
 		openSearchManager.createIndex(indexName, columns, null,
 				Collections.emptyList(), Collections.emptyList(), defaultAnalyzers);
-		waitForIndexReachable();
+		openSearchManager.waitForIndexWritable(indexName);
 
 		// call under test
 		openSearchManager.deleteIndex(indexName);
@@ -122,7 +122,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 				new ColumnModel().setId("1").setName("name").setColumnType(ColumnType.STRING));
 		openSearchManager.createIndex(indexName, columns, null,
 				Collections.emptyList(), Collections.emptyList(), defaultAnalyzers);
-		waitForIndexReachable();
+		openSearchManager.waitForIndexWritable(indexName);
 
 		// call under test — resource_already_exists returns empty Optional
 		Optional<String> result = openSearchManager.createIndex(indexName, columns, null,
@@ -147,7 +147,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 		);
 		openSearchManager.createIndex(indexName, columns, null,
 				Collections.emptyList(), Collections.emptyList(), defaultAnalyzers);
-		waitForIndexReachable();
+		openSearchManager.waitForIndexWritable(indexName);
 
 		List<BulkOperation> operations = List.of(
 				buildBulkOp(indexName, "1", Map.of("_row_id", 1L, "_row_version", 1L, "1", "mitochondria research", "2", "42")),
@@ -195,7 +195,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 				new ColumnModel().setId("1").setName("name").setColumnType(ColumnType.STRING));
 		openSearchManager.createIndex(indexName, columns, null,
 				Collections.emptyList(), Collections.emptyList(), defaultAnalyzers);
-		waitForIndexReachable();
+		openSearchManager.waitForIndexWritable(indexName);
 
 		List<BulkOperation> operations = List.of(
 				buildBulkOp(indexName, "1", Map.of("_row_id", 1L, "_row_version", 1L, "1", "alpha")),
@@ -314,7 +314,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 
 		openSearchManager.createIndex(indexName, columns, null,
 				Collections.emptyList(), List.of(override), analyzers);
-		waitForIndexReachable();
+		openSearchManager.waitForIndexWritable(indexName);
 
 		List<BulkOperation> operations = List.of(
 				buildBulkOp(indexName, "1", Map.of("_row_id", 1L, "_row_version", 1L, "1", "BRCA1")),
@@ -339,7 +339,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 
 		openSearchManager.createIndex(indexName, columns, null,
 				Collections.emptyList(), Collections.emptyList(), analyzers);
-		waitForIndexReachable();
+		openSearchManager.waitForIndexWritable(indexName);
 
 		List<BulkOperation> operations = List.of(
 				buildBulkOp(indexName, "1", Map.of("_row_id", 1L, "_row_version", 1L, "1", "BRCA1")),
@@ -380,7 +380,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 
 		openSearchManager.createIndex(indexName, columns, null,
 				Collections.emptyList(), Collections.emptyList(), defaultAnalyzers);
-		waitForIndexReachable();
+		openSearchManager.waitForIndexWritable(indexName);
 
 		Map<String, Object> doc = new HashMap<>();
 		doc.put("_row_id", 1L);
@@ -524,24 +524,6 @@ public class OpenSearchManagerImplAutoWiredTest {
 	}
 
 	// ---- Polling helpers ----
-	private void waitForIndexReachable() {
-		String sentinelDocId = "__readiness_probe__";
-		Map<String, Object> sentinel = Map.of("_row_id", -1L, "_row_version", -1L);
-		boolean success = TimeUtils.waitForExponential(POLL_MAX_MS, POLL_INTERVAL_MS, null, (v) -> {
-			try {
-				openSearchManager.bulkIndex(indexName, List.of(
-						BulkOperation.of(op -> op.index(idx -> idx
-								.index(indexName).id(sentinelDocId).document(sentinel)))));
-				return true;
-			} catch (RuntimeException notReady) {
-				return false;
-			}
-		});
-		assertTrue(success, "Timed out waiting for AOSS index " + indexName + " to accept writes");
-		// Remove the sentinel so subsequent search assertions don't count it as a hit.
-		openSearchManager.bulkIndex(indexName, List.of(
-				BulkOperation.of(op -> op.delete(d -> d.index(indexName).id(sentinelDocId)))));
-	}
 
 	private <T> T retryOnAossAnalyzeFlake(Callable<T> action) throws Exception {
 		return TimeUtils.waitForExponentialMaxRetry(VALIDATE_RETRY_MAX, VALIDATE_RETRY_INITIAL_MS, () -> {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +47,7 @@ import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.mockito.ArgumentCaptor;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -90,11 +94,22 @@ public class OpenSearchManagerImplTest {
 	private TextAnalyzer scientific;
 	private String scientificQualifiedName;
 
+	private long originalBulkInitialBackoffMs;
+
 	@BeforeEach
 	public void setUp() {
 		scientificQualifiedName = "org.sagebionetworks-SCIENTIFIC";
 		scientific = new TextAnalyzer().setId("1")
 				.setSettings(new TextAnalyzerSettings().setTokenizer("standard"));
+		// Drop bulk-index retry backoff to 1ms in tests so retry-exhaustion paths don't
+		// actually sleep ~21s per invocation. Restored in @AfterEach.
+		originalBulkInitialBackoffMs = OpenSearchManagerImpl.BULK_INDEX_INITIAL_BACKOFF_MS;
+		OpenSearchManagerImpl.BULK_INDEX_INITIAL_BACKOFF_MS = 1L;
+	}
+
+	@AfterEach
+	public void tearDown() {
+		OpenSearchManagerImpl.BULK_INDEX_INITIAL_BACKOFF_MS = originalBulkInitialBackoffMs;
 	}
 
 	private TextAnalyzer keywordAnalyzer(String id) {
@@ -1056,9 +1071,9 @@ public class OpenSearchManagerImplTest {
 	}
 
 	@Test
-	public void testBulkIndexWithAllRetryableFailuresThrowsRecoverableMessageException() throws Exception {
+	public void testBulkIndexWithAllRetryableFailuresExhaustsRetriesAndThrowsRecoverableMessageException() throws Exception {
 		BulkResponse response = bulkResponseOf(
-				okItem("1"),
+				failedItem("1", 429, "circuit_breaking_exception", "rate limited"),
 				failedItem("2", 429, "circuit_breaking_exception", "rate limited"),
 				failedItem("3", 503, "service_unavailable", "try later"));
 		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
@@ -1068,8 +1083,12 @@ public class OpenSearchManagerImplTest {
 		RecoverableMessageException ex = assertThrows(RecoverableMessageException.class,
 				() -> manager.bulkIndex("search-index-syn1",
 						Arrays.asList(bulkOp("1"), bulkOp("2"), bulkOp("3"))));
-		assertTrue(ex.getMessage().contains("2 retryable"), ex.getMessage());
-		assertTrue(ex.getMessage().contains("0 permanent"), ex.getMessage());
+		assertTrue(ex.getMessage().contains(
+				"failed after " + OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES + " attempts"),
+				ex.getMessage());
+		assertTrue(ex.getMessage().contains("3 document(s) still retryable out of 3"), ex.getMessage());
+		verify(openSearchClient, times(OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES))
+				.bulk(argThat((BulkRequest req) -> req != null));
 	}
 
 	@Test
@@ -1093,10 +1112,10 @@ public class OpenSearchManagerImplTest {
 
 	@ParameterizedTest
 	@ValueSource(ints = {500, 502, 504})
-	public void testBulkIndexWith5xxItemStatusThrowsRecoverableMessageException(int status) throws Exception {
+	public void testBulkIndexWith5xxItemStatusExhaustsRetriesAndThrowsRecoverableMessageException(int status) throws Exception {
 		// AOSS returns 500 with type="exception" and the generic "Internal error occurred while
 		// processing request" reason when shard routing hasn't fully propagated after createIndex —
-		// classified as retryable so SQS can redeliver the change message.
+		// classified as retryable so the intra-batch retry loop backs off and resubmits the subset.
 		BulkResponse response = bulkResponseOf(
 				failedItem("1", status, "exception", "Internal error occurred while processing request"),
 				failedItem("2", status, "exception", "Internal error occurred while processing request"),
@@ -1108,8 +1127,12 @@ public class OpenSearchManagerImplTest {
 		RecoverableMessageException ex = assertThrows(RecoverableMessageException.class,
 				() -> manager.bulkIndex("search-index-syn1",
 						Arrays.asList(bulkOp("1"), bulkOp("2"), bulkOp("3"))));
-		assertTrue(ex.getMessage().contains("3 retryable"), ex.getMessage());
-		assertTrue(ex.getMessage().contains("0 permanent"), ex.getMessage());
+		assertTrue(ex.getMessage().contains(
+				"failed after " + OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES + " attempts"),
+				ex.getMessage());
+		assertTrue(ex.getMessage().contains("3 document(s) still retryable out of 3"), ex.getMessage());
+		verify(openSearchClient, times(OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES))
+				.bulk(argThat((BulkRequest req) -> req != null));
 	}
 
 	@Test
@@ -1223,7 +1246,7 @@ public class OpenSearchManagerImplTest {
 
 	@ParameterizedTest
 	@ValueSource(ints = {500, 502, 504})
-	public void testBulkIndexWithEnvelope5xxThrowsRecoverableMessageException(int status) throws Exception {
+	public void testBulkIndexWithEnvelope5xxExhaustsRetriesAndThrowsRecoverableMessageException(int status) throws Exception {
 		ErrorResponse serverError = ErrorResponse.of(e -> e
 				.error(err -> err.type("exception").reason("Internal error occurred while processing request"))
 				.status(status));
@@ -1233,10 +1256,12 @@ public class OpenSearchManagerImplTest {
 		// call under test
 		assertThrows(RecoverableMessageException.class,
 				() -> manager.bulkIndex("search-index-syn1", Arrays.asList(bulkOp("1"))));
+		verify(openSearchClient, times(OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES))
+				.bulk(argThat((BulkRequest req) -> req != null));
 	}
 
 	@Test
-	public void testBulkIndexWithEnvelope429ThrowsRecoverableMessageException() throws Exception {
+	public void testBulkIndexWithEnvelope429ExhaustsRetriesAndThrowsRecoverableMessageException() throws Exception {
 		ErrorResponse rateLimited = ErrorResponse.of(e -> e
 				.error(err -> err.type("circuit_breaking_exception").reason("rate limited"))
 				.status(429));
@@ -1246,6 +1271,8 @@ public class OpenSearchManagerImplTest {
 		// call under test
 		assertThrows(RecoverableMessageException.class,
 				() -> manager.bulkIndex("search-index-syn1", Arrays.asList(bulkOp("1"))));
+		verify(openSearchClient, times(OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES))
+				.bulk(argThat((BulkRequest req) -> req != null));
 	}
 
 	@Test
@@ -1260,16 +1287,20 @@ public class OpenSearchManagerImplTest {
 		RuntimeException ex = assertThrows(RuntimeException.class,
 				() -> manager.bulkIndex("search-index-syn1", Arrays.asList(bulkOp("1"))));
 		assertFalse(ex instanceof RecoverableMessageException, ex.getClass().getName());
+		verify(openSearchClient, times(1))
+				.bulk(argThat((BulkRequest req) -> req != null));
 	}
 
 	@Test
-	public void testBulkIndexWithIOExceptionThrowsRecoverableMessageException() throws Exception {
+	public void testBulkIndexWithIOExceptionExhaustsRetriesAndThrowsRecoverableMessageException() throws Exception {
 		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
 				.thenThrow(new IOException("connection reset"));
 
 		// call under test
 		assertThrows(RecoverableMessageException.class,
 				() -> manager.bulkIndex("search-index-syn1", Arrays.asList(bulkOp("1"))));
+		verify(openSearchClient, times(OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES))
+				.bulk(argThat((BulkRequest req) -> req != null));
 	}
 
 	@Test
@@ -1279,6 +1310,86 @@ public class OpenSearchManagerImplTest {
 
 		assertEquals(0L, indexed);
 		verifyZeroInteractions(openSearchClient);
+	}
+
+	@Test
+	public void testBulkIndexWithTransientRetryableFailureRecoversOnSecondAttempt() throws Exception {
+		// First attempt: docs 1 and 3 fail with 500 (retryable); doc 2 succeeds.
+		// Second attempt: all remaining succeed — bulkIndex should return the original total.
+		BulkResponse firstResponse = bulkResponseOf(
+				failedItem("1", 500, "exception", "Internal error occurred while processing request"),
+				okItem("2"),
+				failedItem("3", 503, "service_unavailable", "try later"));
+		BulkResponse secondResponse = bulkResponseOf(okItem("1"), okItem("3"));
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenReturn(firstResponse)
+				.thenReturn(secondResponse);
+
+		// call under test
+		long indexed = manager.bulkIndex("search-index-syn1",
+				Arrays.asList(bulkOp("1"), bulkOp("2"), bulkOp("3")));
+
+		assertEquals(3L, indexed);
+		verify(openSearchClient, times(2))
+				.bulk(argThat((BulkRequest req) -> req != null));
+	}
+
+	@Test
+	public void testBulkIndexRetryResubmitsOnlyFailedOps() throws Exception {
+		// Doc 2 succeeds on first attempt; only docs 1 and 3 should appear in the second bulk request.
+		BulkResponse firstResponse = bulkResponseOf(
+				failedItem("1", 500, "exception", "Internal error occurred while processing request"),
+				okItem("2"),
+				failedItem("3", 500, "exception", "Internal error occurred while processing request"));
+		BulkResponse secondResponse = bulkResponseOf(okItem("1"), okItem("3"));
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenReturn(firstResponse)
+				.thenReturn(secondResponse);
+
+		// call under test
+		manager.bulkIndex("search-index-syn1",
+				Arrays.asList(bulkOp("1"), bulkOp("2"), bulkOp("3")));
+
+		ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+		verify(openSearchClient, times(2)).bulk(captor.capture());
+		List<BulkRequest> requests = captor.getAllValues();
+		assertEquals(3, requests.get(0).operations().size(), "first attempt submits all operations");
+		assertEquals(2, requests.get(1).operations().size(), "second attempt submits only failed subset");
+	}
+
+	@Test
+	public void testBulkIndexWithPermanentFailureDoesNotRetry() throws Exception {
+		// Mixed 500 (retryable) + 400 (permanent): one permanent failure disqualifies the batch
+		// from retrying, so bulk() is called exactly once.
+		BulkResponse response = bulkResponseOf(
+				failedItem("1", 500, "exception", "Internal error occurred while processing request"),
+				failedItem("2", 400, "mapper_parsing_exception", "failed to parse field [geneName]"));
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenReturn(response);
+
+		// call under test
+		RuntimeException ex = assertThrows(RuntimeException.class,
+				() -> manager.bulkIndex("search-index-syn1", Arrays.asList(bulkOp("1"), bulkOp("2"))));
+		assertFalse(ex instanceof RecoverableMessageException, ex.getClass().getName());
+		verify(openSearchClient, times(1))
+				.bulk(argThat((BulkRequest req) -> req != null));
+	}
+
+	@Test
+	public void testBulkIndexWithIOExceptionThenSuccessRecovers() throws Exception {
+		// Transient network issue on first two attempts, then success — covers the IOException
+		// branch of the retry loop.
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenThrow(new IOException("connection reset"))
+				.thenThrow(new IOException("connection reset"))
+				.thenReturn(bulkResponseOf(okItem("1")));
+
+		// call under test
+		long indexed = manager.bulkIndex("search-index-syn1", Arrays.asList(bulkOp("1")));
+
+		assertEquals(1L, indexed);
+		verify(openSearchClient, times(3))
+				.bulk(argThat((BulkRequest req) -> req != null));
 	}
 
 	@Test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -47,8 +48,17 @@ import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import java.util.EnumSet;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.TotalHits;
+import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
+import org.opensearch.client.opensearch.core.search.TrackHits;
+import org.sagebionetworks.repo.model.search.SearchQueryPart;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.TextQueryType;
@@ -1373,6 +1383,57 @@ public class OpenSearchManagerImplTest {
 		assertFalse(ex instanceof RecoverableMessageException, ex.getClass().getName());
 		verify(openSearchClient, times(1))
 				.bulk(argThat((BulkRequest req) -> req != null));
+	}
+
+	// --- callSearchApi: trackTotalHits wire behavior ---
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	private SearchResponse<Map> emptySearchResponse() {
+		TotalHits total = TotalHits.of(t -> t.value(0L).relation(TotalHitsRelation.Eq));
+		HitsMetadata<Map> hits = HitsMetadata.of(h -> h.total(total).hits(Collections.emptyList()));
+		return SearchResponse.searchResponseOf(r -> r
+				.took(0L)
+				.timedOut(false)
+				.shards(s -> s.total(1).successful(1).failed(0))
+				.hits(hits));
+	}
+
+	@Test
+	public void testCallSearchApiWithTotalHitsSetsCountToIntMaxValue() throws IOException {
+		when(openSearchClient.search(argThat((SearchRequest req) -> req != null), eq(Map.class)))
+				.thenReturn(emptySearchResponse());
+
+		// call under test
+		manager.callSearchApi("my-index", new BoolQuery.Builder(),
+				0, 10, Collections.emptyMap(), null, null,
+				Collections.emptyList(), Collections.emptyMap(),
+				EnumSet.of(SearchQueryPart.TOTAL_HITS));
+
+		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+		verify(openSearchClient).search(captor.capture(), eq(Map.class));
+		TrackHits trackHits = captor.getValue().trackTotalHits();
+		assertNotNull(trackHits, "trackTotalHits must be set when TOTAL_HITS requested");
+		assertTrue(trackHits.isCount(), "must use count() variant, not enabled()");
+		assertEquals(Integer.MAX_VALUE, trackHits.count());
+	}
+
+	@Test
+	public void testCallSearchApiWithoutTotalHitsSetsEnabledFalse() throws IOException {
+		when(openSearchClient.search(argThat((SearchRequest req) -> req != null), eq(Map.class)))
+				.thenReturn(emptySearchResponse());
+
+		// call under test
+		manager.callSearchApi("my-index", new BoolQuery.Builder(),
+				0, 10, Collections.emptyMap(), null, null,
+				Collections.emptyList(), Collections.emptyMap(),
+				EnumSet.of(SearchQueryPart.HITS));
+
+		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+		verify(openSearchClient).search(captor.capture(), eq(Map.class));
+		TrackHits trackHits = captor.getValue().trackTotalHits();
+		assertNotNull(trackHits, "trackTotalHits must be explicitly disabled");
+		assertTrue(trackHits.isEnabled(), "must use enabled() variant");
+		assertEquals(Boolean.FALSE, trackHits.enabled());
 	}
 
 	@Test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -46,6 +46,10 @@ import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.DeleteRequest;
+import org.opensearch.client.opensearch.core.DeleteResponse;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.IndexResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import java.util.EnumSet;
@@ -105,6 +109,7 @@ public class OpenSearchManagerImplTest {
 	private String scientificQualifiedName;
 
 	private long originalBulkInitialBackoffMs;
+	private long originalProbeInitialBackoffMs;
 
 	@BeforeEach
 	public void setUp() {
@@ -115,11 +120,14 @@ public class OpenSearchManagerImplTest {
 		// actually sleep ~21s per invocation. Restored in @AfterEach.
 		originalBulkInitialBackoffMs = OpenSearchManagerImpl.BULK_INDEX_INITIAL_BACKOFF_MS;
 		OpenSearchManagerImpl.BULK_INDEX_INITIAL_BACKOFF_MS = 1L;
+		originalProbeInitialBackoffMs = OpenSearchManagerImpl.INDEX_WRITABLE_INITIAL_BACKOFF_MS;
+		OpenSearchManagerImpl.INDEX_WRITABLE_INITIAL_BACKOFF_MS = 1L;
 	}
 
 	@AfterEach
 	public void tearDown() {
 		OpenSearchManagerImpl.BULK_INDEX_INITIAL_BACKOFF_MS = originalBulkInitialBackoffMs;
+		OpenSearchManagerImpl.INDEX_WRITABLE_INITIAL_BACKOFF_MS = originalProbeInitialBackoffMs;
 	}
 
 	private TextAnalyzer keywordAnalyzer(String id) {
@@ -1067,6 +1075,21 @@ public class OpenSearchManagerImplTest {
 				.took(1L).items(Arrays.asList(items)));
 	}
 
+	/**
+	 * Build a {@link BulkResponse} whose items line up one-for-one with the operations in
+	 * {@code request} — all failed with the given status/type/reason. Needed because
+	 * {@code bulkIndex} may submit per-op requests after a partial batch failure.
+	 */
+	private static BulkResponse allFailedResponse(BulkRequest request, int status, String type, String reason) {
+		BulkResponseItem[] items = request.operations().stream()
+				.map(op -> {
+					String id = op.index() != null ? op.index().id() : "?";
+					return failedItem(id, status, type, reason);
+				})
+				.toArray(BulkResponseItem[]::new);
+		return bulkResponseOf(items);
+	}
+
 	@Test
 	public void testBulkIndexWithAllItemsSucceed() throws Exception {
 		BulkResponse response = bulkResponseOf(okItem("1"), okItem("2"), okItem("3"));
@@ -1082,12 +1105,11 @@ public class OpenSearchManagerImplTest {
 
 	@Test
 	public void testBulkIndexWithAllRetryableFailuresExhaustsRetriesAndThrowsRecoverableMessageException() throws Exception {
-		BulkResponse response = bulkResponseOf(
-				failedItem("1", 429, "circuit_breaking_exception", "rate limited"),
-				failedItem("2", 429, "circuit_breaking_exception", "rate limited"),
-				failedItem("3", 503, "service_unavailable", "try later"));
+		// Every per-op bulk response fails 429 for whatever doc ids were requested — covers both
+		// the initial batch attempt and the per-document retries that follow.
 		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
-				.thenReturn(response);
+				.thenAnswer(inv -> allFailedResponse(inv.getArgument(0), 429,
+						"circuit_breaking_exception", "rate limited"));
 
 		// call under test
 		RecoverableMessageException ex = assertThrows(RecoverableMessageException.class,
@@ -1097,7 +1119,9 @@ public class OpenSearchManagerImplTest {
 				"failed after " + OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES + " attempts"),
 				ex.getMessage());
 		assertTrue(ex.getMessage().contains("3 document(s) still retryable out of 3"), ex.getMessage());
-		verify(openSearchClient, times(OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES))
+		// 1 batch attempt, then MAX_RETRIES-1 per-document attempts with 3 ops each.
+		int expected = 1 + (OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES - 1) * 3;
+		verify(openSearchClient, times(expected))
 				.bulk(argThat((BulkRequest req) -> req != null));
 	}
 
@@ -1126,12 +1150,9 @@ public class OpenSearchManagerImplTest {
 		// AOSS returns 500 with type="exception" and the generic "Internal error occurred while
 		// processing request" reason when shard routing hasn't fully propagated after createIndex —
 		// classified as retryable so the intra-batch retry loop backs off and resubmits the subset.
-		BulkResponse response = bulkResponseOf(
-				failedItem("1", status, "exception", "Internal error occurred while processing request"),
-				failedItem("2", status, "exception", "Internal error occurred while processing request"),
-				failedItem("3", status, "exception", "Internal error occurred while processing request"));
 		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
-				.thenReturn(response);
+				.thenAnswer(inv -> allFailedResponse(inv.getArgument(0), status,
+						"exception", "Internal error occurred while processing request"));
 
 		// call under test
 		RecoverableMessageException ex = assertThrows(RecoverableMessageException.class,
@@ -1141,7 +1162,9 @@ public class OpenSearchManagerImplTest {
 				"failed after " + OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES + " attempts"),
 				ex.getMessage());
 		assertTrue(ex.getMessage().contains("3 document(s) still retryable out of 3"), ex.getMessage());
-		verify(openSearchClient, times(OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES))
+		// 1 batch attempt, then MAX_RETRIES-1 per-document attempts with 3 ops each.
+		int expected = 1 + (OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES - 1) * 3;
+		verify(openSearchClient, times(expected))
 				.bulk(argThat((BulkRequest req) -> req != null));
 	}
 
@@ -1324,47 +1347,53 @@ public class OpenSearchManagerImplTest {
 
 	@Test
 	public void testBulkIndexWithTransientRetryableFailureRecoversOnSecondAttempt() throws Exception {
-		// First attempt: docs 1 and 3 fail with 500 (retryable); doc 2 succeeds.
-		// Second attempt: all remaining succeed — bulkIndex should return the original total.
+		// First attempt (batch): docs 1 and 3 fail 500, doc 2 succeeds. That triggers
+		// per-document mode — the next two attempts submit docs 1 and 3 individually.
 		BulkResponse firstResponse = bulkResponseOf(
 				failedItem("1", 500, "exception", "Internal error occurred while processing request"),
 				okItem("2"),
 				failedItem("3", 503, "service_unavailable", "try later"));
-		BulkResponse secondResponse = bulkResponseOf(okItem("1"), okItem("3"));
+		BulkResponse singleOk1 = bulkResponseOf(okItem("1"));
+		BulkResponse singleOk3 = bulkResponseOf(okItem("3"));
 		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
 				.thenReturn(firstResponse)
-				.thenReturn(secondResponse);
+				.thenReturn(singleOk1)
+				.thenReturn(singleOk3);
 
 		// call under test
 		long indexed = manager.bulkIndex("search-index-syn1",
 				Arrays.asList(bulkOp("1"), bulkOp("2"), bulkOp("3")));
 
 		assertEquals(3L, indexed);
-		verify(openSearchClient, times(2))
+		verify(openSearchClient, times(3))
 				.bulk(argThat((BulkRequest req) -> req != null));
 	}
 
 	@Test
 	public void testBulkIndexRetryResubmitsOnlyFailedOps() throws Exception {
-		// Doc 2 succeeds on first attempt; only docs 1 and 3 should appear in the second bulk request.
+		// Doc 2 succeeds on first batch attempt. On partial failure the retry switches to
+		// per-document mode, so only docs 1 and 3 come back — each in its own single-op request.
 		BulkResponse firstResponse = bulkResponseOf(
 				failedItem("1", 500, "exception", "Internal error occurred while processing request"),
 				okItem("2"),
 				failedItem("3", 500, "exception", "Internal error occurred while processing request"));
-		BulkResponse secondResponse = bulkResponseOf(okItem("1"), okItem("3"));
+		BulkResponse singleOk1 = bulkResponseOf(okItem("1"));
+		BulkResponse singleOk3 = bulkResponseOf(okItem("3"));
 		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
 				.thenReturn(firstResponse)
-				.thenReturn(secondResponse);
+				.thenReturn(singleOk1)
+				.thenReturn(singleOk3);
 
 		// call under test
 		manager.bulkIndex("search-index-syn1",
 				Arrays.asList(bulkOp("1"), bulkOp("2"), bulkOp("3")));
 
 		ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
-		verify(openSearchClient, times(2)).bulk(captor.capture());
+		verify(openSearchClient, times(3)).bulk(captor.capture());
 		List<BulkRequest> requests = captor.getAllValues();
 		assertEquals(3, requests.get(0).operations().size(), "first attempt submits all operations");
-		assertEquals(2, requests.get(1).operations().size(), "second attempt submits only failed subset");
+		assertEquals(1, requests.get(1).operations().size(), "per-doc retry submits one op");
+		assertEquals(1, requests.get(2).operations().size(), "per-doc retry submits one op");
 	}
 
 	@Test
@@ -1505,5 +1534,238 @@ public class OpenSearchManagerImplTest {
 		assertTrue(result.contains("node=node-a"), result);
 		assertTrue(result.contains("mapper_parsing_exception"), result);
 		assertTrue(result.contains("failed to parse field [geneName]"), result);
+	}
+
+	// --- waitForIndexWritable ---
+
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	private static IndexResponse okIndexResponse() {
+		return IndexResponse.of(b -> b
+				.id(OpenSearchManagerImpl.READINESS_PROBE_DOC_ID)
+				.index("search-index-syn1")
+				.version(1L)
+				.seqNo(0L)
+				.primaryTerm(1L)
+				.result(org.opensearch.client.opensearch._types.Result.Created)
+				.shards(s -> s.total(1).successful(1).failed(0)));
+	}
+
+	private static DeleteResponse okDeleteResponse() {
+		return DeleteResponse.of(b -> b
+				.id(OpenSearchManagerImpl.READINESS_PROBE_DOC_ID)
+				.index("search-index-syn1")
+				.version(1L)
+				.seqNo(1L)
+				.primaryTerm(1L)
+				.result(org.opensearch.client.opensearch._types.Result.Deleted)
+				.shards(s -> s.total(1).successful(1).failed(0)));
+	}
+
+	@Test
+	public void testWaitForIndexWritableWithImmediateSuccessDeletesSentinelAndReturns() throws Exception {
+		when(openSearchClient.index(argThat((IndexRequest<?> req) -> req != null)))
+				.thenReturn(okIndexResponse());
+		when(openSearchClient.delete(argThat((DeleteRequest req) -> req != null)))
+				.thenReturn(okDeleteResponse());
+
+		// call under test
+		manager.waitForIndexWritable("search-index-syn1");
+
+		ArgumentCaptor<IndexRequest> indexCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+		verify(openSearchClient, times(1)).index(indexCaptor.capture());
+		assertEquals("search-index-syn1", indexCaptor.getValue().index());
+		assertEquals(OpenSearchManagerImpl.READINESS_PROBE_DOC_ID, indexCaptor.getValue().id());
+
+		ArgumentCaptor<DeleteRequest> deleteCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
+		verify(openSearchClient, times(1)).delete(deleteCaptor.capture());
+		assertEquals("search-index-syn1", deleteCaptor.getValue().index());
+		assertEquals(OpenSearchManagerImpl.READINESS_PROBE_DOC_ID, deleteCaptor.getValue().id());
+	}
+
+	@Test
+	public void testWaitForIndexWritableWithTransientFailureThenSuccess() throws Exception {
+		OpenSearchException notFound = new OpenSearchException(
+				ErrorResponse.of(er -> er.error(ErrorCause.of(e -> e
+						.type("index_not_found_exception")
+						.reason("no such index"))).status(404)));
+		when(openSearchClient.index(argThat((IndexRequest<?> req) -> req != null)))
+				.thenThrow(notFound)
+				.thenThrow(notFound)
+				.thenReturn(okIndexResponse());
+		when(openSearchClient.delete(argThat((DeleteRequest req) -> req != null)))
+				.thenReturn(okDeleteResponse());
+
+		// call under test
+		manager.waitForIndexWritable("search-index-syn1");
+
+		verify(openSearchClient, times(3)).index(argThat((IndexRequest<?> req) -> req != null));
+		verify(openSearchClient, times(1)).delete(argThat((DeleteRequest req) -> req != null));
+	}
+
+	@Test
+	public void testWaitForIndexWritableExhaustsRetriesAndThrowsRecoverableMessageException() throws Exception {
+		OpenSearchException notFound = new OpenSearchException(
+				ErrorResponse.of(er -> er.error(ErrorCause.of(e -> e
+						.type("index_not_found_exception")
+						.reason("no such index"))).status(404)));
+		when(openSearchClient.index(argThat((IndexRequest<?> req) -> req != null)))
+				.thenThrow(notFound);
+
+		// call under test
+		RecoverableMessageException ex = assertThrows(RecoverableMessageException.class,
+				() -> manager.waitForIndexWritable("search-index-syn1"));
+
+		assertTrue(ex.getMessage().contains("did not accept writes within the retry budget"),
+				ex.getMessage());
+		verify(openSearchClient, times(OpenSearchManagerImpl.INDEX_WRITABLE_MAX_RETRIES))
+				.index(argThat((IndexRequest<?> req) -> req != null));
+		// No sentinel was ever written, so no cleanup delete is attempted.
+		verify(openSearchClient, times(0)).delete(argThat((DeleteRequest req) -> req != null));
+	}
+
+	@Test
+	public void testWaitForIndexWritableWithIOExceptionExhaustsRetries() throws Exception {
+		when(openSearchClient.index(argThat((IndexRequest<?> req) -> req != null)))
+				.thenThrow(new IOException("connection reset"));
+
+		// call under test
+		assertThrows(RecoverableMessageException.class,
+				() -> manager.waitForIndexWritable("search-index-syn1"));
+
+		verify(openSearchClient, times(OpenSearchManagerImpl.INDEX_WRITABLE_MAX_RETRIES))
+				.index(argThat((IndexRequest<?> req) -> req != null));
+	}
+
+	@Test
+	public void testWaitForIndexWritableSentinelCleanupFailureIsSwallowed() throws Exception {
+		// Write succeeds, but delete fails. The probe should still return normally — cleanup
+		// failures are non-fatal; the sentinel with _row_id = -1 cannot collide with real ids.
+		when(openSearchClient.index(argThat((IndexRequest<?> req) -> req != null)))
+				.thenReturn(okIndexResponse());
+		when(openSearchClient.delete(argThat((DeleteRequest req) -> req != null)))
+				.thenThrow(new IOException("cleanup failed"));
+
+		// call under test
+		manager.waitForIndexWritable("search-index-syn1");
+
+		verify(openSearchClient, times(1)).index(argThat((IndexRequest<?> req) -> req != null));
+		verify(openSearchClient, times(1)).delete(argThat((DeleteRequest req) -> req != null));
+	}
+
+	// --- per-document fallback on partial batch failure ---
+
+	@Test
+	public void testBulkIndexSwitchesToPerDocumentModeAfterPartialBatchFailure() throws Exception {
+		// First attempt (batch mode): doc 2 succeeds, docs 1 and 3 fail with 429 — retryable.
+		// Second attempt (per-doc mode): two single-op bulk requests, both succeed.
+		BulkResponse firstResponse = bulkResponseOf(
+				failedItem("1", 429, "circuit_breaking_exception", "rate limited"),
+				okItem("2"),
+				failedItem("3", 429, "circuit_breaking_exception", "rate limited"));
+		BulkResponse singleOk1 = bulkResponseOf(okItem("1"));
+		BulkResponse singleOk3 = bulkResponseOf(okItem("3"));
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenReturn(firstResponse)
+				.thenReturn(singleOk1)
+				.thenReturn(singleOk3);
+
+		// call under test
+		long indexed = manager.bulkIndex("search-index-syn1",
+				Arrays.asList(bulkOp("1"), bulkOp("2"), bulkOp("3")));
+
+		assertEquals(3L, indexed);
+		ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+		verify(openSearchClient, times(3)).bulk(captor.capture());
+		List<BulkRequest> requests = captor.getAllValues();
+		assertEquals(3, requests.get(0).operations().size(), "first attempt submits batch of 3");
+		assertEquals(1, requests.get(1).operations().size(), "per-doc retry submits one op");
+		assertEquals(1, requests.get(2).operations().size(), "per-doc retry submits one op");
+	}
+
+	@Test
+	public void testBulkIndexPerDocumentModeContinuesPartitioningAfterPartialFailure() throws Exception {
+		// First attempt (batch): doc 2 succeeds, docs 1 and 3 fail 429 (retryable).
+		// Second attempt (per-doc): single op for doc 1 fails 429; single op for doc 3 succeeds.
+		// Third attempt (per-doc): single op for doc 1 succeeds.
+		BulkResponse firstResponse = bulkResponseOf(
+				failedItem("1", 429, "circuit_breaking_exception", "rate limited"),
+				okItem("2"),
+				failedItem("3", 429, "circuit_breaking_exception", "rate limited"));
+		BulkResponse single1Failed = bulkResponseOf(
+				failedItem("1", 429, "circuit_breaking_exception", "rate limited"));
+		BulkResponse single3Ok = bulkResponseOf(okItem("3"));
+		BulkResponse single1Ok = bulkResponseOf(okItem("1"));
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenReturn(firstResponse)
+				.thenReturn(single1Failed)
+				.thenReturn(single3Ok)
+				.thenReturn(single1Ok);
+
+		// call under test
+		long indexed = manager.bulkIndex("search-index-syn1",
+				Arrays.asList(bulkOp("1"), bulkOp("2"), bulkOp("3")));
+
+		assertEquals(3L, indexed);
+		verify(openSearchClient, times(4)).bulk(argThat((BulkRequest req) -> req != null));
+	}
+
+	@Test
+	public void testBulkIndexPerDocumentModeEnvelopeFailureDoesNotResubmitSucceededDocs() throws Exception {
+		// Partial 429 triggers per-doc mode with docs 1 and 3 outstanding.
+		// In per-doc mode, doc 1 succeeds, doc 3's single-op request throws an envelope 503
+		// (retryable). The next attempt must only resubmit doc 3 — doc 1 was already indexed.
+		BulkResponse firstResponse = bulkResponseOf(
+				failedItem("1", 429, "circuit_breaking_exception", "rate limited"),
+				okItem("2"),
+				failedItem("3", 429, "circuit_breaking_exception", "rate limited"));
+		BulkResponse single1Ok = bulkResponseOf(okItem("1"));
+		BulkResponse single3Ok = bulkResponseOf(okItem("3"));
+		ErrorResponse serverError = ErrorResponse.of(e -> e
+				.error(err -> err.type("exception").reason("service unavailable"))
+				.status(503));
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenReturn(firstResponse)
+				.thenReturn(single1Ok)
+				.thenThrow(new OpenSearchException(serverError))
+				.thenReturn(single3Ok);
+
+		// call under test
+		long indexed = manager.bulkIndex("search-index-syn1",
+				Arrays.asList(bulkOp("1"), bulkOp("2"), bulkOp("3")));
+
+		assertEquals(3L, indexed);
+		ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+		verify(openSearchClient, times(4)).bulk(captor.capture());
+		List<BulkRequest> requests = captor.getAllValues();
+		// attempt 1 (batch of 3) → attempt 2 per-doc: submits doc 1 (ok) then doc 3 (envelope 503 aborts)
+		// → attempt 3 per-doc: must only carry doc 3 forward, not doc 1 again.
+		assertEquals(3, requests.get(0).operations().size(), "batch attempt");
+		assertEquals(1, requests.get(1).operations().size(), "per-doc: doc 1 ok");
+		assertEquals(1, requests.get(2).operations().size(), "per-doc: doc 3 envelope 503");
+		assertEquals(1, requests.get(3).operations().size(),
+				"retry after envelope failure must only resubmit the unprocessed doc, not the succeeded one");
+		assertEquals("3", requests.get(3).operations().get(0).index().id(),
+				"succeeded doc 1 must not be resubmitted");
+	}
+
+	@Test
+	public void testBulkIndexPerDocumentModePermanentFailureStopsRetries() throws Exception {
+		// Partial 429 triggers per-doc mode. On the per-doc retry, doc 1's single op comes back 400
+		// (permanent), so the whole bulkIndex call fails without further retries.
+		BulkResponse firstResponse = bulkResponseOf(
+				failedItem("1", 429, "circuit_breaking_exception", "rate limited"),
+				okItem("2"));
+		BulkResponse single1Permanent = bulkResponseOf(
+				failedItem("1", 400, "mapper_parsing_exception", "failed to parse field [geneName]"));
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenReturn(firstResponse)
+				.thenReturn(single1Permanent);
+
+		// call under test
+		RuntimeException ex = assertThrows(RuntimeException.class,
+				() -> manager.bulkIndex("search-index-syn1",
+						Arrays.asList(bulkOp("1"), bulkOp("2"))));
+		assertFalse(ex instanceof RecoverableMessageException, ex.getClass().getName());
+		verify(openSearchClient, times(2)).bulk(argThat((BulkRequest req) -> req != null));
 	}
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImplTest.java
@@ -338,6 +338,44 @@ public class SearchIndexLifecycleManagerImplTest {
 	}
 
 	@Test
+	public void testHandleCreateOnSourceTableLockUnavailablePropagates() throws Exception {
+		// The source table's read lock is unavailable (a writer holds it — e.g. BuildTableIndex
+		// is running). LockUnavilableException is thrown bare from querySinglePage with no cause
+		// chain. It must propagate out of buildIndex without recording FAILED so the worker can
+		// translate it to RecoverableMessageException and SQS retries.
+		UserInfo triggering = triggeringUser();
+		SearchIndex searchIndex = new SearchIndex();
+		searchIndex.setDefiningSQL(DEFINING_SQL);
+		searchIndex.setParentId("syn100");
+
+		stubBuildLock();
+		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
+		when(userManager.getUserInfo(USER_ID)).thenReturn(triggering);
+		when(userManager.getUserInfo(ANON_ID)).thenReturn(anonymousUser());
+		when(entityManager.getEntity(triggering, ENTITY_ID, SearchIndex.class)).thenReturn(searchIndex);
+		when(tableManagerSupport.getTableSchema(IdAndVersion.parse(ENTITY_ID)))
+				.thenReturn(Collections.singletonList(
+						new ColumnModel().setId("100").setName("name").setColumnType(ColumnType.STRING)));
+		when(searchConfigurationResolver.resolve(eq(triggering), any(), eq("syn100"))).thenReturn(Optional.empty());
+		LockUnavilableException lockEx = new LockUnavilableException(LockType.Write, "TABLE-LOCK-789", "BuildTableIndex,syn789");
+		when(tableQueryManager.querySinglePage(eq(progressCallback), any(UserInfo.class), any(), any()))
+				.thenThrow(lockEx);
+
+		// call under test — LockUnavilableException from buildIndex propagates out of the
+		// inner multi-catch and is then wrapped by handleCreate's outer catch into
+		// RecoverableMessageException so the worker retries rather than recording FAILED.
+		RecoverableMessageException thrown = assertThrows(RecoverableMessageException.class,
+				() -> manager.handleCreate(progressCallback, ENTITY_ID, USER_ID));
+
+		assertSame(lockEx, thrown.getCause());
+		// Only CREATING was written — no FAILED, no cleanup
+		ArgumentCaptor<SearchIndexStatus> captor = ArgumentCaptor.forClass(SearchIndexStatus.class);
+		verify(statusDao).createOrUpdate(captor.capture());
+		assertEquals(SearchIndexState.CREATING, captor.getValue().getState());
+		verify(openSearchManager, never()).deleteIndex(any());
+	}
+
+	@Test
 	public void testHandleDeleteWithActiveStateDeletesIndexAndStatus() throws Exception {
 		stubBuildLock();
 		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
@@ -458,6 +496,78 @@ public class SearchIndexLifecycleManagerImplTest {
 		ArgumentCaptor<SearchIndexStatus> captor = ArgumentCaptor.forClass(SearchIndexStatus.class);
 		verify(statusDao, org.mockito.Mockito.times(2)).createOrUpdate(captor.capture());
 		assertEquals(SearchIndexState.FAILED, captor.getAllValues().get(1).getState());
+	}
+
+	@Test
+	public void testHandleCreateCallsWaitForIndexWritableBetweenCreateAndRunQuery() throws Exception {
+		// AOSS acknowledges createIndex while shards are still not writable; the readiness probe
+		// must run before runQueryAsStream so the bulk stream does not race against
+		// index_not_found_exception.
+		UserInfo triggering = triggeringUser();
+		SearchIndex searchIndex = new SearchIndex();
+		searchIndex.setDefiningSQL(DEFINING_SQL);
+		searchIndex.setParentId("syn100");
+
+		stubBuildLock();
+		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
+		when(userManager.getUserInfo(USER_ID)).thenReturn(triggering);
+		when(userManager.getUserInfo(ANON_ID)).thenReturn(anonymousUser());
+		when(entityManager.getEntity(triggering, ENTITY_ID, SearchIndex.class)).thenReturn(searchIndex);
+		when(tableManagerSupport.getTableSchema(IdAndVersion.parse(ENTITY_ID)))
+				.thenReturn(Collections.singletonList(
+						new ColumnModel().setId("100").setName("name").setColumnType(ColumnType.STRING)));
+		when(searchConfigurationResolver.resolve(any(), any(), any())).thenReturn(Optional.empty());
+		when(tableQueryManager.querySinglePage(any(), any(), any(), any()))
+				.thenReturn(new QueryResultBundle().setQueryCount(0L));
+
+		// call under test
+		manager.handleCreate(progressCallback, ENTITY_ID, USER_ID);
+
+		org.mockito.InOrder order = org.mockito.Mockito.inOrder(openSearchManager, tableQueryManager);
+		order.verify(openSearchManager).deleteIndex("search-index-" + ENTITY_ID);
+		order.verify(openSearchManager).createIndex(eq("search-index-" + ENTITY_ID),
+				any(), any(), any(), any(), any());
+		order.verify(openSearchManager).waitForIndexWritable("search-index-" + ENTITY_ID);
+		order.verify(tableQueryManager).runQueryAsStream(eq(progressCallback), any(UserInfo.class),
+				any(), any(), any());
+	}
+
+	@Test
+	public void testHandleCreateWhenProbeThrowsRecoverablePropagatesWithoutRecordingFailed() throws Exception {
+		// waitForIndexWritable exhausts its retry budget and throws RecoverableMessageException.
+		// That must propagate out of buildIndex unchanged and NOT flip the SearchIndex to FAILED —
+		// the build will succeed on a later SQS retry.
+		UserInfo triggering = triggeringUser();
+		SearchIndex searchIndex = new SearchIndex();
+		searchIndex.setDefiningSQL(DEFINING_SQL);
+		searchIndex.setParentId("syn100");
+
+		stubBuildLock();
+		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
+		when(userManager.getUserInfo(USER_ID)).thenReturn(triggering);
+		when(userManager.getUserInfo(ANON_ID)).thenReturn(anonymousUser());
+		when(entityManager.getEntity(triggering, ENTITY_ID, SearchIndex.class)).thenReturn(searchIndex);
+		when(tableManagerSupport.getTableSchema(IdAndVersion.parse(ENTITY_ID)))
+				.thenReturn(Collections.singletonList(
+						new ColumnModel().setId("100").setName("name").setColumnType(ColumnType.STRING)));
+		when(searchConfigurationResolver.resolve(any(), any(), any())).thenReturn(Optional.empty());
+		when(tableQueryManager.querySinglePage(any(), any(), any(), any()))
+				.thenReturn(new QueryResultBundle().setQueryCount(0L));
+		RecoverableMessageException probeFailed = new RecoverableMessageException(
+				"AOSS index search-index-" + ENTITY_ID + " did not accept writes within the retry budget");
+		doThrow(probeFailed).when(openSearchManager).waitForIndexWritable("search-index-" + ENTITY_ID);
+
+		// call under test
+		RecoverableMessageException thrown = assertThrows(RecoverableMessageException.class,
+				() -> manager.handleCreate(progressCallback, ENTITY_ID, USER_ID));
+		assertSame(probeFailed, thrown);
+
+		// Only CREATING was recorded — probe failure is transient, not a permanent failure.
+		ArgumentCaptor<SearchIndexStatus> captor = ArgumentCaptor.forClass(SearchIndexStatus.class);
+		verify(statusDao).createOrUpdate(captor.capture());
+		assertEquals(SearchIndexState.CREATING, captor.getValue().getState());
+		// Streaming must not have started — the probe runs first.
+		verify(tableQueryManager, never()).runQueryAsStream(any(), any(), any(), any(), any());
 	}
 
 	// -------- SearchIndexRowHandler tests --------

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImplTest.java
@@ -54,6 +54,11 @@ import org.sagebionetworks.table.cluster.ConnectionFactory;
 import org.sagebionetworks.table.cluster.search.SearchIndexStatusDao;
 import org.sagebionetworks.util.progress.ProgressCallback;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
+import org.sagebionetworks.workers.util.semaphore.LockUnavilableException;
+import org.sagebionetworks.workers.util.semaphore.LockType;
+import org.sagebionetworks.workers.util.semaphore.WriteLock;
+import org.sagebionetworks.workers.util.semaphore.WriteLockRequest;
+import org.sagebionetworks.workers.util.semaphore.WriteReadSemaphore;
 
 @ExtendWith(MockitoExtension.class)
 public class SearchIndexLifecycleManagerImplTest {
@@ -89,9 +94,26 @@ public class SearchIndexLifecycleManagerImplTest {
 	private TableManagerSupport tableManagerSupport;
 	@Mock
 	private ColumnModelManager columnModelManager;
+	@Mock
+	private WriteReadSemaphore writeReadSemaphore;
+	@Mock
+	private WriteLock writeLock;
 
 	@InjectMocks
 	private SearchIndexLifecycleManagerImpl manager;
+
+	private static final String LOCK_KEY = "search-index-build:" + ENTITY_ID;
+
+	private void stubBuildLock() throws Exception {
+		when(progressCallback.getLockTimeoutSeconds()).thenReturn(300L);
+		when(writeReadSemaphore.getWriteLock(any(WriteLockRequest.class))).thenReturn(writeLock);
+	}
+
+	private void stubLockUnavailable() throws Exception {
+		when(progressCallback.getLockTimeoutSeconds()).thenReturn(300L);
+		when(writeReadSemaphore.getWriteLock(any(WriteLockRequest.class)))
+				.thenThrow(new LockUnavilableException(LockType.Write, LOCK_KEY, "other-worker"));
+	}
 
 	private UserInfo triggeringUser() {
 		UserInfo user = new UserInfo(false, USER_ID, null);
@@ -113,6 +135,7 @@ public class SearchIndexLifecycleManagerImplTest {
 		searchIndex.setDefiningSQL(DEFINING_SQL);
 		searchIndex.setParentId("syn100");
 
+		stubBuildLock();
 		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
 		when(userManager.getUserInfo(USER_ID)).thenReturn(triggering);
 		when(userManager.getUserInfo(ANON_ID)).thenReturn(anon);
@@ -145,6 +168,7 @@ public class SearchIndexLifecycleManagerImplTest {
 		searchIndex.setDefiningSQL(DEFINING_SQL);
 		searchIndex.setParentId("syn100");
 
+		stubBuildLock();
 		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
 		when(userManager.getUserInfo(USER_ID)).thenReturn(triggering);
 		when(userManager.getUserInfo(ANON_ID)).thenReturn(anonymousUser());
@@ -181,6 +205,7 @@ public class SearchIndexLifecycleManagerImplTest {
 
 		String longMessage = "x".repeat(5000);
 
+		stubBuildLock();
 		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
 		when(userManager.getUserInfo(USER_ID)).thenReturn(triggering);
 		when(userManager.getUserInfo(ANON_ID)).thenReturn(anonymousUser());
@@ -210,6 +235,7 @@ public class SearchIndexLifecycleManagerImplTest {
 		searchIndex.setDefiningSQL(DEFINING_SQL);
 		searchIndex.setParentId("syn100");
 
+		stubBuildLock();
 		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
 		when(userManager.getUserInfo(USER_ID)).thenReturn(triggering);
 		when(userManager.getUserInfo(ANON_ID)).thenReturn(anonymousUser());
@@ -243,6 +269,7 @@ public class SearchIndexLifecycleManagerImplTest {
 		searchIndex.setDefiningSQL(DEFINING_SQL);
 		searchIndex.setParentId("syn100");
 
+		stubBuildLock();
 		ErrorCause cause = ErrorCause.of(b -> b
 				.type("status_exception")
 				.reason("Deletion failed for indices [search-index-syn456] due to concurrent deletes, please try again"));
@@ -287,6 +314,7 @@ public class SearchIndexLifecycleManagerImplTest {
 		searchIndex.setDefiningSQL(DEFINING_SQL);
 		searchIndex.setParentId("syn100");
 
+		stubBuildLock();
 		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
 		when(userManager.getUserInfo(USER_ID)).thenReturn(triggering);
 		when(userManager.getUserInfo(ANON_ID)).thenReturn(anonymousUser());
@@ -310,52 +338,126 @@ public class SearchIndexLifecycleManagerImplTest {
 	}
 
 	@Test
-	public void testHandleDeleteWithCreatingStateThrowsRecoverable() {
-		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
-		when(statusDao.getState(456L)).thenReturn(Optional.of(SearchIndexState.CREATING));
-
-		// call under test
-		assertThrows(org.sagebionetworks.workers.util.aws.message.RecoverableMessageException.class,
-				() -> manager.handleDelete(ENTITY_ID));
-
-		verify(openSearchManager, never()).deleteIndex(any());
-		verify(statusDao, never()).delete(any());
-	}
-
-	@Test
 	public void testHandleDeleteWithActiveStateDeletesIndexAndStatus() throws Exception {
+		stubBuildLock();
 		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
 		when(statusDao.getState(456L)).thenReturn(Optional.of(SearchIndexState.ACTIVE));
 
 		// call under test
-		manager.handleDelete(ENTITY_ID);
+		manager.handleDelete(progressCallback, ENTITY_ID);
 
 		verify(openSearchManager).deleteIndex("search-index-" + ENTITY_ID);
 		verify(statusDao).delete(456L);
+		verify(writeLock).close();
 	}
 
 	@Test
 	public void testHandleDeleteWithFailedStateDeletesIndexAndStatus() throws Exception {
+		stubBuildLock();
 		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
 		when(statusDao.getState(456L)).thenReturn(Optional.of(SearchIndexState.FAILED));
 
 		// call under test
-		manager.handleDelete(ENTITY_ID);
+		manager.handleDelete(progressCallback, ENTITY_ID);
 
 		verify(openSearchManager).deleteIndex("search-index-" + ENTITY_ID);
 		verify(statusDao).delete(456L);
+		verify(writeLock).close();
 	}
 
 	@Test
 	public void testHandleDeleteWithMissingStatusIsNoOp() throws Exception {
+		stubBuildLock();
 		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
 		when(statusDao.getState(456L)).thenReturn(Optional.empty());
 
 		// call under test
-		manager.handleDelete(ENTITY_ID);
+		manager.handleDelete(progressCallback, ENTITY_ID);
 
 		verify(openSearchManager, never()).deleteIndex(any());
 		verify(statusDao, never()).delete(any());
+		verify(writeLock).close();
+	}
+
+	@Test
+	public void testHandleDeleteWithLockAlreadyHeld() throws Exception {
+		stubLockUnavailable();
+
+		// call under test
+		assertThrows(RecoverableMessageException.class,
+				() -> manager.handleDelete(progressCallback, ENTITY_ID));
+
+		verify(openSearchManager, never()).deleteIndex(any());
+		verify(statusDao, never()).delete(any());
+	}
+
+	// -------- per-entity lock tests --------
+
+	@Test
+	public void testHandleCreateWithLockAlreadyHeld() throws Exception {
+		stubLockUnavailable();
+
+		// call under test
+		assertThrows(RecoverableMessageException.class,
+				() -> manager.handleCreate(progressCallback, ENTITY_ID, USER_ID));
+
+		verify(statusDao, never()).createOrUpdate(any());
+		verify(openSearchManager, never()).deleteIndex(any());
+		verify(openSearchManager, never()).createIndex(any(), any(), any(), any(), any(), any());
+	}
+
+	@Test
+	public void testHandleCreateReleasesLockOnSuccess() throws Exception {
+		stubBuildLock();
+		UserInfo triggering = triggeringUser();
+		SearchIndex searchIndex = new SearchIndex();
+		searchIndex.setDefiningSQL(DEFINING_SQL);
+		searchIndex.setParentId("syn100");
+
+		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
+		when(userManager.getUserInfo(USER_ID)).thenReturn(triggering);
+		when(userManager.getUserInfo(ANON_ID)).thenReturn(anonymousUser());
+		when(entityManager.getEntity(triggering, ENTITY_ID, SearchIndex.class)).thenReturn(searchIndex);
+		when(tableManagerSupport.getTableSchema(IdAndVersion.parse(ENTITY_ID)))
+				.thenReturn(Collections.singletonList(
+						new ColumnModel().setId("100").setName("name").setColumnType(ColumnType.STRING)));
+		when(searchConfigurationResolver.resolve(any(), any(), any())).thenReturn(Optional.empty());
+		when(tableQueryManager.querySinglePage(any(), any(), any(), any()))
+				.thenReturn(new QueryResultBundle().setQueryCount(0L));
+
+		// call under test
+		manager.handleCreate(progressCallback, ENTITY_ID, USER_ID);
+
+		verify(writeLock).close();
+		ArgumentCaptor<SearchIndexStatus> captor = ArgumentCaptor.forClass(SearchIndexStatus.class);
+		verify(statusDao, org.mockito.Mockito.times(2)).createOrUpdate(captor.capture());
+		assertEquals(SearchIndexState.ACTIVE, captor.getAllValues().get(1).getState());
+	}
+
+	@Test
+	public void testHandleCreateReleasesLockOnFailure() throws Exception {
+		stubBuildLock();
+		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
+		when(userManager.getUserInfo(USER_ID)).thenReturn(triggeringUser());
+		SearchIndex searchIndex = new SearchIndex();
+		searchIndex.setDefiningSQL(DEFINING_SQL);
+		searchIndex.setParentId("syn100");
+		when(entityManager.getEntity(triggeringUser(), ENTITY_ID, SearchIndex.class)).thenReturn(searchIndex);
+		when(tableManagerSupport.getTableSchema(IdAndVersion.parse(ENTITY_ID)))
+				.thenReturn(Collections.singletonList(
+						new ColumnModel().setId("100").setName("name").setColumnType(ColumnType.STRING)));
+		when(searchConfigurationResolver.resolve(any(), any(), any())).thenReturn(Optional.empty());
+		when(userManager.getUserInfo(ANON_ID)).thenReturn(anonymousUser());
+		when(tableQueryManager.querySinglePage(any(), any(), any(), any()))
+				.thenThrow(new RuntimeException("unexpected failure"));
+
+		// call under test — exception is swallowed by the FAILED handler, lock must still be released
+		manager.handleCreate(progressCallback, ENTITY_ID, USER_ID);
+
+		verify(writeLock).close();
+		ArgumentCaptor<SearchIndexStatus> captor = ArgumentCaptor.forClass(SearchIndexStatus.class);
+		verify(statusDao, org.mockito.Mockito.times(2)).createOrUpdate(captor.capture());
+		assertEquals(SearchIndexState.FAILED, captor.getAllValues().get(1).getState());
 	}
 
 	// -------- SearchIndexRowHandler tests --------

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/SearchManagementController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/SearchManagementController.java
@@ -764,13 +764,49 @@ public class SearchManagementController {
 	 * Start an asynchronous search query job against a
 	 * <a href="${org.sagebionetworks.repo.model.search.table.SearchIndex}">SearchIndex</a>.
 	 * <p>
+	 * The request wraps a
+	 * <a href="${org.sagebionetworks.repo.model.search.SearchQuery}">SearchQuery</a>
+	 * — see that schema for the full set of available knobs. Highlights:
+	 * </p>
+	 * <ul>
+	 *   <li><b>queryType</b> — the full-text query model. See
+	 *       <a href="${org.sagebionetworks.repo.model.search.SearchQueryType}">SearchQueryType</a>
+	 *       for the per-type explanation of scoring, accepted parameters, and when to use each.
+	 *       Default is <code>SIMPLE_QUERY_STRING</code>. An empty or null <code>queryText</code>
+	 *       automatically selects <code>MATCH_ALL</code>.</li>
+	 *   <li><b>queryFields</b> — restrict the search to specific columns, with optional per-field
+	 *       boost using <code>column^N</code> syntax (e.g. <code>"title^3"</code>). Empty means
+	 *       all indexed fields.</li>
+	 *   <li><b>Filters</b> — <code>termsFilters</code>, <code>rangeFilters</code>,
+	 *       <code>existsFilters</code>, and <code>notExistsFilters</code> narrow the result set.
+	 *       All filters run in non-scoring context (yes/no matching, cacheable) — they do not
+	 *       contribute to relevance.</li>
+	 *   <li><b>Facets</b> — <code>facetRequests</code> produce bucket aggregations per column.
+	 *       Sort by <code>COUNT</code> or <code>KEY</code> in either direction; cap each facet
+	 *       with <code>maxValueCount</code>.</li>
+	 *   <li><b>Response tuning</b> — <code>returnFields</code>, <code>sort</code> (including the
+	 *       special <code>_score</code> pseudo-column), <code>offset</code>,
+	 *       <code>limit</code> (capped at 100), and <code>highlight</code>.</li>
+	 * </ul>
+	 * <p>
+	 * Results are returned as a
+	 * <a href="${org.sagebionetworks.repo.model.search.SearchQueryResults}">SearchQueryResults</a>.
 	 * Use <a href="${GET.search.query.async.get.asyncToken}">GET /search/query/async/get/{asyncToken}</a>
-	 * to poll for results.
+	 * to poll for results — while the job is running the GET returns HTTP 202 with a
+	 * <a href="${org.sagebionetworks.repo.model.asynch.AsynchronousJobStatus}">AsynchronousJobStatus</a>.
+	 * </p>
+	 * <p>
+	 * The caller must have <code>READ</code> access to the source table or view that backs the
+	 * SearchIndex. Row-level access is enforced automatically: rows the caller cannot read are
+	 * filtered out of the results before they leave the server.
 	 * </p>
 	 *
 	 * @param userId The ID of the authenticated user.
-	 * @param request The search query request including the searchIndexId and query parameters.
-	 * @return An async job token to poll for results.
+	 * @param request The search query request including the <code>searchIndexId</code> and the
+	 *                embedded <code>SearchQuery</code>.
+	 * @return An async job token. Poll
+	 *         <a href="${GET.search.query.async.get.asyncToken}">GET /search/query/async/get/{asyncToken}</a>
+	 *         for the final results.
 	 */
 	@RequiredScope({ view })
 	@ResponseStatus(HttpStatus.CREATED)
@@ -811,13 +847,22 @@ public class SearchManagementController {
 	 * Perform a synchronous autocomplete search query against a
 	 * <a href="${org.sagebionetworks.repo.model.search.table.SearchIndex}">SearchIndex</a>.
 	 * <p>
-	 * This endpoint uses a PREFIX query type and caps results at 8. It is intended for
-	 * typeahead / autocomplete UI patterns where low latency and small result sets are preferred.
+	 * This endpoint is purpose-built for type-ahead input: it overrides any supplied
+	 * <code>queryType</code> with <code>PREFIX</code> (see
+	 * <a href="${org.sagebionetworks.repo.model.search.SearchQueryType}">SearchQueryType</a>
+	 * for the full description) and caps <code>limit</code> at 8 to keep responses small
+	 * and latency low. Caller-supplied <code>facetRequests</code> and
+	 * <code>highlight</code> are ignored — autocomplete returns matching hits only.
+	 * </p>
+	 * <p>
+	 * For anything that needs scored relevance, faceting, or result counts, use the async
+	 * <a href="${POST.search.query.async.start}">POST /search/query/async/start</a> endpoint
+	 * instead.
 	 * </p>
 	 *
 	 * @param userId The ID of the authenticated user.
-	 * @param request The search query request including the searchIndexId.
-	 * @return The autocomplete results.
+	 * @param request The search query request including the <code>searchIndexId</code>.
+	 * @return The autocomplete results (up to 8 hits).
 	 */
 	@RequiredScope({ view })
 	@ResponseStatus(HttpStatus.OK)

--- a/services/workers/src/main/java/org/sagebionetworks/search/workers/SearchIndexLifecycleWorker.java
+++ b/services/workers/src/main/java/org/sagebionetworks/search/workers/SearchIndexLifecycleWorker.java
@@ -65,7 +65,7 @@ public class SearchIndexLifecycleWorker implements BatchChangeMessageDrivenRunne
 							progressCallback, entityId, message.getUserId());
 					break;
 				case DELETE:
-					searchIndexLifecycleManager.handleDelete(entityId);
+					searchIndexLifecycleManager.handleDelete(progressCallback, entityId);
 					break;
 				default:
 					break;
@@ -85,7 +85,14 @@ public class SearchIndexLifecycleWorker implements BatchChangeMessageDrivenRunne
 			LOG.warn("Transient lock exception for entity {}, retrying: {}", entityId, e.getMessage());
 			throw new RecoverableMessageException(e);
 		} catch (NotFoundException e) {
-			searchIndexLifecycleManager.handleDelete(entityId);
+			try {
+				searchIndexLifecycleManager.handleDelete(progressCallback, entityId);
+			} catch (RecoverableMessageException rme) {
+				LOG.warn("Recoverable exception for entity {}: {}", entityId, rme.getMessage());
+				throw rme;
+			} catch (Exception deleteEx) {
+				LOG.error("Failed to process lifecycle message for entity: " + entityId, deleteEx);
+			}
 		} catch (Throwable e) {
 			// Unexpected — keep full stack trace; this is the path that surfaces real bugs.
 			LOG.error("Failed to process lifecycle message for entity: " + entityId, e);

--- a/services/workers/src/main/java/org/sagebionetworks/search/workers/SearchIndexLifecycleWorker.java
+++ b/services/workers/src/main/java/org/sagebionetworks/search/workers/SearchIndexLifecycleWorker.java
@@ -1,10 +1,8 @@
 package org.sagebionetworks.search.workers;
 
-import java.util.List;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.sagebionetworks.asynchronous.workers.changes.BatchChangeMessageDrivenRunner;
+import org.sagebionetworks.asynchronous.workers.changes.ChangeMessageDrivenRunner;
 import org.sagebionetworks.repo.manager.search.SearchIndexLifecycleManager;
 import org.sagebionetworks.repo.model.EntityType;
 import org.sagebionetworks.repo.model.ObjectType;
@@ -23,7 +21,7 @@ import org.springframework.stereotype.Service;
 import org.sagebionetworks.database.semaphore.LockReleaseFailedException;
 
 @Service
-public class SearchIndexLifecycleWorker implements BatchChangeMessageDrivenRunner {
+public class SearchIndexLifecycleWorker implements ChangeMessageDrivenRunner {
 
 	private static final Logger LOG = LogManager.getLogger(SearchIndexLifecycleWorker.class);
 
@@ -37,14 +35,12 @@ public class SearchIndexLifecycleWorker implements BatchChangeMessageDrivenRunne
 	}
 
 	@Override
-	public void run(ProgressCallback progressCallback, List<ChangeMessage> messages)
+	public void run(ProgressCallback progressCallback, ChangeMessage message)
 			throws RecoverableMessageException, Exception {
-		for (ChangeMessage message : messages) {
-			if (message.getObjectType() != ObjectType.ENTITY) {
-				continue;
-			}
-			processMessage(progressCallback, message);
+		if (message.getObjectType() != ObjectType.ENTITY) {
+			return;
 		}
+		processMessage(progressCallback, message);
 	}
 
 	private void processMessage(ProgressCallback progressCallback, ChangeMessage message)

--- a/services/workers/src/test/java/org/sagebionetworks/search/workers/SearchIndexLifecycleWorkerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/search/workers/SearchIndexLifecycleWorkerTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,7 +69,7 @@ public class SearchIndexLifecycleWorkerTest {
 		msg.setChangeType(ChangeType.CREATE);
 
 		// call under test
-		worker.run(progressCallback, Collections.singletonList(msg));
+		worker.run(progressCallback, msg);
 
 		verifyZeroInteractions(nodeDao);
 		verifyZeroInteractions(searchIndexLifecycleManager);
@@ -82,7 +80,7 @@ public class SearchIndexLifecycleWorkerTest {
 		when(nodeDao.getNodeTypeById(ENTITY_ID)).thenReturn(EntityType.file);
 
 		// call under test
-		worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE)));
+		worker.run(progressCallback, entityMessage(ENTITY_ID, ChangeType.CREATE));
 
 		verifyZeroInteractions(searchIndexLifecycleManager);
 	}
@@ -92,7 +90,7 @@ public class SearchIndexLifecycleWorkerTest {
 		when(nodeDao.getNodeTypeById(ENTITY_ID)).thenReturn(EntityType.searchindex);
 
 		// call under test
-		worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE)));
+		worker.run(progressCallback, entityMessage(ENTITY_ID, ChangeType.CREATE));
 
 		verify(searchIndexLifecycleManager).handleCreate(progressCallback, ENTITY_ID, USER_ID);
 		verify(searchIndexLifecycleManager, never()).handleUpdate(progressCallback, ENTITY_ID, USER_ID);
@@ -104,7 +102,7 @@ public class SearchIndexLifecycleWorkerTest {
 		when(nodeDao.getNodeTypeById(ENTITY_ID)).thenReturn(EntityType.searchindex);
 
 		// call under test
-		worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.UPDATE)));
+		worker.run(progressCallback, entityMessage(ENTITY_ID, ChangeType.UPDATE));
 
 		verify(searchIndexLifecycleManager).handleUpdate(progressCallback, ENTITY_ID, USER_ID);
 		verify(searchIndexLifecycleManager, never()).handleCreate(progressCallback, ENTITY_ID, USER_ID);
@@ -116,7 +114,7 @@ public class SearchIndexLifecycleWorkerTest {
 		when(nodeDao.getNodeTypeById(ENTITY_ID)).thenReturn(EntityType.searchindex);
 
 		// call under test
-		worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.DELETE)));
+		worker.run(progressCallback, entityMessage(ENTITY_ID, ChangeType.DELETE));
 
 		verify(searchIndexLifecycleManager).handleDelete(progressCallback, ENTITY_ID);
 		verify(searchIndexLifecycleManager, never()).handleCreate(progressCallback, ENTITY_ID, USER_ID);
@@ -128,7 +126,7 @@ public class SearchIndexLifecycleWorkerTest {
 		when(nodeDao.getNodeTypeById(ENTITY_ID)).thenThrow(new NotFoundException("not found"));
 
 		// call under test
-		worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.UPDATE)));
+		worker.run(progressCallback, entityMessage(ENTITY_ID, ChangeType.UPDATE));
 
 		verify(searchIndexLifecycleManager).handleDelete(progressCallback, ENTITY_ID);
 		verify(searchIndexLifecycleManager, never()).handleCreate(progressCallback, ENTITY_ID, USER_ID);
@@ -143,7 +141,7 @@ public class SearchIndexLifecycleWorkerTest {
 
 		// call under test
 		assertThrows(RecoverableMessageException.class, () ->
-				worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE))));
+				worker.run(progressCallback, entityMessage(ENTITY_ID, ChangeType.CREATE)));
 
 		verify(searchIndexLifecycleManager, never()).handleDelete(progressCallback, ENTITY_ID);
 	}
@@ -156,7 +154,7 @@ public class SearchIndexLifecycleWorkerTest {
 
 		// call under test
 		assertThrows(RecoverableMessageException.class, () ->
-				worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE))));
+				worker.run(progressCallback, entityMessage(ENTITY_ID, ChangeType.CREATE)));
 
 		verify(searchIndexLifecycleManager, never()).handleDelete(progressCallback, ENTITY_ID);
 	}
@@ -169,7 +167,7 @@ public class SearchIndexLifecycleWorkerTest {
 
 		// call under test
 		assertThrows(RecoverableMessageException.class, () ->
-				worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE))));
+				worker.run(progressCallback, entityMessage(ENTITY_ID, ChangeType.CREATE)));
 	}
 
 	@Test
@@ -179,7 +177,7 @@ public class SearchIndexLifecycleWorkerTest {
 				.when(searchIndexLifecycleManager).handleCreate(progressCallback, ENTITY_ID, USER_ID);
 
 		// call under test — the manager records FAILED; worker logs and moves on.
-		worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE)));
+		worker.run(progressCallback, entityMessage(ENTITY_ID, ChangeType.CREATE));
 
 		verify(searchIndexLifecycleManager, never()).handleDelete(progressCallback, ENTITY_ID);
 	}
@@ -204,7 +202,7 @@ public class SearchIndexLifecycleWorkerTest {
 
 		// call under test
 		assertThrows(RecoverableMessageException.class, () ->
-				worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE))));
+				worker.run(progressCallback, entityMessage(ENTITY_ID, ChangeType.CREATE)));
 	}
 
 	@Test
@@ -214,7 +212,7 @@ public class SearchIndexLifecycleWorkerTest {
 				.when(searchIndexLifecycleManager).handleCreate(progressCallback, ENTITY_ID, USER_ID);
 
 		// call under test — unknown runtime exceptions are logged and swallowed.
-		worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE)));
+		worker.run(progressCallback, entityMessage(ENTITY_ID, ChangeType.CREATE));
 
 		verify(searchIndexLifecycleManager, never()).handleDelete(progressCallback, ENTITY_ID);
 	}

--- a/services/workers/src/test/java/org/sagebionetworks/search/workers/SearchIndexLifecycleWorkerTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/search/workers/SearchIndexLifecycleWorkerTest.java
@@ -96,7 +96,7 @@ public class SearchIndexLifecycleWorkerTest {
 
 		verify(searchIndexLifecycleManager).handleCreate(progressCallback, ENTITY_ID, USER_ID);
 		verify(searchIndexLifecycleManager, never()).handleUpdate(progressCallback, ENTITY_ID, USER_ID);
-		verify(searchIndexLifecycleManager, never()).handleDelete(ENTITY_ID);
+		verify(searchIndexLifecycleManager, never()).handleDelete(progressCallback, ENTITY_ID);
 	}
 
 	@Test
@@ -108,7 +108,7 @@ public class SearchIndexLifecycleWorkerTest {
 
 		verify(searchIndexLifecycleManager).handleUpdate(progressCallback, ENTITY_ID, USER_ID);
 		verify(searchIndexLifecycleManager, never()).handleCreate(progressCallback, ENTITY_ID, USER_ID);
-		verify(searchIndexLifecycleManager, never()).handleDelete(ENTITY_ID);
+		verify(searchIndexLifecycleManager, never()).handleDelete(progressCallback, ENTITY_ID);
 	}
 
 	@Test
@@ -118,7 +118,7 @@ public class SearchIndexLifecycleWorkerTest {
 		// call under test
 		worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.DELETE)));
 
-		verify(searchIndexLifecycleManager).handleDelete(ENTITY_ID);
+		verify(searchIndexLifecycleManager).handleDelete(progressCallback, ENTITY_ID);
 		verify(searchIndexLifecycleManager, never()).handleCreate(progressCallback, ENTITY_ID, USER_ID);
 		verify(searchIndexLifecycleManager, never()).handleUpdate(progressCallback, ENTITY_ID, USER_ID);
 	}
@@ -130,7 +130,7 @@ public class SearchIndexLifecycleWorkerTest {
 		// call under test
 		worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.UPDATE)));
 
-		verify(searchIndexLifecycleManager).handleDelete(ENTITY_ID);
+		verify(searchIndexLifecycleManager).handleDelete(progressCallback, ENTITY_ID);
 		verify(searchIndexLifecycleManager, never()).handleCreate(progressCallback, ENTITY_ID, USER_ID);
 		verify(searchIndexLifecycleManager, never()).handleUpdate(progressCallback, ENTITY_ID, USER_ID);
 	}
@@ -145,7 +145,7 @@ public class SearchIndexLifecycleWorkerTest {
 		assertThrows(RecoverableMessageException.class, () ->
 				worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE))));
 
-		verify(searchIndexLifecycleManager, never()).handleDelete(ENTITY_ID);
+		verify(searchIndexLifecycleManager, never()).handleDelete(progressCallback, ENTITY_ID);
 	}
 
 	@Test
@@ -158,7 +158,7 @@ public class SearchIndexLifecycleWorkerTest {
 		assertThrows(RecoverableMessageException.class, () ->
 				worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE))));
 
-		verify(searchIndexLifecycleManager, never()).handleDelete(ENTITY_ID);
+		verify(searchIndexLifecycleManager, never()).handleDelete(progressCallback, ENTITY_ID);
 	}
 
 	@Test
@@ -181,7 +181,7 @@ public class SearchIndexLifecycleWorkerTest {
 		// call under test — the manager records FAILED; worker logs and moves on.
 		worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE)));
 
-		verify(searchIndexLifecycleManager, never()).handleDelete(ENTITY_ID);
+		verify(searchIndexLifecycleManager, never()).handleDelete(progressCallback, ENTITY_ID);
 	}
 
 	@ParameterizedTest
@@ -216,6 +216,6 @@ public class SearchIndexLifecycleWorkerTest {
 		// call under test — unknown runtime exceptions are logged and swallowed.
 		worker.run(progressCallback, Collections.singletonList(entityMessage(ENTITY_ID, ChangeType.CREATE)));
 
-		verify(searchIndexLifecycleManager, never()).handleDelete(ENTITY_ID);
+		verify(searchIndexLifecycleManager, never()).handleDelete(progressCallback, ENTITY_ID);
 	}
 }


### PR DESCRIPTION
## Changes

### 1. Index-writable probe between `createIndex` and the row stream

AOSS acknowledges `createIndex` and the index becomes queryable before the shards are actually ready to accept *writes*. The lifecycle manager was streaming rows into the fresh index seconds later and hitting `index_not_found_exception` on the first bulk call — surfaced as a permanent FAILED status on the `SearchIndex` entity even though nothing was wrong with the configuration.

`OpenSearchManager.waitForIndexWritable(String)` writes a fixed-id sentinel document (`__readiness_probe__`, `_row_id = -1`) and deletes it. It's the only reliable readiness signal: a query-based probe returns empty results before shards are ready, so it wasn't catching the race. The probe is called in `SearchIndexLifecycleManagerImpl.buildIndex` between `createIndex` and `runQueryAsStream`. On exhaustion it throws `RecoverableMessageException` so SQS retries the rebuild instead of marking the entity FAILED.

### 2. Intra-batch bulk-index retry with per-document fallback

When AOSS returns transient 5xx/429 on a subset of documents, `OpenSearchManagerImpl.bulkIndex()` previously threw `RecoverableMessageException` for the whole batch, causing SQS to redeliver the full batch repeatedly — producing the same partial failure every time (observed as "462 rejected out of 782" looping for minutes on `syn74846962`).

`bulkIndex()` now wraps the AOSS call in `TimeUtils.waitForExponentialMaxRetry` (10 attempts, 10s initial backoff, 1.2× multiplier — sequence ≈ 10, 12, 14.4, 17.3, 20.7, 24.9, 29.9, 35.8, 43.0s). The shape:

- **Attempt 1** submits the whole batch in one bulk request.
- **Attempts 2..N** iterate the list of incomplete ops and send each op as its own single-op bulk request, so a single slow shard can't cause the whole batch to be rejected again.
- Each op is removed from the incomplete list only *after* `executeBulk` returns. If an envelope-level `RetryException` (429 / 5xx / IOException) aborts the per-op loop mid-iteration, the ops that already landed are gone from the list and the next attempt only resubmits what's left.
- Permanent 4xx item failures short-circuit immediately with up to 5 sample descriptors embedded in the exception message.
- A single WARN is logged per attempt (not per item) so sustained throttling doesn't explode log volume; per-item ERROR descriptors are emitted only if retries are exhausted.

`SearchIndexLifecycleManagerImpl.BATCH_SIZE` is bumped `100 → 1000` now that per-op retry exists to handle partial rejection.

```mermaid
sequenceDiagram
    autonumber
    participant L as LifecycleManager
    participant M as OpenSearchManagerImpl
    participant A as AOSS

    L->>M: createIndex
    M->>A: PUT index
    A-->>M: acknowledged, shards not yet writable

    rect rgba(200,220,255,0.25)
      Note over L,A: 1. Wait until the index actually accepts writes
      L->>M: waitForIndexWritable
      M->>A: index sentinel doc
      A-->>M: 404 index_not_found_exception
      M->>M: back off
      M->>A: index sentinel doc
      A-->>M: 201 Created
      M->>A: delete sentinel doc
      A-->>M: 200 Deleted
    end

    L->>M: bulkIndex 1000 docs

    rect rgba(255,230,200,0.25)
      Note over M,A: 2. Attempt 1 - whole batch
      M->>A: bulk(1000)
      A-->>M: 800 ok, 200 retryable 429
      M->>M: keep 200 as incomplete
      M->>M: back off
    end

    rect rgba(220,255,220,0.25)
      Note over M,A: 3. Attempts 2..N - one op per bulk request
      loop for each op in incomplete
        M->>A: bulk one op
        A-->>M: ok / 429 / 5xx / 4xx
        M->>M: drop op from incomplete on return
      end
      M->>M: classify aggregated items
      M->>M: retry if any still incomplete
      M-->>L: 1000
    end

    Note over L,A: Exhaustion path: waitForIndexWritable OR bulkIndex throws<br/>RecoverableMessageException, SQS retries, entity stays in CREATING
```

### 3. Single-message lifecycle worker

`SearchIndexLifecycleWorker` now implements `ChangeMessageDrivenRunner` instead of `BatchChangeMessageDrivenRunner`. The batch worker's "batch-size=1 fallback on failure" pattern doesn't apply to this worker — a SearchIndex rebuild can take minutes, so per-message concurrency is the right granularity. Non-`ENTITY` messages return immediately.

### 4. Write semaphore on lifecycle build/delete

`handleCreate`, `handleUpdate`, and `handleDelete` acquire a per-entity `WriteLock` via `WriteReadSemaphore` before touching the AOSS index or status table. If the lock is unavailable (another worker is already building the same index), a `RecoverableMessageException` is thrown so SQS backs off and retries. This fixes a race where a create worker and an update worker could concurrently build/delete the same index, clobbering each other — and replaces the previous ad-hoc CREATING-state check in `handleDelete`.

### 5. Remove 10k cap on `track_total_hits`

OpenSearch defaults `track_total_hits` to `10000`. When the `TOTAL_HITS` response part is requested, the search request now sets the count variant to `Integer.MAX_VALUE` so AOSS counts all matching documents accurately.

### 6. Schema doc improvements

Expanded descriptions on `SearchQuery`, `SearchQueryType`, `KeyRange`, `KeyValues`, and the `SearchManagementController` Javadoc to clarify query semantics, filter behavior, field boost syntax, and pagination limits.

## Test plan

- [x] `mvn test -pl services/repository-managers -Dtest=OpenSearchManagerImplTest` (119 tests) — covers:
  - Probe happy-path, transient-then-success, exhaustion → `RecoverableMessageException`, `IOException` exhaustion, cleanup-delete failure swallowed
  - Attempt 1 whole-batch success; attempt 1 partial failure → per-op retries drain remaining docs
  - Per-op retries resubmit only the still-incomplete docs (captured via `ArgumentCaptor`)
  - Envelope 503 mid per-op loop does NOT resubmit already-succeeded docs
  - Permanent 4xx item failure short-circuits without further retries; sample descriptors embedded in exception message capped at 5
  - Retry exhaustion → `RecoverableMessageException`; `track_total_hits` count wiring
- [x] `mvn test -pl services/repository-managers -Dtest=SearchIndexLifecycleManagerImplTest` (21 tests) — covers:
  - `InOrder` call sequence: `deleteIndex` → `createIndex` → `waitForIndexWritable` → `runQueryAsStream`
  - Probe `RecoverableMessageException` propagates without recording FAILED and without starting the row stream
  - Write-lock acquisition on create/update/delete and `LockUnavilableException` → `RecoverableMessageException` conversion
- [x] `mvn test -pl services/repository-managers -Dtest=OpenSearchManagerImplAutoWiredTest` (14 tests, live AWS, ~150s) — exercises the real probe and bulk paths against the dev AOSS collection
- [x] `mvn verify -pl integration-test -Dit.test='ITSearchIndexEntityTest,ITSearchQueryTest,ITSearchConfigurationTest,IT510SynapseJavaClientSearchTest'` — full-stack search IT tests
- [ ] Deploy to dev pipeline; trigger a SearchIndex build large enough to provoke AOSS throttling and confirm:
  - `"Index {} not yet writable (attempt N/10)"` WARN lines appear if shards are slow
  - `"Bulk index attempt N/10 for {}: K retryable of M; backing off"` WARN on partial batch failure
  - Job reaches ACTIVE instead of FAILED
