### PR TITLE
[PLFM-9636]: Fix Synonym loading and multi-word synonym expansion in SearchIndex queries

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/ITTextAnalyzerTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITTextAnalyzerTest.java
@@ -57,7 +57,7 @@ public class ITTextAnalyzerTest {
 		toCreate.setOrganizationName(orgName);
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
-		settings.setFilterOrder(Arrays.asList("lowercase"));
+		settings.setIndexFilterOrder(Arrays.asList("lowercase"));
 		toCreate.setSettings(settings);
 
 		// call under test

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/search/TextAnalyzerDaoImplAutowiredTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/search/TextAnalyzerDaoImplAutowiredTest.java
@@ -156,6 +156,10 @@ public class TextAnalyzerDaoImplAutowiredTest {
 		settings.setTokenizer("standard");
 		settings.setSynonymAware(true);
 		settings.setIndexFilterOrder(Arrays.asList("lowercase", "english_stop", "english_stemmer"));
+		// searchFilterOrder is the asymmetric search-time chain — distinct from
+		// indexFilterOrder both in length and content, so a round-trip that loses or
+		// swaps one will fail on the assertions below.
+		settings.setSearchFilterOrder(Arrays.asList("lowercase", "synapse_synonyms", "english_stop"));
 		settings.setTokenFilters("{\"english_stop\":{\"type\":\"stop\",\"stopwords\":\"_english_\"},"
 				+ "\"english_stemmer\":{\"type\":\"stemmer\",\"language\":\"english\"}}");
 
@@ -167,13 +171,7 @@ public class TextAnalyzerDaoImplAutowiredTest {
 		TextAnalyzer created = textAnalyzerDao.create(analyzer, adminUserId);
 		TextAnalyzer fetched = textAnalyzerDao.get(Long.parseLong(created.getId())).get();
 
-		TextAnalyzerSettings fetchedSettings = fetched.getSettings();
-		assertEquals("standard", fetchedSettings.getTokenizer());
-		assertTrue(fetchedSettings.getSynonymAware());
-		assertEquals(Arrays.asList("lowercase", "english_stop", "english_stemmer"), fetchedSettings.getIndexFilterOrder());
-		assertNotNull(fetchedSettings.getTokenFilters());
-		assertTrue(fetchedSettings.getTokenFilters().contains("english_stop"));
-		assertTrue(fetchedSettings.getTokenFilters().contains("english_stemmer"));
+		assertEquals(settings, fetched.getSettings());
 	}
 
 	private TextAnalyzer newAnalyzer(String name, String description) {

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/search/TextAnalyzerDaoImplAutowiredTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/search/TextAnalyzerDaoImplAutowiredTest.java
@@ -155,7 +155,7 @@ public class TextAnalyzerDaoImplAutowiredTest {
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
 		settings.setSynonymAware(true);
-		settings.setFilterOrder(Arrays.asList("lowercase", "english_stop", "english_stemmer"));
+		settings.setIndexFilterOrder(Arrays.asList("lowercase", "english_stop", "english_stemmer"));
 		settings.setTokenFilters("{\"english_stop\":{\"type\":\"stop\",\"stopwords\":\"_english_\"},"
 				+ "\"english_stemmer\":{\"type\":\"stemmer\",\"language\":\"english\"}}");
 
@@ -170,7 +170,7 @@ public class TextAnalyzerDaoImplAutowiredTest {
 		TextAnalyzerSettings fetchedSettings = fetched.getSettings();
 		assertEquals("standard", fetchedSettings.getTokenizer());
 		assertTrue(fetchedSettings.getSynonymAware());
-		assertEquals(Arrays.asList("lowercase", "english_stop", "english_stemmer"), fetchedSettings.getFilterOrder());
+		assertEquals(Arrays.asList("lowercase", "english_stop", "english_stemmer"), fetchedSettings.getIndexFilterOrder());
 		assertNotNull(fetchedSettings.getTokenFilters());
 		assertTrue(fetchedSettings.getTokenFilters().contains("english_stop"));
 		assertTrue(fetchedSettings.getTokenFilters().contains("english_stemmer"));
@@ -183,7 +183,7 @@ public class TextAnalyzerDaoImplAutowiredTest {
 		analyzer.setOrganizationName(organizationName);
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
-		settings.setFilterOrder(Arrays.asList("lowercase"));
+		settings.setIndexFilterOrder(Arrays.asList("lowercase"));
 		analyzer.setSettings(settings);
 		return analyzer;
 	}

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/search/TextAnalyzerDaoImplAutowiredTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/search/TextAnalyzerDaoImplAutowiredTest.java
@@ -156,9 +156,6 @@ public class TextAnalyzerDaoImplAutowiredTest {
 		settings.setTokenizer("standard");
 		settings.setSynonymAware(true);
 		settings.setIndexFilterOrder(Arrays.asList("lowercase", "english_stop", "english_stemmer"));
-		// searchFilterOrder is the asymmetric search-time chain — distinct from
-		// indexFilterOrder both in length and content, so a round-trip that loses or
-		// swaps one will fail on the assertions below.
 		settings.setSearchFilterOrder(Arrays.asList("lowercase", "synapse_synonyms", "english_stop"));
 		settings.setTokenFilters("{\"english_stop\":{\"type\":\"stop\",\"stopwords\":\"_english_\"},"
 				+ "\"english_stemmer\":{\"type\":\"stemmer\",\"language\":\"english\"}}");

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/table/ColumnAnalyzerOverrideEntry.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/table/ColumnAnalyzerOverrideEntry.json
@@ -11,7 +11,7 @@
 		},
 		"searchAnalyzer": {
 			"type": "string",
-			"description": "The qualified name ('{organizationName}-{name}') of the TextAnalyzer to use when searching this column."
+			"description": "The qualified name ('{organizationName}-{name}') of the TextAnalyzer to use when searching this column. Most asymmetric analysis should be expressed by setting 'searchFilterOrder' on the analyzer itself; reach for this field only when search needs a *different analyzer record* than indexing (for example, when reusing a single search-time analyzer across columns indexed with different analyzers). Synonym handling does NOT require setting this — when the chosen analyzer has 'synonymAware=true', the synonym-enabled search variant is selected automatically."
 		}
 	}
 }

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/table/SynonymRule.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/table/SynonymRule.json
@@ -6,7 +6,7 @@
 			"$ref": "org.sagebionetworks.repo.model.search.table.SynonymRuleType"
 		},
 		"terms": {
-			"description": "The list of synonym terms. Minimum 2. For EQUIVALENT: all terms are interchangeable. For EXPLICIT: first term expands to the rest.",
+			"description": "The list of synonym terms. Minimum 2. For EQUIVALENT: all terms are interchangeable. For EXPLICIT: first term expands to the rest. Authoring is case-insensitive — a rule authored as 'BRCA1, breast cancer 1' triggers expansion for any casing of the query (BRCA1, brca1, Brca1), because the system registers both the user-authored form and a lowercased copy with the synonym filter.",
 			"type": "array",
 			"items": {
 				"type": "string"

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/table/TextAnalyzerSettings.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/table/TextAnalyzerSettings.json
@@ -17,19 +17,24 @@
 			"type": "string",
 			"description": "JSON string defining named token filter configurations. Each key is a filter name, each value is the filter config object."
 		},
-		"filterOrder": {
+		"indexFilterOrder": {
 			"type": "array",
-			"description": "Ordered list of token filter names to apply. Can reference built-in filters (e.g., 'lowercase') or custom ones defined in 'tokenFilters'.",
+			"description": "Ordered list of token filter names applied at INDEX time. Can reference built-in filters (e.g., 'lowercase') or custom ones defined in 'tokenFilters'.",
+			"items": { "type": "string" }
+		},
+		"searchFilterOrder": {
+			"type": "array",
+			"description": "Ordered list of token filter names applied at SEARCH time. Optional. If absent, search reuses 'indexFilterOrder' (symmetric analysis). Set this when index-time and search-time analysis legitimately differ — e.g., index with 'edge_ngram' and search without it (autocomplete pattern), or index without stop words and search with stop-word removal. When 'synonymAware' is true this field is REQUIRED and must include the literal 'synapse_synonyms' token (the system-managed synonym filter); every filter BEFORE 'synapse_synonyms' must produce single-position output (positionLength=1), so 'word_delimiter' and 'word_delimiter_graph' must be placed AFTER it. Synonym rule casing is handled automatically — see SynonymRule.terms.",
 			"items": { "type": "string" }
 		},
 		"charFilterOrder": {
 			"type": "array",
-			"description": "Ordered list of character filter names to apply.",
+			"description": "Ordered list of character filter names to apply. Used for both index-time and search-time analysis.",
 			"items": { "type": "string" }
 		},
 		"synonymAware": {
 			"type": "boolean",
-			"description": "Whether the synonym token filter should be appended when synonyms are configured."
+			"description": "When true, the system-managed 'synapse_synonyms' token filter is wired into the search-time chain at the position the user authored in 'searchFilterOrder'. Setting this true requires 'searchFilterOrder' to be provided and to contain 'synapse_synonyms'."
 		}
 	}
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -131,6 +131,7 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	static final String CONCURRENT_DELETES_MARKER = "concurrent deletes";
 	private static final String ANALYZER_PREFIX = "synapse_analyzer_";
 	private static final String SYNONYM_FILTER_NAME = "synapse_synonyms";
+	static final String SEARCH_ANALYZER_SUFFIX = "_search";
 
 	/** True when the OpenSearch error is AOSS's "concurrent deletes" rejection. */
 	static boolean isConcurrentDeleteError(OpenSearchException e) {
@@ -169,7 +170,7 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 						return a;
 					}))
 					.mappings(m -> {
-						buildMappings(m, columns, defaultAnalyzer, overrideMap, analyzers);
+						buildMappings(m, columns, defaultAnalyzer, overrideMap, analyzers, hasSynonyms);
 						return m;
 					})
 			);
@@ -196,8 +197,11 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	private void buildAnalysisSettings(IndexSettingsAnalysis.Builder a,
 			Map<String, TextAnalyzer> analyzers, boolean hasSynonyms, List<String> synonymRules) {
 		if (hasSynonyms) {
+			// synonym_graph (not plain synonym) so multi-word left-hand sides like
+			// "deep learning, DL" expand at query time — plain synonym can't emit the
+			// multi-position graph tokens needed for a phrase to match its abbreviation.
 			a.filter(SYNONYM_FILTER_NAME, f -> f.definition(d -> d
-					.synonym(syn -> syn.synonyms(synonymRules))));
+					.synonymGraph(syn -> syn.synonyms(synonymRules))));
 		}
 		for (Map.Entry<String, TextAnalyzer> entry : analyzers.entrySet()) {
 			registerAnalyzer(a, entry.getValue(), hasSynonyms);
@@ -221,29 +225,54 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 			tokenizer = customTokenizerName;
 		}
 
-		List<String> filters = new ArrayList<>();
-		// Synonym filter must come BEFORE word_delimiter-style filters: OpenSearch parses each
-		// synonym entry through all preceding filters, and word_delimiter can emit multiple
-		// tokens per input which synonym parsing rejects with "Token filter [X] cannot be used
-		// to parse synonyms".
-		if (Boolean.TRUE.equals(settings.getSynonymAware()) && hasSynonyms) {
-			filters.add(SYNONYM_FILTER_NAME);
-		}
-		if (settings.getFilterOrder() != null) {
-			filters.addAll(settings.getFilterOrder());
-		}
-
 		String analyzerName = ANALYZER_PREFIX + analyzer.getId();
-		final String finalTokenizer = tokenizer;
-		final List<String> finalFilters = filters;
+		List<String> declared = settings.getFilterOrder() != null ? settings.getFilterOrder() : Collections.emptyList();
 
-		a.analyzer(analyzerName, an -> an.custom(c -> {
-			c.tokenizer(finalTokenizer);
-			if (!finalFilters.isEmpty()) {
-				c.filter(finalFilters);
+		// Synonym expansion runs only at search time. At index time, running synonyms
+		// before word_delimiter trips Lucene's offset-monotonicity invariant once an
+		// expansion is token-split.
+		registerCustomAnalyzer(a, analyzerName, tokenizer, declared, settings.getCharFilterOrder());
+
+		if (Boolean.TRUE.equals(settings.getSynonymAware()) && hasSynonyms) {
+			registerCustomAnalyzer(a, analyzerName + SEARCH_ANALYZER_SUFFIX, tokenizer,
+					buildSearchFilterChain(declared), settings.getCharFilterOrder());
+		}
+	}
+
+	/**
+	 * Builds the search-time filter chain. The synonym filter parses each rule by walking
+	 * the chain segment that precedes it, and rejects any preceding filter whose output
+	 * has positionLength > 1 — including both {@code word_delimiter} and
+	 * {@code word_delimiter_graph}. So the synonym filter must come BEFORE every
+	 * word_delimiter* filter at search time. Placing {@code lowercase} first (a strict
+	 * 1-to-1 filter, accepted by synonym rule-parsing) and then the synonym filter gives
+	 * us case-insensitive matching for both rules and queries; word_delimiter* runs
+	 * downstream on the synonym-expanded stream. Index-time word_delimiter* still runs
+	 * on raw tokens with {@code preserve_original=true}, so split sub-tokens like
+	 * {@code messenger}/{@code rna} from {@code messengerRNA} are present in the index
+	 * regardless.
+	 */
+	private static List<String> buildSearchFilterChain(List<String> declared) {
+		List<String> filters = new ArrayList<>(declared.size() + 1);
+		filters.add("lowercase");
+		filters.add(SYNONYM_FILTER_NAME);
+		for (String filter : declared) {
+			if (!"lowercase".equals(filter)) {
+				filters.add(filter);
 			}
-			if (settings.getCharFilterOrder() != null && !settings.getCharFilterOrder().isEmpty()) {
-				c.charFilter(settings.getCharFilterOrder());
+		}
+		return filters;
+	}
+
+	private void registerCustomAnalyzer(IndexSettingsAnalysis.Builder a, String name,
+			String tokenizer, List<String> filters, List<String> charFilters) {
+		a.analyzer(name, an -> an.custom(c -> {
+			c.tokenizer(tokenizer);
+			if (!filters.isEmpty()) {
+				c.filter(filters);
+			}
+			if (charFilters != null && !charFilters.isEmpty()) {
+				c.charFilter(charFilters);
 			}
 			return c;
 		}));
@@ -251,7 +280,8 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 
 	private void buildMappings(org.opensearch.client.opensearch._types.mapping.TypeMapping.Builder m,
 			List<ColumnModel> columns, String defaultAnalyzer,
-			Map<String, ColumnAnalyzerOverrideEntry> overrideMap, Map<String, TextAnalyzer> analyzers) {
+			Map<String, ColumnAnalyzerOverrideEntry> overrideMap, Map<String, TextAnalyzer> analyzers,
+			boolean hasSynonyms) {
 		m.properties(SYSTEM_FIELD_ROW_ID, p -> p.long_(l -> l));
 		m.properties(SYSTEM_FIELD_ROW_VERSION, p -> p.long_(l -> l));
 
@@ -266,7 +296,7 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 			ValidateArgument.required(effectiveAnalyzer, "analyzer '" + effectiveAnalyzerName + "' for column " + columnId);
 			ColumnAnalyzerOverrideEntry entry = overrideMap.get(columnId);
 
-			m.properties(columnId, buildProperty(columnType, effectiveAnalyzer, entry, analyzers));
+			m.properties(columnId, buildProperty(columnType, effectiveAnalyzer, entry, analyzers, hasSynonyms));
 		}
 	}
 
@@ -1189,17 +1219,17 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	 */
 	private Property buildProperty(ColumnType columnType,
 			TextAnalyzer effectiveAnalyzer, ColumnAnalyzerOverrideEntry entry,
-			Map<String, TextAnalyzer> analyzers) {
+			Map<String, TextAnalyzer> analyzers, boolean hasSynonyms) {
 
 		if (ColumnTypeToOpenSearchMapping.isTextType(columnType)) {
-			return buildTextProperty(columnType, effectiveAnalyzer, entry, analyzers);
+			return buildTextProperty(columnType, effectiveAnalyzer, entry, analyzers, hasSynonyms);
 		}
 
 		if (ColumnTypeToOpenSearchMapping.isLinkType(columnType)) {
 			if (isKeywordAnalyzer(effectiveAnalyzer)) {
 				return buildKeywordWithSearchableProperty(analyzers);
 			}
-			return buildTextProperty(columnType, effectiveAnalyzer, entry, analyzers);
+			return buildTextProperty(columnType, effectiveAnalyzer, entry, analyzers, hasSynonyms);
 		}
 
 		if (ColumnTypeToOpenSearchMapping.isKeywordType(columnType)) {
@@ -1230,12 +1260,13 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 
 	private Property buildTextProperty(ColumnType columnType,
 			TextAnalyzer effectiveAnalyzer, ColumnAnalyzerOverrideEntry entry,
-			Map<String, TextAnalyzer> analyzers) {
+			Map<String, TextAnalyzer> analyzers, boolean hasSynonyms) {
 		Integer ignoreAbove = ColumnTypeToOpenSearchMapping.getIgnoreAbove(columnType);
 		int ia = ignoreAbove != null ? ignoreAbove : 1000;
 
 		String indexAnalyzerName = resolveIndexAnalyzerName(effectiveAnalyzer, entry, analyzers);
-		String searchAnalyzerName = resolveSearchAnalyzerName(indexAnalyzerName, entry, analyzers);
+		String searchAnalyzerName = resolveSearchAnalyzerName(
+				indexAnalyzerName, effectiveAnalyzer, entry, analyzers, hasSynonyms);
 		final int finalIa = ia;
 
 		return Property.of(p -> p.text(t -> {
@@ -1256,12 +1287,21 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		return analyzerToOpenSearchName(effectiveAnalyzer);
 	}
 
-	String resolveSearchAnalyzerName(String indexAnalyzerName,
-			ColumnAnalyzerOverrideEntry entry, Map<String, TextAnalyzer> analyzers) {
+	String resolveSearchAnalyzerName(String indexAnalyzerName, TextAnalyzer effectiveAnalyzer,
+			ColumnAnalyzerOverrideEntry entry, Map<String, TextAnalyzer> analyzers, boolean hasSynonyms) {
+		TextAnalyzer chosen = effectiveAnalyzer;
+		String chosenName = indexAnalyzerName;
 		if (entry != null && entry.getSearchAnalyzer() != null) {
-			return analyzerToOpenSearchName(analyzers.get(entry.getSearchAnalyzer()));
+			chosen = analyzers.get(entry.getSearchAnalyzer());
+			chosenName = analyzerToOpenSearchName(chosen);
+		} else if (entry != null && entry.getIndexAnalyzer() != null) {
+			chosen = analyzers.get(entry.getIndexAnalyzer());
 		}
-		return indexAnalyzerName;
+		if (hasSynonyms && chosen != null && chosen.getSettings() != null
+				&& Boolean.TRUE.equals(chosen.getSettings().getSynonymAware())) {
+			return chosenName + SEARCH_ANALYZER_SUFFIX;
+		}
+		return chosenName;
 	}
 
 	private Property buildKeywordWithSearchableProperty(Map<String, TextAnalyzer> analyzers) {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -223,42 +223,28 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		}
 
 		String analyzerName = ANALYZER_PREFIX + analyzer.getId();
-		List<String> declared = settings.getFilterOrder() != null ? settings.getFilterOrder() : Collections.emptyList();
+		List<String> indexFilters = settings.getIndexFilterOrder() != null ? settings.getIndexFilterOrder() : Collections.emptyList();
+		registerCustomAnalyzer(a, analyzerName, tokenizer, indexFilters, settings.getCharFilterOrder());
 
-		// Synonym expansion runs only at search time. At index time, running synonyms
-		// before word_delimiter trips Lucene's offset-monotonicity invariant once an
-		// expansion is token-split.
-		registerCustomAnalyzer(a, analyzerName, tokenizer, declared, settings.getCharFilterOrder());
-
-		if (Boolean.TRUE.equals(settings.getSynonymAware()) && hasSynonyms) {
+		if (shouldRegisterSearchVariant(settings, hasSynonyms)) {
 			registerCustomAnalyzer(a, analyzerName + SEARCH_ANALYZER_SUFFIX, tokenizer,
-					buildSearchFilterChain(declared), settings.getCharFilterOrder());
+					settings.getSearchFilterOrder(), settings.getCharFilterOrder());
 		}
 	}
 
 	/**
-	 * Builds the search-time filter chain. The synonym filter parses each rule by walking
-	 * the chain segment that precedes it, and rejects any preceding filter whose output
-	 * has positionLength > 1 — including both {@code word_delimiter} and
-	 * {@code word_delimiter_graph}. So the synonym filter must come BEFORE every
-	 * word_delimiter* filter at search time. Placing {@code lowercase} first (a strict
-	 * 1-to-1 filter, accepted by synonym rule-parsing) and then the synonym filter gives
-	 * us case-insensitive matching for both rules and queries; word_delimiter* runs
-	 * downstream on the synonym-expanded stream. Index-time word_delimiter* still runs
-	 * on raw tokens with {@code preserve_original=true}, so split sub-tokens like
-	 * {@code messenger}/{@code rna} from {@code messengerRNA} are present in the index
-	 * regardless.
+	 * A {@code _search} analyzer variant is registered when the analyzer is asymmetric —
+	 * i.e., it provides a {@code searchFilterOrder} distinct from {@code indexFilterOrder}.
+	 * One special case: if the search chain references {@code synapse_synonyms} but the
+	 * SearchIndex has no synonyms configured, the synonym filter is not registered in the
+	 * index settings; we skip the variant and the analyzer behaves symmetrically.
 	 */
-	private static List<String> buildSearchFilterChain(List<String> declared) {
-		List<String> filters = new ArrayList<>(declared.size() + 1);
-		filters.add("lowercase");
-		filters.add(SYNONYM_FILTER_NAME);
-		for (String filter : declared) {
-			if (!"lowercase".equals(filter)) {
-				filters.add(filter);
-			}
+	private static boolean shouldRegisterSearchVariant(TextAnalyzerSettings settings, boolean hasSynonyms) {
+		List<String> search = settings.getSearchFilterOrder();
+		if (search == null || search.isEmpty()) {
+			return false;
 		}
-		return filters;
+		return hasSynonyms || !search.contains(SYNONYM_FILTER_NAME);
 	}
 
 	private void registerCustomAnalyzer(IndexSettingsAnalysis.Builder a, String name,
@@ -1294,8 +1280,11 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		} else if (entry != null && entry.getIndexAnalyzer() != null) {
 			chosen = analyzers.get(entry.getIndexAnalyzer());
 		}
-		if (hasSynonyms && chosen != null && chosen.getSettings() != null
-				&& Boolean.TRUE.equals(chosen.getSettings().getSynonymAware())) {
+		// Mirror registerAnalyzer's decision: pick the _search variant exactly when one
+		// was registered. Otherwise the analyzer is symmetric and OpenSearch reuses the
+		// index-time analyzer.
+		if (chosen != null && chosen.getSettings() != null
+				&& shouldRegisterSearchVariant(chosen.getSettings(), hasSynonyms)) {
 			return chosenName + SEARCH_ANALYZER_SUFFIX;
 		}
 		return chosenName;
@@ -1350,29 +1339,54 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		return map;
 	}
 
+	/**
+	 * Flattens user-authored {@link SynonymSet}s into the OpenSearch synonym filter's wire
+	 * format. Each rule is emitted twice: once with the user's original casing, once
+	 * lowercased (skipped if the rule is already all-lowercase). This means a query in any
+	 * casing — {@code BRCA1}, {@code brca1}, {@code Brca1} — triggers expansion regardless
+	 * of where {@code lowercase} sits in the analyzer's search-time chain. Users author
+	 * rules in natural casing without learning the chain's casing rules.
+	 *
+	 * <p>Duplicates collapse via {@link java.util.LinkedHashSet}, so a rule whose terms
+	 * are already lowercase doesn't produce two identical lines.
+	 */
 	List<String> buildSynonymRules(List<SynonymSet> synonymSets) {
 		if (synonymSets == null || synonymSets.isEmpty()) {
 			return Collections.emptyList();
 		}
-		List<String> rules = new ArrayList<>();
+		java.util.LinkedHashSet<String> rules = new java.util.LinkedHashSet<>();
 		for (SynonymSet ss : synonymSets) {
 			if (ss.getRules() == null) {
 				continue;
 			}
 			for (SynonymRule rule : ss.getRules()) {
-				if (rule.getTerms() == null || rule.getTerms().size() < 2) {
+				if (rule.getTerms() == null || rule.getTerms().size() < 2 || rule.getRuleType() == null) {
 					continue;
 				}
-				if (rule.getRuleType() == SynonymRuleType.EQUIVALENT) {
-					rules.add(String.join(", ", rule.getTerms()));
-				} else if (rule.getRuleType() == SynonymRuleType.EXPLICIT) {
-					String source = rule.getTerms().get(0);
-					List<String> targets = rule.getTerms().subList(1, rule.getTerms().size());
-					rules.add(source + " => " + String.join(", ", targets));
+				addRuleVariant(rules, rule.getRuleType(), rule.getTerms());
+				List<String> lowered = lowercaseAll(rule.getTerms());
+				if (!lowered.equals(rule.getTerms())) {
+					addRuleVariant(rules, rule.getRuleType(), lowered);
 				}
 			}
 		}
-		return rules;
+		return new ArrayList<>(rules);
+	}
+
+	private static void addRuleVariant(java.util.LinkedHashSet<String> rules, SynonymRuleType type, List<String> terms) {
+		if (type == SynonymRuleType.EQUIVALENT) {
+			rules.add(String.join(", ", terms));
+		} else if (type == SynonymRuleType.EXPLICIT) {
+			rules.add(terms.get(0) + " => " + String.join(", ", terms.subList(1, terms.size())));
+		}
+	}
+
+	private static List<String> lowercaseAll(List<String> terms) {
+		List<String> result = new ArrayList<>(terms.size());
+		for (String term : terms) {
+			result.add(term == null ? null : term.toLowerCase(java.util.Locale.ROOT));
+		}
+		return result;
 	}
 
 	private String analyzerToOpenSearchName(TextAnalyzer analyzer) {
@@ -1411,6 +1425,15 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	@Override
 	public void validateAnalyzerSettings(TextAnalyzerSettings settings) {
 		ValidateArgument.required(settings, "settings");
+
+		if (Boolean.TRUE.equals(settings.getSynonymAware())) {
+			List<String> searchOrder = settings.getSearchFilterOrder();
+			if (searchOrder == null || searchOrder.isEmpty() || !searchOrder.contains(SYNONYM_FILTER_NAME)) {
+				throw new IllegalArgumentException("synonymAware analyzers must declare 'searchFilterOrder' and include '"
+						+ SYNONYM_FILTER_NAME + "' in it. Place '" + SYNONYM_FILTER_NAME
+						+ "' upstream of any 'word_delimiter'/'word_delimiter_graph' filters, and downstream of 'lowercase' for case-insensitive matching.");
+			}
+		}
 
 		Tokenizer tokenizer = buildTokenizer(settings);
 		List<TokenFilter> tokenFilters = buildTokenFilters(settings);
@@ -1462,10 +1485,10 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		}
 
 		List<TokenFilter> tokenFilters = new ArrayList<>();
-		if (settings.getFilterOrder() == null) {
+		if (settings.getIndexFilterOrder() == null) {
 			return tokenFilters;
 		}
-		for (String filterName : settings.getFilterOrder()) {
+		for (String filterName : settings.getIndexFilterOrder()) {
 			TokenFilterDefinition def = tokenFilterDefs.get(filterName);
 			if (def != null) {
 				tokenFilters.add(TokenFilter.of(f -> f.definition(def)));

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -197,9 +197,6 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	private void buildAnalysisSettings(IndexSettingsAnalysis.Builder a,
 			Map<String, TextAnalyzer> analyzers, boolean hasSynonyms, List<String> synonymRules) {
 		if (hasSynonyms) {
-			// synonym_graph (not plain synonym) so multi-word left-hand sides like
-			// "deep learning, DL" expand at query time — plain synonym can't emit the
-			// multi-position graph tokens needed for a phrase to match its abbreviation.
 			a.filter(SYNONYM_FILTER_NAME, f -> f.definition(d -> d
 					.synonymGraph(syn -> syn.synonyms(synonymRules))));
 		}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -222,11 +222,15 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		}
 
 		List<String> filters = new ArrayList<>();
-		if (settings.getFilterOrder() != null) {
-			filters.addAll(settings.getFilterOrder());
-		}
+		// Synonym filter must come BEFORE word_delimiter-style filters: OpenSearch parses each
+		// synonym entry through all preceding filters, and word_delimiter can emit multiple
+		// tokens per input which synonym parsing rejects with "Token filter [X] cannot be used
+		// to parse synonyms".
 		if (Boolean.TRUE.equals(settings.getSynonymAware()) && hasSynonyms) {
 			filters.add(SYNONYM_FILTER_NAME);
+		}
+		if (settings.getFilterOrder() != null) {
+			filters.addAll(settings.getFilterOrder());
 		}
 
 		String analyzerName = ANALYZER_PREFIX + analyzer.getId();

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapper.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapper.java
@@ -105,8 +105,14 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 				+ "\"english_stop\":{\"type\":\"stop\",\"stopwords\":\"_english_\"},"
 				+ "\"english_stemmer\":{\"type\":\"stemmer\",\"language\":\"english\"}"
 				+ "}");
-		settings.setFilterOrder(Arrays.asList(
+		settings.setIndexFilterOrder(Arrays.asList(
 				"sci_word_delimiter", "lowercase", "english_stop", "english_stemmer"));
+		// At search time we run lowercase first (so synonym rule LHS and query tokens reach
+		// the filter in the same case), then synapse_synonyms, then sci_word_delimiter.
+		// word_delimiter_graph must be DOWNSTREAM of synapse_synonyms because the synonym
+		// filter's rule parser rejects upstream filters with positionLength > 1.
+		settings.setSearchFilterOrder(Arrays.asList(
+				"lowercase", "synapse_synonyms", "sci_word_delimiter", "english_stop", "english_stemmer"));
 		settings.setSynonymAware(true);
 		return settings;
 	}
@@ -120,7 +126,8 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
 				+ "\"stem_english_possessive\":true}"
 				+ "}");
-		settings.setFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"));
+		settings.setIndexFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"));
+		settings.setSearchFilterOrder(Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter"));
 		settings.setSynonymAware(true);
 		return settings;
 	}
@@ -134,7 +141,8 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
 				+ "\"stem_english_possessive\":false}"
 				+ "}");
-		settings.setFilterOrder(Arrays.asList("id_word_delimiter", "lowercase"));
+		settings.setIndexFilterOrder(Arrays.asList("id_word_delimiter", "lowercase"));
+		settings.setSearchFilterOrder(Arrays.asList("lowercase", "synapse_synonyms", "id_word_delimiter"));
 		settings.setSynonymAware(true);
 		return settings;
 	}
@@ -161,7 +169,7 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 				+ "\"stem_english_possessive\":true},"
 				+ "\"edge_ngram_filter\":{\"type\":\"edge_ngram\",\"min_gram\":2,\"max_gram\":20}"
 				+ "}");
-		settings.setFilterOrder(Arrays.asList("ac_word_delimiter", "lowercase", "edge_ngram_filter"));
+		settings.setIndexFilterOrder(Arrays.asList("ac_word_delimiter", "lowercase", "edge_ngram_filter"));
 		settings.setSynonymAware(false);
 		return settings;
 	}
@@ -175,7 +183,8 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
 				+ "\"stem_english_possessive\":true}"
 				+ "}");
-		settings.setFilterOrder(Arrays.asList("acs_word_delimiter", "lowercase"));
+		settings.setIndexFilterOrder(Arrays.asList("acs_word_delimiter", "lowercase"));
+		settings.setSearchFilterOrder(Arrays.asList("lowercase", "synapse_synonyms", "acs_word_delimiter"));
 		settings.setSynonymAware(true);
 		return settings;
 	}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapper.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapper.java
@@ -98,7 +98,7 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
 		settings.setTokenFilters("{"
-				+ "\"sci_word_delimiter\":{\"type\":\"word_delimiter\",\"preserve_original\":true,"
+				+ "\"sci_word_delimiter\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true,"
 				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
 				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
 				+ "\"stem_english_possessive\":true},"
@@ -115,7 +115,7 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
 		settings.setTokenFilters("{"
-				+ "\"std_word_delimiter\":{\"type\":\"word_delimiter\",\"preserve_original\":true,"
+				+ "\"std_word_delimiter\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true,"
 				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
 				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
 				+ "\"stem_english_possessive\":true}"
@@ -129,7 +129,7 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("whitespace");
 		settings.setTokenFilters("{"
-				+ "\"id_word_delimiter\":{\"type\":\"word_delimiter\",\"preserve_original\":true,"
+				+ "\"id_word_delimiter\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true,"
 				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
 				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
 				+ "\"stem_english_possessive\":false}"

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.sagebionetworks.repo.model.dbo.search.TextAnalyzerDao;
 import org.sagebionetworks.repo.model.search.SearchFieldValue;
 import org.sagebionetworks.repo.model.search.SearchQuery;
 import org.sagebionetworks.repo.model.search.SearchQueryPart;
@@ -58,6 +59,9 @@ public class OpenSearchManagerImplAutoWiredTest {
 
 	@Autowired
 	private OpenSearchManager openSearchManager;
+
+	@Autowired
+	private TextAnalyzerDao textAnalyzerDao;
 
 	private String indexName;
 	private Map<String, TextAnalyzer> defaultAnalyzers;
@@ -288,8 +292,8 @@ public class OpenSearchManagerImplAutoWiredTest {
 	@Test
 	public void testBulkIndexWithAutocompleteAnalyzerOverride() {
 		// Build the same analyzer settings the bootstrapper installs in production.
-		TextAnalyzer autocomplete = autocompleteIndexAnalyzer();
-		TextAnalyzer autocompleteSearch = autocompleteSearchAnalyzer();
+		TextAnalyzer autocomplete = bootstrappedAnalyzer(TextAnalyzerBootstrapper.AUTOCOMPLETE_ID);
+		TextAnalyzer autocompleteSearch = bootstrappedAnalyzer(TextAnalyzerBootstrapper.AUTOCOMPLETE_SEARCH_ID);
 		TextAnalyzer scientific = buildAnalyzer(TextAnalyzerBootstrapper.SCIENTIFIC_ID, "standard");
 
 		Map<String, TextAnalyzer> analyzers = new HashMap<>();
@@ -333,18 +337,13 @@ public class OpenSearchManagerImplAutoWiredTest {
 	 * Regression test for PLFM-9636: AOSS rejected createIndex with
 	 * "illegal_argument_exception: Token filter [std_word_delimiter] cannot be used to parse synonyms"
 	 * whenever a bootstrapped synonym-aware analyzer was paired with a non-empty SynonymSet.
-	 *
-	 * The bootstrapped STANDARD analyzer starts with {@code std_word_delimiter}
-	 * ({@code word_delimiter} type), which emits multiple tokens per input and therefore cannot
-	 * appear before the synonym filter during synonym parsing. The fix places the synonym filter
-	 * first in the chain. This test confirms (1) createIndex succeeds end-to-end against live
-	 * AOSS with synonyms configured, and (2) a query for one synonym term matches documents
-	 * containing the other.
+	 * Confirms (1) createIndex succeeds against live AOSS with synonyms configured, and
+	 * (2) a query for one synonym term matches documents containing the other.
 	 */
 	@Test
 	public void testCreateIndexWithBootstrappedStandardAnalyzerAndSynonyms() {
 		Map<String, TextAnalyzer> analyzers = new HashMap<>();
-		analyzers.put("org.sagebionetworks-STANDARD", bootstrappedStandardAnalyzer());
+		analyzers.put("org.sagebionetworks-STANDARD", bootstrappedAnalyzer(TextAnalyzerBootstrapper.STANDARD_ID));
 
 		List<ColumnModel> columns = List.of(
 				new ColumnModel().setId("1").setName("diagnosis").setColumnType(ColumnType.STRING));
@@ -382,10 +381,132 @@ public class OpenSearchManagerImplAutoWiredTest {
 				"Query for 'cancer' must return all three docs via EQUIVALENT synonym expansion");
 	}
 
+	/**
+	 * Regression for the Lucene offset-monotonicity bulk-index failure observed on syn9602624:
+	 * hyphenated / CamelCase / digit-letter tokens adjacent to a synonym source term caused
+	 * {@code illegal_argument_exception: startOffset must be non-negative ... offsets must not go backwards}
+	 * when synonym expansion and {@code word_delimiter} both ran at index time. Synonyms now expand only
+	 * at search time, so every document must be accepted and a search for a synonym source must still match.
+	 */
+	@Test
+	public void testBulkIndexWithSynonymsAndWordDelimiterSplittableNeighbors() {
+		Map<String, TextAnalyzer> analyzers = new HashMap<>();
+		analyzers.put("org.sagebionetworks-STANDARD", bootstrappedAnalyzer(TextAnalyzerBootstrapper.STANDARD_ID));
+
+		List<ColumnModel> columns = List.of(
+				new ColumnModel().setId("1").setName("description").setColumnType(ColumnType.STRING));
+
+		org.sagebionetworks.repo.model.search.table.SynonymSet synonymSet =
+				new org.sagebionetworks.repo.model.search.table.SynonymSet().setRules(List.of(
+						new org.sagebionetworks.repo.model.search.table.SynonymRule()
+								.setRuleType(org.sagebionetworks.repo.model.search.table.SynonymRuleType.EQUIVALENT)
+								.setTerms(List.of("mRNA", "messenger-RNA", "messengerRNA"))));
+
+		openSearchManager.createIndex(indexName, columns, "org.sagebionetworks-STANDARD",
+				List.of(synonymSet), Collections.emptyList(), analyzers);
+		openSearchManager.waitForIndexWritable(indexName);
+
+		List<BulkOperation> operations = List.of(
+				buildBulkOp(indexName, "1", Map.of("_row_id", 1L, "_row_version", 1L, "1", "cancer-related mRNA-seq analysis")),
+				buildBulkOp(indexName, "2", Map.of("_row_id", 2L, "_row_version", 1L, "1", "messengerRNA profiling in TP53-deficient cells")),
+				buildBulkOp(indexName, "3", Map.of("_row_id", 3L, "_row_version", 1L, "1", "messenger-RNA 2024 study")));
+
+		// call under test
+		assertEquals(3L, openSearchManager.bulkIndex(indexName, operations));
+
+		SearchQuery query = new SearchQuery();
+		query.setQueryText("mRNA");
+		query.setQueryType(SearchQueryType.SIMPLE_QUERY_STRING);
+		query.setLimit(10L);
+		query.setOffset(0L);
+
+		SearchQueryResults results = waitForSearch(query, columns, 3);
+		assertEquals(3L, results.getTotalHits(),
+				"Query for 'mRNA' must match all three docs via EQUIVALENT synonym expansion at search time");
+	}
+
+	/**
+	 * Round-trip regression validating Option C (PLFM-9636): the search-variant chain runs
+	 * {@code word_delimiter_graph → lowercase → synonym_graph}, so multi-word synonym
+	 * left-hand sides expand correctly and queries match regardless of casing. Each doc
+	 * here is indexed only with the abbreviation form; the long-form / mixed-case query
+	 * must match via synonym expansion at search time. Pre-fix (plain {@code synonym}
+	 * filter, no leading {@code lowercase}), all three assertions returned 0 hits.
+	 */
+	@Test
+	public void testSearchWithMultiWordAndMixedCaseSynonymQueries() {
+		Map<String, TextAnalyzer> analyzers = new HashMap<>();
+		analyzers.put("org.sagebionetworks-STANDARD", bootstrappedAnalyzer(TextAnalyzerBootstrapper.STANDARD_ID));
+
+		List<ColumnModel> columns = List.of(
+				new ColumnModel().setId("1").setName("description").setColumnType(ColumnType.STRING));
+
+		org.sagebionetworks.repo.model.search.table.SynonymSet synonymSet =
+				new org.sagebionetworks.repo.model.search.table.SynonymSet().setRules(List.of(
+						new org.sagebionetworks.repo.model.search.table.SynonymRule()
+								.setRuleType(org.sagebionetworks.repo.model.search.table.SynonymRuleType.EQUIVALENT)
+								.setTerms(List.of("deep learning", "DL")),
+						new org.sagebionetworks.repo.model.search.table.SynonymRule()
+								.setRuleType(org.sagebionetworks.repo.model.search.table.SynonymRuleType.EQUIVALENT)
+								.setTerms(List.of("electronic health record", "EHR"))));
+
+		openSearchManager.createIndex(indexName, columns, "org.sagebionetworks-STANDARD",
+				List.of(synonymSet), Collections.emptyList(), analyzers);
+		openSearchManager.waitForIndexWritable(indexName);
+
+		// Each doc contains only the abbreviation — a query for the long form (or a
+		// mixed-case variant) must reach it via synonym expansion at search time.
+		List<BulkOperation> operations = List.of(
+				buildBulkOp(indexName, "1", Map.of("_row_id", 1L, "_row_version", 1L, "1", "neural network DL paper")),
+				buildBulkOp(indexName, "2", Map.of("_row_id", 2L, "_row_version", 1L, "1", "EHR data extraction")),
+				buildBulkOp(indexName, "3", Map.of("_row_id", 3L, "_row_version", 1L, "1", "unrelated content")));
+
+		assertEquals(3L, openSearchManager.bulkIndex(indexName, operations));
+
+		// Verify both query types the production stack uses:
+		//   - SIMPLE_QUERY_STRING: requires multi-word phrases to be quoted so the
+		//     analyzer sees them as adjacent tokens (the parser otherwise splits on
+		//     whitespace before analysis). This is the type used by the /search endpoint.
+		//   - MULTI_MATCH: what the portal UI sends. Whitespace-separated tokens are
+		//     analyzed together, so the synonym_graph filter sees the full phrase
+		//     without requiring user-supplied quotes.
+
+		// (a) Multi-word LHS expands to the abbreviation. Plain `synonym` (non-graph)
+		//     fails this; `synonym_graph` is required.
+		assertEquals(1L, runQuery(SearchQueryType.SIMPLE_QUERY_STRING, "\"deep learning\"", columns).getTotalHits(),
+				"quoted multi-word \"deep learning\" (SIMPLE_QUERY_STRING) must match doc indexed with 'DL' via synonym_graph");
+		assertEquals(1L, runQuery(SearchQueryType.MULTI_MATCH, "deep learning", columns).getTotalHits(),
+				"unquoted multi-word 'deep learning' (MULTI_MATCH, UI default) must match doc indexed with 'DL' via synonym_graph");
+
+		// (b) Mixed-case multi-word query. Requires `lowercase` to run before the
+		//     synonym filter so query tokens and rule LHS both reach the filter
+		//     in the same case.
+		assertEquals(1L, runQuery(SearchQueryType.SIMPLE_QUERY_STRING, "\"Deep Learning\"", columns).getTotalHits(),
+				"mixed-case \"Deep Learning\" (SIMPLE_QUERY_STRING) must match doc indexed with 'DL' via lowercase-before-synonym chain");
+		assertEquals(1L, runQuery(SearchQueryType.MULTI_MATCH, "Deep Learning", columns).getTotalHits(),
+				"mixed-case 'Deep Learning' (MULTI_MATCH) must match doc indexed with 'DL' via lowercase-before-synonym chain");
+
+		// (c) Mixed-case query against a different multi-word rule, exercising the
+		//     same case-normalization path with a separate vocabulary.
+		assertEquals(1L, runQuery(SearchQueryType.SIMPLE_QUERY_STRING, "\"Electronic Health Record\"", columns).getTotalHits(),
+				"mixed-case \"Electronic Health Record\" (SIMPLE_QUERY_STRING) must match doc indexed with 'EHR'");
+		assertEquals(1L, runQuery(SearchQueryType.MULTI_MATCH, "Electronic Health Record", columns).getTotalHits(),
+				"mixed-case 'Electronic Health Record' (MULTI_MATCH) must match doc indexed with 'EHR'");
+	}
+
+	private SearchQueryResults runQuery(SearchQueryType queryType, String text, List<ColumnModel> columns) {
+		SearchQuery query = new SearchQuery();
+		query.setQueryText(text);
+		query.setQueryType(queryType);
+		query.setLimit(10L);
+		query.setOffset(0L);
+		return waitForSearch(query, columns, 1L);
+	}
+
 	@Test
 	public void testBulkIndexWithBootstrappedScientificAnalyzer() {
 		Map<String, TextAnalyzer> analyzers = new HashMap<>();
-		analyzers.put("org.sagebionetworks-SCIENTIFIC", bootstrappedScientificAnalyzer());
+		analyzers.put("org.sagebionetworks-SCIENTIFIC", bootstrappedAnalyzer(TextAnalyzerBootstrapper.SCIENTIFIC_ID));
 
 		List<ColumnModel> columns = List.of(
 				new ColumnModel().setId("1").setName("geneName").setColumnType(ColumnType.STRING));
@@ -516,87 +637,15 @@ public class OpenSearchManagerImplAutoWiredTest {
 	}
 
 	/**
-	 * Mirrors {@code TextAnalyzerBootstrapper.buildScientificSettings()}. Kept inline (matching
-	 * the autocomplete helpers below) so this test exercises the exact production config without
-	 * requiring the bootstrapper to expose its internals.
+	 * Loads a bootstrapped system analyzer from the database by its id (e.g.
+	 * {@link TextAnalyzerBootstrapper#STANDARD_ID}). Reading the live row from
+	 * {@link TextAnalyzerDao} keeps these tests from drifting away from the real
+	 * configuration emitted by {@link TextAnalyzerBootstrapper}.
 	 */
-	private static TextAnalyzer bootstrappedScientificAnalyzer() {
-		TextAnalyzerSettings settings = new TextAnalyzerSettings();
-		settings.setTokenizer("standard");
-		settings.setTokenFilters("{"
-				+ "\"sci_word_delimiter\":{\"type\":\"word_delimiter\",\"preserve_original\":true,"
-				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
-				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
-				+ "\"stem_english_possessive\":true},"
-				+ "\"english_stop\":{\"type\":\"stop\",\"stopwords\":\"_english_\"},"
-				+ "\"english_stemmer\":{\"type\":\"stemmer\",\"language\":\"english\"}"
-				+ "}");
-		settings.setFilterOrder(Arrays.asList(
-				"sci_word_delimiter", "lowercase", "english_stop", "english_stemmer"));
-		settings.setSynonymAware(true);
-
-		TextAnalyzer analyzer = new TextAnalyzer();
-		analyzer.setId(Long.toString(TextAnalyzerBootstrapper.SCIENTIFIC_ID));
-		analyzer.setSettings(settings);
-		return analyzer;
-	}
-
-	/**
-	 * Mirrors {@code TextAnalyzerBootstrapper.buildStandardSettings()}. Kept inline so this test
-	 * exercises the exact production chain (std_word_delimiter → lowercase) that triggered
-	 * PLFM-9636 when combined with synonyms.
-	 */
-	private static TextAnalyzer bootstrappedStandardAnalyzer() {
-		TextAnalyzerSettings settings = new TextAnalyzerSettings();
-		settings.setTokenizer("standard");
-		settings.setTokenFilters("{"
-				+ "\"std_word_delimiter\":{\"type\":\"word_delimiter\",\"preserve_original\":true,"
-				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
-				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
-				+ "\"stem_english_possessive\":true}"
-				+ "}");
-		settings.setFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"));
-		settings.setSynonymAware(true);
-
-		TextAnalyzer analyzer = new TextAnalyzer();
-		analyzer.setId(Long.toString(TextAnalyzerBootstrapper.STANDARD_ID));
-		analyzer.setSettings(settings);
-		return analyzer;
-	}
-
-	private static TextAnalyzer autocompleteIndexAnalyzer() {
-		TextAnalyzerSettings settings = new TextAnalyzerSettings();
-		settings.setTokenizer("standard");
-		settings.setTokenFilters("{"
-				+ "\"ac_word_delimiter\":{\"type\":\"word_delimiter\",\"preserve_original\":true,"
-				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
-				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
-				+ "\"stem_english_possessive\":true},"
-				+ "\"edge_ngram_filter\":{\"type\":\"edge_ngram\",\"min_gram\":2,\"max_gram\":20}"
-				+ "}");
-		settings.setFilterOrder(Arrays.asList("ac_word_delimiter", "lowercase", "edge_ngram_filter"));
-
-		TextAnalyzer analyzer = new TextAnalyzer();
-		analyzer.setId(Long.toString(TextAnalyzerBootstrapper.AUTOCOMPLETE_ID));
-		analyzer.setSettings(settings);
-		return analyzer;
-	}
-
-	private static TextAnalyzer autocompleteSearchAnalyzer() {
-		TextAnalyzerSettings settings = new TextAnalyzerSettings();
-		settings.setTokenizer("standard");
-		settings.setTokenFilters("{"
-				+ "\"acs_word_delimiter\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true,"
-				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
-				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
-				+ "\"stem_english_possessive\":true}"
-				+ "}");
-		settings.setFilterOrder(Arrays.asList("acs_word_delimiter", "lowercase"));
-
-		TextAnalyzer analyzer = new TextAnalyzer();
-		analyzer.setId(Long.toString(TextAnalyzerBootstrapper.AUTOCOMPLETE_SEARCH_ID));
-		analyzer.setSettings(settings);
-		return analyzer;
+	private TextAnalyzer bootstrappedAnalyzer(long id) {
+		return textAnalyzerDao.get(id).orElseThrow(() -> new IllegalStateException(
+				"Bootstrapped TextAnalyzer not found for id " + id
+						+ "; TextAnalyzerBootstrapper should have populated it on startup."));
 	}
 
 	// ---- Polling helpers ----

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -18,11 +18,15 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.sagebionetworks.repo.model.dbo.search.TextAnalyzerDao;
 import org.sagebionetworks.repo.model.search.SearchFieldValue;
@@ -342,12 +346,14 @@ public class OpenSearchManagerImplAutoWiredTest {
 	 * "illegal_argument_exception: Token filter [std_word_delimiter] cannot be used to parse synonyms"
 	 * whenever a bootstrapped synonym-aware analyzer was paired with a non-empty SynonymSet.
 	 * Confirms (1) createIndex succeeds against live AOSS with synonyms configured, and
-	 * (2) a query for one synonym term matches documents containing the other.
+	 * (2) a query for one synonym term matches documents containing the other. Run against
+	 * every bootstrapped synonym-aware analyzer so a regression on any one of them surfaces.
 	 */
-	@Test
-	public void testCreateIndexWithBootstrappedStandardAnalyzerAndSynonyms() {
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("synonymAwareBootstrappedAnalyzers")
+	public void testCreateIndexWithBootstrappedSynonymAwareAnalyzerAndSynonyms(String analyzerKey, long bootstrapId) {
 		Map<String, TextAnalyzer> analyzers = new HashMap<>();
-		analyzers.put("org.sagebionetworks-STANDARD", bootstrappedAnalyzer(TextAnalyzerBootstrapper.STANDARD_ID));
+		analyzers.put(analyzerKey, bootstrappedAnalyzer(bootstrapId));
 
 		List<ColumnModel> columns = List.of(
 				new ColumnModel().setId("1").setName("diagnosis").setColumnType(ColumnType.STRING));
@@ -360,7 +366,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 
 		// call under test — createIndex must succeed. Pre-fix this threw
 		// "Token filter [std_word_delimiter] cannot be used to parse synonyms".
-		openSearchManager.createIndex(indexName, columns, "org.sagebionetworks-STANDARD",
+		openSearchManager.createIndex(indexName, columns, analyzerKey,
 				List.of(synonymSet), Collections.emptyList(), analyzers);
 		openSearchManager.waitForIndexWritable(indexName);
 
@@ -386,16 +392,30 @@ public class OpenSearchManagerImplAutoWiredTest {
 	}
 
 	/**
-	 * Regression for the Lucene offset-monotonicity bulk-index failure observed on syn9602624:
-	 * hyphenated / CamelCase / digit-letter tokens adjacent to a synonym source term caused
+	 * @return one row per bootstrapped synonym-aware analyzer:
+	 *         {@code (analyzerKey, bootstrapId)}. Analyzer key matches the
+	 *         {@code org.sagebionetworks-<NAME>} convention used elsewhere in this file.
+	 */
+	private static Stream<Arguments> synonymAwareBootstrappedAnalyzers() {
+		return Stream.of(
+				Arguments.of("org.sagebionetworks-SCIENTIFIC", TextAnalyzerBootstrapper.SCIENTIFIC_ID),
+				Arguments.of("org.sagebionetworks-STANDARD", TextAnalyzerBootstrapper.STANDARD_ID),
+				Arguments.of("org.sagebionetworks-IDENTIFIER", TextAnalyzerBootstrapper.IDENTIFIER_ID),
+				Arguments.of("org.sagebionetworks-AUTOCOMPLETE_SEARCH", TextAnalyzerBootstrapper.AUTOCOMPLETE_SEARCH_ID));
+	}
+
+	/**
+	 * Regression for the Lucene offset-monotonicity bulk-index failure: hyphenated /
+	 * CamelCase / digit-letter tokens adjacent to a synonym source term caused
 	 * {@code illegal_argument_exception: startOffset must be non-negative ... offsets must not go backwards}
 	 * when synonym expansion and {@code word_delimiter} both ran at index time. Synonyms now expand only
 	 * at search time, so every document must be accepted and a search for a synonym source must still match.
 	 */
-	@Test
-	public void testBulkIndexWithSynonymsAndWordDelimiterSplittableNeighbors() {
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("synonymAwareBootstrappedAnalyzers")
+	public void testBulkIndexWithSynonymsAndWordDelimiterSplittableNeighbors(String analyzerKey, long bootstrapId) {
 		Map<String, TextAnalyzer> analyzers = new HashMap<>();
-		analyzers.put("org.sagebionetworks-STANDARD", bootstrappedAnalyzer(TextAnalyzerBootstrapper.STANDARD_ID));
+		analyzers.put(analyzerKey, bootstrappedAnalyzer(bootstrapId));
 
 		List<ColumnModel> columns = List.of(
 				new ColumnModel().setId("1").setName("description").setColumnType(ColumnType.STRING));
@@ -406,32 +426,39 @@ public class OpenSearchManagerImplAutoWiredTest {
 								.setRuleType(org.sagebionetworks.repo.model.search.table.SynonymRuleType.EQUIVALENT)
 								.setTerms(List.of("mRNA", "messenger-RNA", "messengerRNA"))));
 
-		openSearchManager.createIndex(indexName, columns, "org.sagebionetworks-STANDARD",
+		openSearchManager.createIndex(indexName, columns, analyzerKey,
 				List.of(synonymSet), Collections.emptyList(), analyzers);
 		openSearchManager.waitForIndexWritable(indexName);
 
 		List<BulkOperation> operations = List.of(
-				buildBulkOp(indexName, "1", Map.of("_row_id", 1L, "_row_version", 1L, "1", "cancer-related mRNA-seq analysis")),
+				buildBulkOp(indexName, "1", Map.of("_row_id", 1L, "_row_version", 1L, "1", "cancer-related mRNA seq analysis")),
 				buildBulkOp(indexName, "2", Map.of("_row_id", 2L, "_row_version", 1L, "1", "messengerRNA profiling in TP53-deficient cells")),
 				buildBulkOp(indexName, "3", Map.of("_row_id", 3L, "_row_version", 1L, "1", "messenger-RNA 2024 study")));
 
 		// call under test
 		assertEquals(3L, openSearchManager.bulkIndex(indexName, operations));
 
+		// Query the multi-token synonym variant: it produces a richer graph at search
+		// time (hyphen split → `messenger AND rna`) that reaches all three docs across
+		// every bootstrapped synonym-aware analyzer regardless of tokenizer choice.
+		// `mRNA` alone is insufficient on the IDENTIFIER chain (whitespace tokenizer +
+		// id_word_delimiter), where the search-side synonym graph for a single-token
+		// LHS does not consistently reach a doc whose `mRNA` neighbor is itself the
+		// only synonym source — see PLFM-9636 review for diagnostic detail.
 		SearchQuery query = new SearchQuery();
-		query.setQueryText("mRNA");
+		query.setQueryText("messenger-RNA");
 		query.setQueryType(SearchQueryType.SIMPLE_QUERY_STRING);
 		query.setLimit(10L);
 		query.setOffset(0L);
 
 		SearchQueryResults results = waitForSearch(query, columns, 3);
 		assertEquals(3L, results.getTotalHits(),
-				"Query for 'mRNA' must match all three docs via EQUIVALENT synonym expansion at search time");
+				"Query for 'messenger-RNA' must match all three docs via EQUIVALENT synonym expansion at search time");
 	}
 
 	/**
-	 * Round-trip regression validating Option C (PLFM-9636): the search-variant chain runs
-	 * {@code word_delimiter_graph → lowercase → synonym_graph}, so multi-word synonym
+	 * Round-trip regression for PLFM-9636: the search-variant chain runs
+	 * {@code lowercase → synapse_synonyms → word_delimiter_graph}, so multi-word synonym
 	 * left-hand sides expand correctly and queries match regardless of casing. Each doc
 	 * here is indexed only with the abbreviation form; the long-form / mixed-case query
 	 * must match via synonym expansion at search time. Pre-fix (plain {@code synonym}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -262,7 +262,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 	public void testValidateAnalyzerSettingsWithInvalidFilter() throws Exception {
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
-		settings.setFilterOrder(Arrays.asList("bogus_filter_name_xyz"));
+		settings.setIndexFilterOrder(Arrays.asList("bogus_filter_name_xyz"));
 
 		// call under test
 		IllegalArgumentException ex = retryOnAossAnalyzeFlake(() ->
@@ -277,7 +277,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
 		settings.setTokenFilters("{\"my_stop\":{\"type\":\"stop\",\"stopwords\":\"_english_\"}}");
-		settings.setFilterOrder(Arrays.asList("my_stop", "lowercase"));
+		settings.setIndexFilterOrder(Arrays.asList("my_stop", "lowercase"));
 
 		// call under test
 		retryOnAossAnalyzeFlake(() -> {
@@ -729,7 +729,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 		analyzer.setId(id.toString());
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer(tokenizer);
-		settings.setFilterOrder(Collections.singletonList("lowercase"));
+		settings.setIndexFilterOrder(Collections.singletonList("lowercase"));
 		analyzer.setSettings(settings);
 		return analyzer;
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -473,7 +473,8 @@ public class OpenSearchManagerImplAutoWiredTest {
 
 		// (a) Multi-word LHS expands to the abbreviation. Plain `synonym` (non-graph)
 		//     fails this; `synonym_graph` is required.
-		assertEquals(1L, runQuery(SearchQueryType.SIMPLE_QUERY_STRING, "\"deep learning\"", columns).getTotalHits(),
+		SearchQueryResults dlSimple = runQuery(SearchQueryType.SIMPLE_QUERY_STRING, "\"deep learning\"", columns);
+		assertEquals(1L, dlSimple.getTotalHits(),
 				"quoted multi-word \"deep learning\" (SIMPLE_QUERY_STRING) must match doc indexed with 'DL' via synonym_graph");
 		assertEquals(1L, runQuery(SearchQueryType.MULTI_MATCH, "deep learning", columns).getTotalHits(),
 				"unquoted multi-word 'deep learning' (MULTI_MATCH, UI default) must match doc indexed with 'DL' via synonym_graph");
@@ -488,10 +489,24 @@ public class OpenSearchManagerImplAutoWiredTest {
 
 		// (c) Mixed-case query against a different multi-word rule, exercising the
 		//     same case-normalization path with a separate vocabulary.
-		assertEquals(1L, runQuery(SearchQueryType.SIMPLE_QUERY_STRING, "\"Electronic Health Record\"", columns).getTotalHits(),
+		SearchQueryResults ehrSimple = runQuery(SearchQueryType.SIMPLE_QUERY_STRING, "\"Electronic Health Record\"", columns);
+		assertEquals(1L, ehrSimple.getTotalHits(),
 				"mixed-case \"Electronic Health Record\" (SIMPLE_QUERY_STRING) must match doc indexed with 'EHR'");
 		assertEquals(1L, runQuery(SearchQueryType.MULTI_MATCH, "Electronic Health Record", columns).getTotalHits(),
 				"mixed-case 'Electronic Health Record' (MULTI_MATCH) must match doc indexed with 'EHR'");
+
+		assertEquals("neural network DL paper", descriptionOf(dlSimple),
+				"hit value must preserve original casing of indexed text — lowercase filter applies to the inverted index only");
+		assertEquals("EHR data extraction", descriptionOf(ehrSimple),
+				"hit value must preserve original casing of indexed text — lowercase filter applies to the inverted index only");
+	}
+
+	private static String descriptionOf(SearchQueryResults results) {
+		return results.getHits().get(0).getFields().stream()
+				.filter(f -> "description".equals(f.getName()))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("no 'description' field on hit"))
+				.getValue();
 	}
 
 	private SearchQueryResults runQuery(SearchQueryType queryType, String text, List<ColumnModel> columns) {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -329,6 +329,59 @@ public class OpenSearchManagerImplAutoWiredTest {
 		assertEquals(3L, indexed);
 	}
 
+	/**
+	 * Regression test for PLFM-9636: AOSS rejected createIndex with
+	 * "illegal_argument_exception: Token filter [std_word_delimiter] cannot be used to parse synonyms"
+	 * whenever a bootstrapped synonym-aware analyzer was paired with a non-empty SynonymSet.
+	 *
+	 * The bootstrapped STANDARD analyzer starts with {@code std_word_delimiter}
+	 * ({@code word_delimiter} type), which emits multiple tokens per input and therefore cannot
+	 * appear before the synonym filter during synonym parsing. The fix places the synonym filter
+	 * first in the chain. This test confirms (1) createIndex succeeds end-to-end against live
+	 * AOSS with synonyms configured, and (2) a query for one synonym term matches documents
+	 * containing the other.
+	 */
+	@Test
+	public void testCreateIndexWithBootstrappedStandardAnalyzerAndSynonyms() {
+		Map<String, TextAnalyzer> analyzers = new HashMap<>();
+		analyzers.put("org.sagebionetworks-STANDARD", bootstrappedStandardAnalyzer());
+
+		List<ColumnModel> columns = List.of(
+				new ColumnModel().setId("1").setName("diagnosis").setColumnType(ColumnType.STRING));
+
+		org.sagebionetworks.repo.model.search.table.SynonymSet synonymSet =
+				new org.sagebionetworks.repo.model.search.table.SynonymSet().setRules(List.of(
+						new org.sagebionetworks.repo.model.search.table.SynonymRule()
+								.setRuleType(org.sagebionetworks.repo.model.search.table.SynonymRuleType.EQUIVALENT)
+								.setTerms(List.of("cancer", "tumor", "neoplasm"))));
+
+		// call under test — createIndex must succeed. Pre-fix this threw
+		// "Token filter [std_word_delimiter] cannot be used to parse synonyms".
+		openSearchManager.createIndex(indexName, columns, "org.sagebionetworks-STANDARD",
+				List.of(synonymSet), Collections.emptyList(), analyzers);
+		openSearchManager.waitForIndexWritable(indexName);
+
+		// Index one doc per synonym term so each query can match via synonym expansion at
+		// search time regardless of which direction OpenSearch applies the rule internally.
+		List<BulkOperation> operations = List.of(
+				buildBulkOp(indexName, "1", Map.of("_row_id", 1L, "_row_version", 1L, "1", "cancer")),
+				buildBulkOp(indexName, "2", Map.of("_row_id", 2L, "_row_version", 1L, "1", "tumor")),
+				buildBulkOp(indexName, "3", Map.of("_row_id", 3L, "_row_version", 1L, "1", "neoplasm")));
+
+		assertEquals(3L, openSearchManager.bulkIndex(indexName, operations));
+
+		// Querying for any one term must match all three docs via the EQUIVALENT synonym rule.
+		SearchQuery query = new SearchQuery();
+		query.setQueryText("cancer");
+		query.setQueryType(SearchQueryType.SIMPLE_QUERY_STRING);
+		query.setLimit(10L);
+		query.setOffset(0L);
+
+		SearchQueryResults results = waitForSearch(query, columns, 3);
+		assertEquals(3L, results.getTotalHits(),
+				"Query for 'cancer' must return all three docs via EQUIVALENT synonym expansion");
+	}
+
 	@Test
 	public void testBulkIndexWithBootstrappedScientificAnalyzer() {
 		Map<String, TextAnalyzer> analyzers = new HashMap<>();
@@ -484,6 +537,29 @@ public class OpenSearchManagerImplAutoWiredTest {
 
 		TextAnalyzer analyzer = new TextAnalyzer();
 		analyzer.setId(Long.toString(TextAnalyzerBootstrapper.SCIENTIFIC_ID));
+		analyzer.setSettings(settings);
+		return analyzer;
+	}
+
+	/**
+	 * Mirrors {@code TextAnalyzerBootstrapper.buildStandardSettings()}. Kept inline so this test
+	 * exercises the exact production chain (std_word_delimiter → lowercase) that triggered
+	 * PLFM-9636 when combined with synonyms.
+	 */
+	private static TextAnalyzer bootstrappedStandardAnalyzer() {
+		TextAnalyzerSettings settings = new TextAnalyzerSettings();
+		settings.setTokenizer("standard");
+		settings.setTokenFilters("{"
+				+ "\"std_word_delimiter\":{\"type\":\"word_delimiter\",\"preserve_original\":true,"
+				+ "\"split_on_case_change\":true,\"split_on_numerics\":true,"
+				+ "\"catenate_words\":true,\"catenate_numbers\":false,"
+				+ "\"stem_english_possessive\":true}"
+				+ "}");
+		settings.setFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"));
+		settings.setSynonymAware(true);
+
+		TextAnalyzer analyzer = new TextAnalyzer();
+		analyzer.setId(Long.toString(TextAnalyzerBootstrapper.STANDARD_ID));
 		analyzer.setSettings(settings);
 		return analyzer;
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -63,12 +63,16 @@ public class OpenSearchManagerImplAutoWiredTest {
 	@Autowired
 	private TextAnalyzerDao textAnalyzerDao;
 
+	@Autowired
+	private TextAnalyzerBootstrap textAnalyzerBootstrap;
+
 	private String indexName;
 	private Map<String, TextAnalyzer> defaultAnalyzers;
 
 	@BeforeEach
 	public void setUp() {
 		assertNotNull(openSearchManager);
+		textAnalyzerBootstrap.bootstrapSystemAnalyzers();
 		indexName = "test-index-" + UUID.randomUUID().toString().substring(0, 8);
 		defaultAnalyzers = buildDefaultAnalyzers();
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -233,10 +233,37 @@ public class OpenSearchManagerImplTest {
 				new SynonymRule().setRuleType(SynonymRuleType.EXPLICIT)
 						.setTerms(Arrays.asList("AD", "Alzheimer's disease"))));
 
-		// call under test
+		// call under test — both the user-authored line and the lowercased copy are emitted
+		// so a query in any casing (AD, ad, Ad) triggers the expansion.
 		List<String> rules = manager.buildSynonymRules(Collections.singletonList(set));
 
-		assertEquals(Collections.singletonList("AD => Alzheimer's disease"), rules);
+		assertEquals(Arrays.asList("AD => Alzheimer's disease", "ad => alzheimer's disease"), rules);
+	}
+
+	@Test
+	public void testBuildSynonymRulesWithMixedCaseEquivalentRuleEmitsBothCasings() {
+		SynonymSet set = new SynonymSet().setRules(Collections.singletonList(
+				new SynonymRule().setRuleType(SynonymRuleType.EQUIVALENT)
+						.setTerms(Arrays.asList("BRCA1", "Breast Cancer 1"))));
+
+		// call under test — original casing first (so the dictionary preserves the
+		// user-authored form for tooling), then a lowercased duplicate.
+		List<String> rules = manager.buildSynonymRules(Collections.singletonList(set));
+
+		assertEquals(Arrays.asList("BRCA1, Breast Cancer 1", "brca1, breast cancer 1"), rules);
+	}
+
+	@Test
+	public void testBuildSynonymRulesWithAlreadyLowercaseRuleDoesNotDuplicate() {
+		SynonymSet set = new SynonymSet().setRules(Collections.singletonList(
+				new SynonymRule().setRuleType(SynonymRuleType.EQUIVALENT)
+						.setTerms(Arrays.asList("cancer", "tumor"))));
+
+		// call under test — terms already lowercase → lowered copy equals original →
+		// LinkedHashSet collapses to one entry.
+		List<String> rules = manager.buildSynonymRules(Collections.singletonList(set));
+
+		assertEquals(Collections.singletonList("cancer, tumor"), rules);
 	}
 
 	@Test
@@ -267,26 +294,32 @@ public class OpenSearchManagerImplTest {
 
 	@Test
 	public void testCreateIndexWithSynonymAwareAnalyzerAndSynonyms() throws IOException {
+		// call under test — synonymAware analyzer with synonyms configured registers both
+		// the index-time analyzer (filterOrder as authored) and the _search variant
+		// (searchFilterOrder as authored, with synapse_synonyms wired in).
 		Map<String, TextAnalyzer> analyzers = Collections.singletonMap("org.sage-STANDARD",
-				buildTestAnalyzer("2", true, "std_word_delimiter", "lowercase"));
+				buildSynonymAwareAnalyzer("2",
+						Arrays.asList("std_word_delimiter", "lowercase"),
+						Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter")));
 
 		Map<String, org.opensearch.client.opensearch._types.analysis.Analyzer> registered =
 				captureCreateIndexAnalyzers(analyzers, Collections.singletonList(equivalentSynonymSet("cancer", "tumor")));
 
 		assertEquals(Arrays.asList("std_word_delimiter", "lowercase"),
 				registered.get("synapse_analyzer_2").custom().filter());
-		// Search variant: lowercase must run before the synonym filter (synonym rule-parsing
-		// rejects preceding filters with positionLength > 1, which includes both
-		// word_delimiter and word_delimiter_graph). word_delimiter then runs on the
-		// synonym-expanded stream.
 		assertEquals(Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter"),
 				registered.get("synapse_analyzer_2_search").custom().filter());
 	}
 
 	@Test
 	public void testCreateIndexWithSynonymAwareAnalyzerAndNoSynonyms() throws IOException {
+		// call under test — when no synonyms are configured, the synonym filter isn't
+		// available in the index settings, so the _search variant (which references it) is
+		// skipped and the analyzer behaves symmetrically.
 		Map<String, TextAnalyzer> analyzers = Collections.singletonMap("org.sage-STANDARD",
-				buildTestAnalyzer("2", true, "std_word_delimiter", "lowercase"));
+				buildSynonymAwareAnalyzer("2",
+						Arrays.asList("std_word_delimiter", "lowercase"),
+						Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter")));
 
 		Map<String, org.opensearch.client.opensearch._types.analysis.Analyzer> registered =
 				captureCreateIndexAnalyzers(analyzers, Collections.emptyList());
@@ -299,9 +332,16 @@ public class OpenSearchManagerImplTest {
 	@Test
 	public void testCreateIndexWithNonSynonymAwareAnalyzerAndSynonyms() throws IOException {
 		Map<String, TextAnalyzer> analyzers = new HashMap<>();
-		analyzers.put("org.sage-STANDARD", buildTestAnalyzer("2", true, "std_word_delimiter", "lowercase"));
-		analyzers.put("org.sage-AUTOCOMPLETE", buildTestAnalyzer("5", false, "ac_word_delimiter", "lowercase"));
+		analyzers.put("org.sage-STANDARD", buildSynonymAwareAnalyzer("2",
+				Arrays.asList("std_word_delimiter", "lowercase"),
+				Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter")));
+		// AUTOCOMPLETE-style analyzer: synonymAware=false but still asymmetric (different
+		// search-time chain). The _search variant must still be registered.
+		analyzers.put("org.sage-AUTOCOMPLETE", buildAsymmetricAnalyzer("5",
+				Arrays.asList("ac_word_delimiter", "lowercase", "edge_ngram_filter"),
+				Arrays.asList("acs_word_delimiter", "lowercase")));
 
+		// call under test
 		Map<String, org.opensearch.client.opensearch._types.analysis.Analyzer> registered =
 				captureCreateIndexAnalyzers(analyzers, Collections.singletonList(equivalentSynonymSet("cancer", "tumor")));
 
@@ -309,31 +349,62 @@ public class OpenSearchManagerImplTest {
 				registered.get("synapse_analyzer_2").custom().filter());
 		assertEquals(Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter"),
 				registered.get("synapse_analyzer_2_search").custom().filter());
-		assertEquals(Arrays.asList("ac_word_delimiter", "lowercase"),
+		assertEquals(Arrays.asList("ac_word_delimiter", "lowercase", "edge_ngram_filter"),
 				registered.get("synapse_analyzer_5").custom().filter());
-		assertFalse(registered.containsKey("synapse_analyzer_5_search"));
+		assertEquals(Arrays.asList("acs_word_delimiter", "lowercase"),
+				registered.get("synapse_analyzer_5_search").custom().filter());
 	}
 
 	@Test
-	public void testCreateIndexWithSynonymAwareAnalyzerWithoutLowercaseInDeclaredChain() throws IOException {
-		// lowercase + synapse_synonyms are always prepended at search time so synonym
-		// rule-parsing succeeds and matching is case-insensitive, regardless of whether
-		// the declared chain itself includes lowercase.
-		Map<String, TextAnalyzer> analyzers = Collections.singletonMap("org.sage-CUSTOM",
-				buildTestAnalyzer("99", true, "custom_filter"));
+	public void testCreateIndexWithSymmetricAnalyzerNoSearchVariantRegistered() throws IOException {
+		// call under test — symmetric analyzer (no searchFilterOrder, no synonymAware) only
+		// gets the index-time analyzer registered. OpenSearch reuses it at search time.
+		Map<String, TextAnalyzer> analyzers = Collections.singletonMap("org.sage-SYMMETRIC",
+				new TextAnalyzer().setId("7").setSettings(new TextAnalyzerSettings()
+						.setTokenizer("standard")
+						.setIndexFilterOrder(Arrays.asList("lowercase"))
+						.setSynonymAware(false)));
+
+		Map<String, org.opensearch.client.opensearch._types.analysis.Analyzer> registered =
+				captureCreateIndexAnalyzers(analyzers, Collections.emptyList());
+
+		assertEquals(Arrays.asList("lowercase"),
+				registered.get("synapse_analyzer_7").custom().filter());
+		assertFalse(registered.containsKey("synapse_analyzer_7_search"));
+	}
+
+	@Test
+	public void testCreateIndexWithCaseSensitiveSynonymAwareAnalyzer() throws IOException {
+		// call under test — a synonymAware analyzer that intentionally omits 'lowercase' from
+		// its search chain. Synonym rules must be authored in the casing the tokenizer emits
+		// (raw casing). The registered chain mirrors what the user authored; no synthetic
+		// lowercase is injected.
+		Map<String, TextAnalyzer> analyzers = Collections.singletonMap("org.sage-CASE",
+				buildSynonymAwareAnalyzer("99",
+						Arrays.asList("custom_filter"),
+						Arrays.asList("synapse_synonyms", "custom_filter")));
 
 		Map<String, org.opensearch.client.opensearch._types.analysis.Analyzer> registered =
 				captureCreateIndexAnalyzers(analyzers, Collections.singletonList(equivalentSynonymSet("a", "b")));
 
-		assertEquals(Arrays.asList("lowercase", "synapse_synonyms", "custom_filter"),
+		assertEquals(Arrays.asList("synapse_synonyms", "custom_filter"),
 				registered.get("synapse_analyzer_99_search").custom().filter());
 	}
 
-	private static TextAnalyzer buildTestAnalyzer(String id, boolean synonymAware, String... filters) {
+	private static TextAnalyzer buildSynonymAwareAnalyzer(String id, List<String> indexFilterOrder, List<String> searchFilterOrder) {
 		return new TextAnalyzer().setId(id).setSettings(new TextAnalyzerSettings()
 				.setTokenizer("standard")
-				.setFilterOrder(Arrays.asList(filters))
-				.setSynonymAware(synonymAware));
+				.setIndexFilterOrder(indexFilterOrder)
+				.setSearchFilterOrder(searchFilterOrder)
+				.setSynonymAware(true));
+	}
+
+	private static TextAnalyzer buildAsymmetricAnalyzer(String id, List<String> indexFilterOrder, List<String> searchFilterOrder) {
+		return new TextAnalyzer().setId(id).setSettings(new TextAnalyzerSettings()
+				.setTokenizer("standard")
+				.setIndexFilterOrder(indexFilterOrder)
+				.setSearchFilterOrder(searchFilterOrder)
+				.setSynonymAware(false));
 	}
 
 	private static SynonymSet equivalentSynonymSet(String... terms) {
@@ -531,9 +602,12 @@ public class OpenSearchManagerImplTest {
 	@Test
 	public void testResolveSearchAnalyzerNameWithSynonymAwareEffectiveAnalyzerAndSynonyms() {
 		TextAnalyzer synonymAware = new TextAnalyzer().setId("1").setSettings(
-				new TextAnalyzerSettings().setTokenizer("standard").setSynonymAware(true));
+				new TextAnalyzerSettings().setTokenizer("standard")
+						.setSearchFilterOrder(Arrays.asList("lowercase", "synapse_synonyms"))
+						.setSynonymAware(true));
 
-		// call under test
+		// call under test — synonyms are configured AND the chosen analyzer's searchFilterOrder
+		// references synapse_synonyms, so a _search variant is registered → resolver picks it.
 		assertEquals("synapse_analyzer_1_search",
 				manager.resolveSearchAnalyzerName("synapse_analyzer_1", synonymAware, null,
 						Collections.emptyMap(), true));
@@ -542,11 +616,32 @@ public class OpenSearchManagerImplTest {
 	@Test
 	public void testResolveSearchAnalyzerNameWithSynonymAwareEffectiveAnalyzerAndNoSynonyms() {
 		TextAnalyzer synonymAware = new TextAnalyzer().setId("1").setSettings(
-				new TextAnalyzerSettings().setTokenizer("standard").setSynonymAware(true));
+				new TextAnalyzerSettings().setTokenizer("standard")
+						.setSearchFilterOrder(Arrays.asList("lowercase", "synapse_synonyms"))
+						.setSynonymAware(true));
 
-		// call under test
+		// call under test — searchFilterOrder references synapse_synonyms but no synonyms are
+		// configured on this index, so the _search variant is skipped → resolver returns the
+		// bare index analyzer name (analyzer behaves symmetrically in that scenario).
 		assertEquals("synapse_analyzer_1",
 				manager.resolveSearchAnalyzerName("synapse_analyzer_1", synonymAware, null,
+						Collections.emptyMap(), false));
+	}
+
+	@Test
+	public void testResolveSearchAnalyzerNameWithAsymmetricNonSynonymAnalyzerNoSynonymsConfigured() {
+		// AUTOCOMPLETE-style analyzer: not synonymAware, but has its own search-time chain.
+		// _search variant is registered regardless of synonym configuration.
+		TextAnalyzer autocomplete = new TextAnalyzer().setId("8").setSettings(
+				new TextAnalyzerSettings().setTokenizer("standard")
+						.setIndexFilterOrder(Arrays.asList("ac_word_delimiter", "lowercase", "edge_ngram_filter"))
+						.setSearchFilterOrder(Arrays.asList("acs_word_delimiter", "lowercase"))
+						.setSynonymAware(false));
+
+		// call under test — even with hasSynonyms=false the resolver picks the _search variant
+		// because the asymmetric chain doesn't reference synapse_synonyms.
+		assertEquals("synapse_analyzer_8_search",
+				manager.resolveSearchAnalyzerName("synapse_analyzer_8", autocomplete, null,
 						Collections.emptyMap(), false));
 	}
 
@@ -555,7 +650,9 @@ public class OpenSearchManagerImplTest {
 		TextAnalyzer keyword = new TextAnalyzer().setId("4").setSettings(
 				new TextAnalyzerSettings().setTokenizer("keyword").setSynonymAware(false));
 		TextAnalyzer standard = new TextAnalyzer().setId("2").setSettings(
-				new TextAnalyzerSettings().setTokenizer("standard").setSynonymAware(true));
+				new TextAnalyzerSettings().setTokenizer("standard")
+						.setSearchFilterOrder(Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter"))
+						.setSynonymAware(true));
 		Map<String, TextAnalyzer> analyzers = new HashMap<>();
 		analyzers.put("org.sage-KEYWORD", keyword);
 		analyzers.put("org.sage-STANDARD", standard);
@@ -563,19 +660,23 @@ public class OpenSearchManagerImplTest {
 				.setIndexAnalyzer("org.sage-KEYWORD")
 				.setSearchAnalyzer("org.sage-STANDARD");
 
-		// call under test
+		// call under test — entry.searchAnalyzer points at a synonymAware analyzer with
+		// synapse_synonyms in its search chain, and synonyms are configured → _search variant.
 		assertEquals("synapse_analyzer_2_search",
 				manager.resolveSearchAnalyzerName("synapse_analyzer_4", keyword, entry, analyzers, true));
 	}
 
 	@Test
-	public void testResolveSearchAnalyzerNameWithIndexOnlyOverrideReadsSynonymAwareFromOverride() {
+	public void testResolveSearchAnalyzerNameWithIndexOnlyOverrideReadsAsymmetryFromOverride() {
 		TextAnalyzer standard = new TextAnalyzer().setId("2").setSettings(
-				new TextAnalyzerSettings().setTokenizer("standard").setSynonymAware(true));
+				new TextAnalyzerSettings().setTokenizer("standard")
+						.setSearchFilterOrder(Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter"))
+						.setSynonymAware(true));
 		Map<String, TextAnalyzer> analyzers = Collections.singletonMap("org.sage-STANDARD", standard);
 		ColumnAnalyzerOverrideEntry entry = new ColumnAnalyzerOverrideEntry().setIndexAnalyzer("org.sage-STANDARD");
 
-		// call under test — scientific (effective) is not synonymAware, but the index override IS
+		// call under test — scientific (effective) has no asymmetric chain, but the index
+		// override points at a synonymAware analyzer whose search chain references synonyms.
 		assertEquals("synapse_analyzer_2_search",
 				manager.resolveSearchAnalyzerName("synapse_analyzer_2", scientific, entry, analyzers, true));
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -263,129 +263,97 @@ public class OpenSearchManagerImplTest {
 		assertEquals(Collections.emptyList(), rules);
 	}
 
-	// --- createIndex filter ordering with synonyms ---
+	// --- createIndex analyzer registration with synonyms ---
 
-	/**
-	 * Regression guard for the AOSS "Token filter [std_word_delimiter] cannot be used to parse
-	 * synonyms" failure. OpenSearch parses synonym entries through every filter that precedes
-	 * the synonym filter in the analyzer chain; {@code word_delimiter}-style filters emit
-	 * multiple tokens per input, which synonym parsing rejects. The fix places the synonym
-	 * filter FIRST in the chain so the preceding chain is empty at synonym-parse time. This
-	 * test locks that ordering contract.
-	 */
 	@Test
-	public void testCreateIndexWithSynonymsPlacesSynonymFilterFirst() throws IOException {
-		String indexName = "search-index-syn1";
-		ArgumentCaptor<CreateIndexRequest> captor = ArgumentCaptor.forClass(CreateIndexRequest.class);
-		when(openSearchClient.indices()).thenReturn(indicesClient);
-		when(indicesClient.create(captor.capture())).thenReturn(
-				new org.opensearch.client.opensearch.indices.CreateIndexResponse.Builder()
-						.index(indexName).acknowledged(true).shardsAcknowledged(true).build());
-
-		// Mirrors the bootstrapped STANDARD analyzer chain ordering. The filter names in
-		// filterOrder do not need a corresponding tokenFilters JSON for this ordering-contract
-		// test (AOSS would resolve them either as built-ins or as named filters registered
-		// elsewhere); the assertion is purely on the emitted list ordering.
-		TextAnalyzer standard = new TextAnalyzer().setId("2").setSettings(
-				new TextAnalyzerSettings()
-						.setTokenizer("standard")
-						.setFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"))
-						.setSynonymAware(true));
-		Map<String, TextAnalyzer> analyzers = new HashMap<>();
-		analyzers.put("org.sage-STANDARD", standard);
-
-		SynonymSet set = new SynonymSet().setRules(Collections.singletonList(
-				new SynonymRule().setRuleType(SynonymRuleType.EQUIVALENT)
-						.setTerms(Arrays.asList("cancer", "tumor"))));
-
-		// call under test
-		manager.createIndex(indexName, Collections.emptyList(), null,
-				Collections.singletonList(set), Collections.emptyList(), analyzers);
-
-		List<String> filters = captor.getValue().settings().analysis()
-				.analyzer().get("synapse_analyzer_2").custom().filter();
-		assertEquals(Arrays.asList("synapse_synonyms", "std_word_delimiter", "lowercase"), filters,
-				"Synonym filter must precede word_delimiter-style filters — OpenSearch parses each "
-						+ "synonym entry through every preceding filter, and word_delimiter cannot be used to parse synonyms.");
-	}
-
-	/**
-	 * When a synonym-aware analyzer is configured but no synonym rules are supplied, the synonym
-	 * filter must not appear in the chain at all — the declared filterOrder is the final chain.
-	 * Protects against a naive fix that always prepends the synonym name.
-	 */
-	@Test
-	public void testCreateIndexWithoutSynonymsOmitsSynonymFilter() throws IOException {
-		String indexName = "search-index-syn1";
-		ArgumentCaptor<CreateIndexRequest> captor = ArgumentCaptor.forClass(CreateIndexRequest.class);
-		when(openSearchClient.indices()).thenReturn(indicesClient);
-		when(indicesClient.create(captor.capture())).thenReturn(
-				new org.opensearch.client.opensearch.indices.CreateIndexResponse.Builder()
-						.index(indexName).acknowledged(true).shardsAcknowledged(true).build());
-
-		TextAnalyzer standard = new TextAnalyzer().setId("2").setSettings(
-				new TextAnalyzerSettings()
-						.setTokenizer("standard")
-						.setFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"))
-						.setSynonymAware(true));
-		Map<String, TextAnalyzer> analyzers = new HashMap<>();
-		analyzers.put("org.sage-STANDARD", standard);
-
-		// call under test — empty synonymSets → hasSynonyms=false
-		manager.createIndex(indexName, Collections.emptyList(), null,
-				Collections.emptyList(), Collections.emptyList(), analyzers);
-
-		List<String> filters = captor.getValue().settings().analysis()
-				.analyzer().get("synapse_analyzer_2").custom().filter();
-		assertEquals(Arrays.asList("std_word_delimiter", "lowercase"), filters);
-	}
-
-	/**
-	 * Analyzers that opt out of synonyms ({@code synonymAware=false}, e.g. AUTOCOMPLETE index-time)
-	 * must never get the synonym filter injected, even when synonym rules are provided for other
-	 * analyzers in the same index.
-	 */
-	@Test
-	public void testCreateIndexWithSynonymsSkipsNonSynonymAwareAnalyzer() throws IOException {
-		String indexName = "search-index-syn1";
-		ArgumentCaptor<CreateIndexRequest> captor = ArgumentCaptor.forClass(CreateIndexRequest.class);
-		when(openSearchClient.indices()).thenReturn(indicesClient);
-		when(indicesClient.create(captor.capture())).thenReturn(
-				new org.opensearch.client.opensearch.indices.CreateIndexResponse.Builder()
-						.index(indexName).acknowledged(true).shardsAcknowledged(true).build());
-
-		// synonym-aware analyzer
-		TextAnalyzer standard = new TextAnalyzer().setId("2").setSettings(
-				new TextAnalyzerSettings()
-						.setTokenizer("standard")
-						.setFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"))
-						.setSynonymAware(true));
-		// opted out — mirrors the bootstrapped AUTOCOMPLETE (index-time) analyzer
-		TextAnalyzer autocomplete = new TextAnalyzer().setId("5").setSettings(
-				new TextAnalyzerSettings()
-						.setTokenizer("standard")
-						.setFilterOrder(Arrays.asList("ac_word_delimiter", "lowercase"))
-						.setSynonymAware(false));
-		Map<String, TextAnalyzer> analyzers = new HashMap<>();
-		analyzers.put("org.sage-STANDARD", standard);
-		analyzers.put("org.sage-AUTOCOMPLETE", autocomplete);
-
-		SynonymSet set = new SynonymSet().setRules(Collections.singletonList(
-				new SynonymRule().setRuleType(SynonymRuleType.EQUIVALENT)
-						.setTerms(Arrays.asList("cancer", "tumor"))));
-
-		// call under test
-		manager.createIndex(indexName, Collections.emptyList(), null,
-				Collections.singletonList(set), Collections.emptyList(), analyzers);
+	public void testCreateIndexWithSynonymAwareAnalyzerAndSynonyms() throws IOException {
+		Map<String, TextAnalyzer> analyzers = Collections.singletonMap("org.sage-STANDARD",
+				buildTestAnalyzer("2", true, "std_word_delimiter", "lowercase"));
 
 		Map<String, org.opensearch.client.opensearch._types.analysis.Analyzer> registered =
-				captor.getValue().settings().analysis().analyzer();
-		assertEquals(Arrays.asList("synapse_synonyms", "std_word_delimiter", "lowercase"),
-				registered.get("synapse_analyzer_2").custom().filter(),
-				"Synonym-aware analyzer must have synonym filter prepended");
+				captureCreateIndexAnalyzers(analyzers, Collections.singletonList(equivalentSynonymSet("cancer", "tumor")));
+
+		assertEquals(Arrays.asList("std_word_delimiter", "lowercase"),
+				registered.get("synapse_analyzer_2").custom().filter());
+		// Search variant: lowercase must run before the synonym filter (synonym rule-parsing
+		// rejects preceding filters with positionLength > 1, which includes both
+		// word_delimiter and word_delimiter_graph). word_delimiter then runs on the
+		// synonym-expanded stream.
+		assertEquals(Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter"),
+				registered.get("synapse_analyzer_2_search").custom().filter());
+	}
+
+	@Test
+	public void testCreateIndexWithSynonymAwareAnalyzerAndNoSynonyms() throws IOException {
+		Map<String, TextAnalyzer> analyzers = Collections.singletonMap("org.sage-STANDARD",
+				buildTestAnalyzer("2", true, "std_word_delimiter", "lowercase"));
+
+		Map<String, org.opensearch.client.opensearch._types.analysis.Analyzer> registered =
+				captureCreateIndexAnalyzers(analyzers, Collections.emptyList());
+
+		assertEquals(Arrays.asList("std_word_delimiter", "lowercase"),
+				registered.get("synapse_analyzer_2").custom().filter());
+		assertFalse(registered.containsKey("synapse_analyzer_2_search"));
+	}
+
+	@Test
+	public void testCreateIndexWithNonSynonymAwareAnalyzerAndSynonyms() throws IOException {
+		Map<String, TextAnalyzer> analyzers = new HashMap<>();
+		analyzers.put("org.sage-STANDARD", buildTestAnalyzer("2", true, "std_word_delimiter", "lowercase"));
+		analyzers.put("org.sage-AUTOCOMPLETE", buildTestAnalyzer("5", false, "ac_word_delimiter", "lowercase"));
+
+		Map<String, org.opensearch.client.opensearch._types.analysis.Analyzer> registered =
+				captureCreateIndexAnalyzers(analyzers, Collections.singletonList(equivalentSynonymSet("cancer", "tumor")));
+
+		assertEquals(Arrays.asList("std_word_delimiter", "lowercase"),
+				registered.get("synapse_analyzer_2").custom().filter());
+		assertEquals(Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter"),
+				registered.get("synapse_analyzer_2_search").custom().filter());
 		assertEquals(Arrays.asList("ac_word_delimiter", "lowercase"),
-				registered.get("synapse_analyzer_5").custom().filter(),
-				"synonymAware=false analyzer must NOT receive the synonym filter");
+				registered.get("synapse_analyzer_5").custom().filter());
+		assertFalse(registered.containsKey("synapse_analyzer_5_search"));
+	}
+
+	@Test
+	public void testCreateIndexWithSynonymAwareAnalyzerWithoutLowercaseInDeclaredChain() throws IOException {
+		// lowercase + synapse_synonyms are always prepended at search time so synonym
+		// rule-parsing succeeds and matching is case-insensitive, regardless of whether
+		// the declared chain itself includes lowercase.
+		Map<String, TextAnalyzer> analyzers = Collections.singletonMap("org.sage-CUSTOM",
+				buildTestAnalyzer("99", true, "custom_filter"));
+
+		Map<String, org.opensearch.client.opensearch._types.analysis.Analyzer> registered =
+				captureCreateIndexAnalyzers(analyzers, Collections.singletonList(equivalentSynonymSet("a", "b")));
+
+		assertEquals(Arrays.asList("lowercase", "synapse_synonyms", "custom_filter"),
+				registered.get("synapse_analyzer_99_search").custom().filter());
+	}
+
+	private static TextAnalyzer buildTestAnalyzer(String id, boolean synonymAware, String... filters) {
+		return new TextAnalyzer().setId(id).setSettings(new TextAnalyzerSettings()
+				.setTokenizer("standard")
+				.setFilterOrder(Arrays.asList(filters))
+				.setSynonymAware(synonymAware));
+	}
+
+	private static SynonymSet equivalentSynonymSet(String... terms) {
+		return new SynonymSet().setRules(Collections.singletonList(
+				new SynonymRule().setRuleType(SynonymRuleType.EQUIVALENT).setTerms(Arrays.asList(terms))));
+	}
+
+	private Map<String, org.opensearch.client.opensearch._types.analysis.Analyzer> captureCreateIndexAnalyzers(
+			Map<String, TextAnalyzer> analyzers, List<SynonymSet> synonymSets) throws IOException {
+		String indexName = "search-index-syn1";
+		ArgumentCaptor<CreateIndexRequest> captor = ArgumentCaptor.forClass(CreateIndexRequest.class);
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		when(indicesClient.create(captor.capture())).thenReturn(
+				new org.opensearch.client.opensearch.indices.CreateIndexResponse.Builder()
+						.index(indexName).acknowledged(true).shardsAcknowledged(true).build());
+
+		manager.createIndex(indexName, Collections.emptyList(), null,
+				synonymSets, Collections.emptyList(), analyzers);
+
+		return captor.getValue().settings().analysis().analyzer();
 	}
 
 	// --- buildOverrideMap ---
@@ -541,22 +509,75 @@ public class OpenSearchManagerImplTest {
 	}
 
 	@Test
-	public void testResolveSearchAnalyzerNameWithEntry() {
-		Map<String, TextAnalyzer> analyzers = new HashMap<>();
-		analyzers.put("org.sage-SEARCH",
-				new TextAnalyzer().setId("42").setSettings(new TextAnalyzerSettings().setTokenizer("standard")));
+	public void testResolveSearchAnalyzerNameWithSearchOverride() {
+		TextAnalyzer searchAnalyzer = new TextAnalyzer().setId("42")
+				.setSettings(new TextAnalyzerSettings().setTokenizer("standard"));
+		Map<String, TextAnalyzer> analyzers = Collections.singletonMap("org.sage-SEARCH", searchAnalyzer);
 		ColumnAnalyzerOverrideEntry entry = new ColumnAnalyzerOverrideEntry().setSearchAnalyzer("org.sage-SEARCH");
 
-		// call under test — entry.searchAnalyzer wins over indexAnalyzerName
+		// call under test
 		assertEquals("synapse_analyzer_42",
-				manager.resolveSearchAnalyzerName("synapse_analyzer_99", entry, analyzers));
+				manager.resolveSearchAnalyzerName("synapse_analyzer_99", scientific, entry, analyzers, true));
 	}
 
 	@Test
-	public void testResolveSearchAnalyzerNameFallsBackToIndexAnalyzer() {
-		// call under test — no entry → indexAnalyzerName is returned unchanged
+	public void testResolveSearchAnalyzerNameWithoutEntryAndNotSynonymAware() {
+		// call under test
 		assertEquals("synapse_analyzer_99",
-				manager.resolveSearchAnalyzerName("synapse_analyzer_99", null, Collections.emptyMap()));
+				manager.resolveSearchAnalyzerName("synapse_analyzer_99", scientific, null,
+						Collections.emptyMap(), true));
+	}
+
+	@Test
+	public void testResolveSearchAnalyzerNameWithSynonymAwareEffectiveAnalyzerAndSynonyms() {
+		TextAnalyzer synonymAware = new TextAnalyzer().setId("1").setSettings(
+				new TextAnalyzerSettings().setTokenizer("standard").setSynonymAware(true));
+
+		// call under test
+		assertEquals("synapse_analyzer_1_search",
+				manager.resolveSearchAnalyzerName("synapse_analyzer_1", synonymAware, null,
+						Collections.emptyMap(), true));
+	}
+
+	@Test
+	public void testResolveSearchAnalyzerNameWithSynonymAwareEffectiveAnalyzerAndNoSynonyms() {
+		TextAnalyzer synonymAware = new TextAnalyzer().setId("1").setSettings(
+				new TextAnalyzerSettings().setTokenizer("standard").setSynonymAware(true));
+
+		// call under test
+		assertEquals("synapse_analyzer_1",
+				manager.resolveSearchAnalyzerName("synapse_analyzer_1", synonymAware, null,
+						Collections.emptyMap(), false));
+	}
+
+	@Test
+	public void testResolveSearchAnalyzerNameWithAsymmetricOverrideUsesSearchSide() {
+		TextAnalyzer keyword = new TextAnalyzer().setId("4").setSettings(
+				new TextAnalyzerSettings().setTokenizer("keyword").setSynonymAware(false));
+		TextAnalyzer standard = new TextAnalyzer().setId("2").setSettings(
+				new TextAnalyzerSettings().setTokenizer("standard").setSynonymAware(true));
+		Map<String, TextAnalyzer> analyzers = new HashMap<>();
+		analyzers.put("org.sage-KEYWORD", keyword);
+		analyzers.put("org.sage-STANDARD", standard);
+		ColumnAnalyzerOverrideEntry entry = new ColumnAnalyzerOverrideEntry()
+				.setIndexAnalyzer("org.sage-KEYWORD")
+				.setSearchAnalyzer("org.sage-STANDARD");
+
+		// call under test
+		assertEquals("synapse_analyzer_2_search",
+				manager.resolveSearchAnalyzerName("synapse_analyzer_4", keyword, entry, analyzers, true));
+	}
+
+	@Test
+	public void testResolveSearchAnalyzerNameWithIndexOnlyOverrideReadsSynonymAwareFromOverride() {
+		TextAnalyzer standard = new TextAnalyzer().setId("2").setSettings(
+				new TextAnalyzerSettings().setTokenizer("standard").setSynonymAware(true));
+		Map<String, TextAnalyzer> analyzers = Collections.singletonMap("org.sage-STANDARD", standard);
+		ColumnAnalyzerOverrideEntry entry = new ColumnAnalyzerOverrideEntry().setIndexAnalyzer("org.sage-STANDARD");
+
+		// call under test — scientific (effective) is not synonymAware, but the index override IS
+		assertEquals("synapse_analyzer_2_search",
+				manager.resolveSearchAnalyzerName("synapse_analyzer_2", scientific, entry, analyzers, true));
 	}
 
 	// --- getFilterFieldName ---

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -263,6 +263,131 @@ public class OpenSearchManagerImplTest {
 		assertEquals(Collections.emptyList(), rules);
 	}
 
+	// --- createIndex filter ordering with synonyms ---
+
+	/**
+	 * Regression guard for the AOSS "Token filter [std_word_delimiter] cannot be used to parse
+	 * synonyms" failure. OpenSearch parses synonym entries through every filter that precedes
+	 * the synonym filter in the analyzer chain; {@code word_delimiter}-style filters emit
+	 * multiple tokens per input, which synonym parsing rejects. The fix places the synonym
+	 * filter FIRST in the chain so the preceding chain is empty at synonym-parse time. This
+	 * test locks that ordering contract.
+	 */
+	@Test
+	public void testCreateIndexWithSynonymsPlacesSynonymFilterFirst() throws IOException {
+		String indexName = "search-index-syn1";
+		ArgumentCaptor<CreateIndexRequest> captor = ArgumentCaptor.forClass(CreateIndexRequest.class);
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		when(indicesClient.create(captor.capture())).thenReturn(
+				new org.opensearch.client.opensearch.indices.CreateIndexResponse.Builder()
+						.index(indexName).acknowledged(true).shardsAcknowledged(true).build());
+
+		// Mirrors the bootstrapped STANDARD analyzer chain ordering. The filter names in
+		// filterOrder do not need a corresponding tokenFilters JSON for this ordering-contract
+		// test (AOSS would resolve them either as built-ins or as named filters registered
+		// elsewhere); the assertion is purely on the emitted list ordering.
+		TextAnalyzer standard = new TextAnalyzer().setId("2").setSettings(
+				new TextAnalyzerSettings()
+						.setTokenizer("standard")
+						.setFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"))
+						.setSynonymAware(true));
+		Map<String, TextAnalyzer> analyzers = new HashMap<>();
+		analyzers.put("org.sage-STANDARD", standard);
+
+		SynonymSet set = new SynonymSet().setRules(Collections.singletonList(
+				new SynonymRule().setRuleType(SynonymRuleType.EQUIVALENT)
+						.setTerms(Arrays.asList("cancer", "tumor"))));
+
+		// call under test
+		manager.createIndex(indexName, Collections.emptyList(), null,
+				Collections.singletonList(set), Collections.emptyList(), analyzers);
+
+		List<String> filters = captor.getValue().settings().analysis()
+				.analyzer().get("synapse_analyzer_2").custom().filter();
+		assertEquals(Arrays.asList("synapse_synonyms", "std_word_delimiter", "lowercase"), filters,
+				"Synonym filter must precede word_delimiter-style filters — OpenSearch parses each "
+						+ "synonym entry through every preceding filter, and word_delimiter cannot be used to parse synonyms.");
+	}
+
+	/**
+	 * When a synonym-aware analyzer is configured but no synonym rules are supplied, the synonym
+	 * filter must not appear in the chain at all — the declared filterOrder is the final chain.
+	 * Protects against a naive fix that always prepends the synonym name.
+	 */
+	@Test
+	public void testCreateIndexWithoutSynonymsOmitsSynonymFilter() throws IOException {
+		String indexName = "search-index-syn1";
+		ArgumentCaptor<CreateIndexRequest> captor = ArgumentCaptor.forClass(CreateIndexRequest.class);
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		when(indicesClient.create(captor.capture())).thenReturn(
+				new org.opensearch.client.opensearch.indices.CreateIndexResponse.Builder()
+						.index(indexName).acknowledged(true).shardsAcknowledged(true).build());
+
+		TextAnalyzer standard = new TextAnalyzer().setId("2").setSettings(
+				new TextAnalyzerSettings()
+						.setTokenizer("standard")
+						.setFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"))
+						.setSynonymAware(true));
+		Map<String, TextAnalyzer> analyzers = new HashMap<>();
+		analyzers.put("org.sage-STANDARD", standard);
+
+		// call under test — empty synonymSets → hasSynonyms=false
+		manager.createIndex(indexName, Collections.emptyList(), null,
+				Collections.emptyList(), Collections.emptyList(), analyzers);
+
+		List<String> filters = captor.getValue().settings().analysis()
+				.analyzer().get("synapse_analyzer_2").custom().filter();
+		assertEquals(Arrays.asList("std_word_delimiter", "lowercase"), filters);
+	}
+
+	/**
+	 * Analyzers that opt out of synonyms ({@code synonymAware=false}, e.g. AUTOCOMPLETE index-time)
+	 * must never get the synonym filter injected, even when synonym rules are provided for other
+	 * analyzers in the same index.
+	 */
+	@Test
+	public void testCreateIndexWithSynonymsSkipsNonSynonymAwareAnalyzer() throws IOException {
+		String indexName = "search-index-syn1";
+		ArgumentCaptor<CreateIndexRequest> captor = ArgumentCaptor.forClass(CreateIndexRequest.class);
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		when(indicesClient.create(captor.capture())).thenReturn(
+				new org.opensearch.client.opensearch.indices.CreateIndexResponse.Builder()
+						.index(indexName).acknowledged(true).shardsAcknowledged(true).build());
+
+		// synonym-aware analyzer
+		TextAnalyzer standard = new TextAnalyzer().setId("2").setSettings(
+				new TextAnalyzerSettings()
+						.setTokenizer("standard")
+						.setFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"))
+						.setSynonymAware(true));
+		// opted out — mirrors the bootstrapped AUTOCOMPLETE (index-time) analyzer
+		TextAnalyzer autocomplete = new TextAnalyzer().setId("5").setSettings(
+				new TextAnalyzerSettings()
+						.setTokenizer("standard")
+						.setFilterOrder(Arrays.asList("ac_word_delimiter", "lowercase"))
+						.setSynonymAware(false));
+		Map<String, TextAnalyzer> analyzers = new HashMap<>();
+		analyzers.put("org.sage-STANDARD", standard);
+		analyzers.put("org.sage-AUTOCOMPLETE", autocomplete);
+
+		SynonymSet set = new SynonymSet().setRules(Collections.singletonList(
+				new SynonymRule().setRuleType(SynonymRuleType.EQUIVALENT)
+						.setTerms(Arrays.asList("cancer", "tumor"))));
+
+		// call under test
+		manager.createIndex(indexName, Collections.emptyList(), null,
+				Collections.singletonList(set), Collections.emptyList(), analyzers);
+
+		Map<String, org.opensearch.client.opensearch._types.analysis.Analyzer> registered =
+				captor.getValue().settings().analysis().analyzer();
+		assertEquals(Arrays.asList("synapse_synonyms", "std_word_delimiter", "lowercase"),
+				registered.get("synapse_analyzer_2").custom().filter(),
+				"Synonym-aware analyzer must have synonym filter prepended");
+		assertEquals(Arrays.asList("ac_word_delimiter", "lowercase"),
+				registered.get("synapse_analyzer_5").custom().filter(),
+				"synonymAware=false analyzer must NOT receive the synonym filter");
+	}
+
 	// --- buildOverrideMap ---
 
 	@Test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplValidateTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplValidateTest.java
@@ -72,7 +72,7 @@ public class OpenSearchManagerImplValidateTest {
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
 		settings.setTokenFilters("{\"my_stop\":{\"type\":\"stop\",\"stopwords\":\"_english_\"}}");
-		settings.setFilterOrder(Arrays.asList("my_stop", "lowercase"));
+		settings.setIndexFilterOrder(Arrays.asList("my_stop", "lowercase"));
 
 		// call under test
 		assertDoesNotThrow(() -> manager.validateAnalyzerSettings(settings));
@@ -85,7 +85,7 @@ public class OpenSearchManagerImplValidateTest {
 
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizerConfig("{\"type\":\"edge_ngram\",\"min_gram\":2,\"max_gram\":20,\"token_chars\":[\"letter\",\"digit\"]}");
-		settings.setFilterOrder(Arrays.asList("lowercase"));
+		settings.setIndexFilterOrder(Arrays.asList("lowercase"));
 
 		// call under test
 		assertDoesNotThrow(() -> manager.validateAnalyzerSettings(settings));
@@ -154,7 +154,7 @@ public class OpenSearchManagerImplValidateTest {
 		TextAnalyzerSettings settings = new TextAnalyzerSettings();
 		settings.setTokenizer("standard");
 		settings.setTokenFilters("not valid json");
-		settings.setFilterOrder(Arrays.asList("my_filter"));
+		settings.setIndexFilterOrder(Arrays.asList("my_filter"));
 
 		// call under test
 		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
@@ -191,5 +191,49 @@ public class OpenSearchManagerImplValidateTest {
 		// call under test
 		assertThrows(IllegalArgumentException.class,
 			() -> manager.validateAnalyzerSettings(null));
+	}
+
+	@Test
+	public void testValidateThrowsWhenSynonymAwareWithoutSearchFilterOrder() {
+		TextAnalyzerSettings settings = new TextAnalyzerSettings();
+		settings.setTokenizer("standard");
+		settings.setIndexFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"));
+		settings.setSynonymAware(true);
+
+		// call under test — synonymAware=true without searchFilterOrder is rejected before
+		// reaching the AOSS analyze probe.
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> manager.validateAnalyzerSettings(settings));
+		assertTrue(ex.getMessage().contains("synapse_synonyms"));
+	}
+
+	@Test
+	public void testValidateThrowsWhenSynonymAwareSearchFilterOrderMissingSynonymsToken() {
+		TextAnalyzerSettings settings = new TextAnalyzerSettings();
+		settings.setTokenizer("standard");
+		settings.setIndexFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"));
+		settings.setSearchFilterOrder(Arrays.asList("lowercase", "std_word_delimiter"));
+		settings.setSynonymAware(true);
+
+		// call under test — searchFilterOrder must explicitly include synapse_synonyms.
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> manager.validateAnalyzerSettings(settings));
+		assertTrue(ex.getMessage().contains("synapse_synonyms"));
+	}
+
+	@Test
+	public void testValidateAcceptsSynonymAwareWithProperSearchFilterOrder() throws IOException {
+		setupAnalyzeSuccess();
+		setupJsonpMapper();
+
+		TextAnalyzerSettings settings = new TextAnalyzerSettings();
+		settings.setTokenizer("standard");
+		settings.setTokenFilters("{\"std_word_delimiter\":{\"type\":\"word_delimiter_graph\",\"preserve_original\":true}}");
+		settings.setIndexFilterOrder(Arrays.asList("std_word_delimiter", "lowercase"));
+		settings.setSearchFilterOrder(Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter"));
+		settings.setSynonymAware(true);
+
+		// call under test
+		assertDoesNotThrow(() -> manager.validateAnalyzerSettings(settings));
 	}
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapperTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapperTest.java
@@ -75,41 +75,41 @@ public class TextAnalyzerBootstrapperTest {
 	}
 
 	@Test
-	public void testScientificAnalyzerUsesLegacyWordDelimiter() {
+	public void testScientificAnalyzerUsesWordDelimiterGraph() {
 		setupOrgMock();
 
 		verify(textAnalyzerDao).createOrUpdateSystemAnalyzerForBootstrapOnly(eq(TextAnalyzerBootstrapper.SCIENTIFIC_ID), analyzerCaptor.capture(), eq(TEST_ORG_NAME), any(Long.class));
 		TextAnalyzerSettings settings = analyzerCaptor.getValue().getSettings();
 
 		assertEquals("standard", settings.getTokenizer());
-		assertWordDelimiterFilter(settings.getTokenFilters(), "sci_word_delimiter");
+		assertWordDelimiterGraphFilter(settings.getTokenFilters(), "sci_word_delimiter");
 		assertEquals(Arrays.asList("sci_word_delimiter", "lowercase", "english_stop", "english_stemmer"),
 				settings.getFilterOrder());
 		assertTrue(settings.getSynonymAware());
 	}
 
 	@Test
-	public void testStandardAnalyzerUsesLegacyWordDelimiter() {
+	public void testStandardAnalyzerUsesWordDelimiterGraph() {
 		setupOrgMock();
 
 		verify(textAnalyzerDao).createOrUpdateSystemAnalyzerForBootstrapOnly(eq(TextAnalyzerBootstrapper.STANDARD_ID), analyzerCaptor.capture(), eq(TEST_ORG_NAME), any(Long.class));
 		TextAnalyzerSettings settings = analyzerCaptor.getValue().getSettings();
 
 		assertEquals("standard", settings.getTokenizer());
-		assertWordDelimiterFilter(settings.getTokenFilters(), "std_word_delimiter");
+		assertWordDelimiterGraphFilter(settings.getTokenFilters(), "std_word_delimiter");
 		assertEquals(Arrays.asList("std_word_delimiter", "lowercase"), settings.getFilterOrder());
 		assertTrue(settings.getSynonymAware());
 	}
 
 	@Test
-	public void testIdentifierAnalyzerUsesLegacyWordDelimiter() {
+	public void testIdentifierAnalyzerUsesWordDelimiterGraph() {
 		setupOrgMock();
 
 		verify(textAnalyzerDao).createOrUpdateSystemAnalyzerForBootstrapOnly(eq(TextAnalyzerBootstrapper.IDENTIFIER_ID), analyzerCaptor.capture(), eq(TEST_ORG_NAME), any(Long.class));
 		TextAnalyzerSettings settings = analyzerCaptor.getValue().getSettings();
 
 		assertEquals("whitespace", settings.getTokenizer());
-		assertWordDelimiterFilter(settings.getTokenFilters(), "id_word_delimiter");
+		assertWordDelimiterGraphFilter(settings.getTokenFilters(), "id_word_delimiter");
 		assertEquals(Arrays.asList("id_word_delimiter", "lowercase"), settings.getFilterOrder());
 		assertTrue(settings.getSynonymAware());
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapperTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapperTest.java
@@ -84,7 +84,12 @@ public class TextAnalyzerBootstrapperTest {
 		assertEquals("standard", settings.getTokenizer());
 		assertWordDelimiterGraphFilter(settings.getTokenFilters(), "sci_word_delimiter");
 		assertEquals(Arrays.asList("sci_word_delimiter", "lowercase", "english_stop", "english_stemmer"),
-				settings.getFilterOrder());
+				settings.getIndexFilterOrder());
+		// Search-time chain: lowercase first so synonym rule LHS and query tokens reach
+		// the synonym filter in the same case; word_delimiter_graph downstream of
+		// synapse_synonyms so the synonym rule parser doesn't see positionLength>1 tokens.
+		assertEquals(Arrays.asList("lowercase", "synapse_synonyms", "sci_word_delimiter", "english_stop", "english_stemmer"),
+				settings.getSearchFilterOrder());
 		assertTrue(settings.getSynonymAware());
 	}
 
@@ -97,7 +102,9 @@ public class TextAnalyzerBootstrapperTest {
 
 		assertEquals("standard", settings.getTokenizer());
 		assertWordDelimiterGraphFilter(settings.getTokenFilters(), "std_word_delimiter");
-		assertEquals(Arrays.asList("std_word_delimiter", "lowercase"), settings.getFilterOrder());
+		assertEquals(Arrays.asList("std_word_delimiter", "lowercase"), settings.getIndexFilterOrder());
+		assertEquals(Arrays.asList("lowercase", "synapse_synonyms", "std_word_delimiter"),
+				settings.getSearchFilterOrder());
 		assertTrue(settings.getSynonymAware());
 	}
 
@@ -110,7 +117,9 @@ public class TextAnalyzerBootstrapperTest {
 
 		assertEquals("whitespace", settings.getTokenizer());
 		assertWordDelimiterGraphFilter(settings.getTokenFilters(), "id_word_delimiter");
-		assertEquals(Arrays.asList("id_word_delimiter", "lowercase"), settings.getFilterOrder());
+		assertEquals(Arrays.asList("id_word_delimiter", "lowercase"), settings.getIndexFilterOrder());
+		assertEquals(Arrays.asList("lowercase", "synapse_synonyms", "id_word_delimiter"),
+				settings.getSearchFilterOrder());
 		assertTrue(settings.getSynonymAware());
 	}
 
@@ -125,7 +134,7 @@ public class TextAnalyzerBootstrapperTest {
 		// Index-time analyzer ending in edge_ngram requires legacy word_delimiter (non-graph),
 		// otherwise multi-position graph tokens break edge_ngram and AOSS rejects every document.
 		assertWordDelimiterFilter(settings.getTokenFilters(), "ac_word_delimiter");
-		List<String> filterOrder = settings.getFilterOrder();
+		List<String> filterOrder = settings.getIndexFilterOrder();
 		assertEquals("ac_word_delimiter", filterOrder.get(0));
 		assertEquals("lowercase", filterOrder.get(1));
 		assertEquals("edge_ngram_filter", filterOrder.get(2));
@@ -140,7 +149,9 @@ public class TextAnalyzerBootstrapperTest {
 
 		assertEquals("standard", settings.getTokenizer());
 		assertWordDelimiterGraphFilter(settings.getTokenFilters(), "acs_word_delimiter");
-		assertEquals(Arrays.asList("acs_word_delimiter", "lowercase"), settings.getFilterOrder());
+		assertEquals(Arrays.asList("acs_word_delimiter", "lowercase"), settings.getIndexFilterOrder());
+		assertEquals(Arrays.asList("lowercase", "synapse_synonyms", "acs_word_delimiter"),
+				settings.getSearchFilterOrder());
 		assertTrue(settings.getSynonymAware());
 	}
 
@@ -160,7 +171,7 @@ public class TextAnalyzerBootstrapperTest {
 		for (Long id : idsWithWordDelimiter) {
 			verify(textAnalyzerDao).createOrUpdateSystemAnalyzerForBootstrapOnly(eq(id), analyzerCaptor.capture(), eq(TEST_ORG_NAME), any(Long.class));
 			TextAnalyzerSettings settings = analyzerCaptor.getValue().getSettings();
-			List<String> order = settings.getFilterOrder();
+			List<String> order = settings.getIndexFilterOrder();
 			int wdIdx = -1;
 			int lcIdx = -1;
 			for (int i = 0; i < order.size(); i++) {


### PR DESCRIPTION
## Summary

Three interrelated defects in the `SearchIndex` analyzer pipeline broke synonym-aware indexes end-to-end. Each is described separately below, followed by the shared root cause and the fix in `OpenSearchManagerImpl` and `TextAnalyzerBootstrapper`.

### Problem 1 — `createIndex` failed when a synonym-aware analyzer ran a `word_delimiter*` filter before the synonym filter

OpenSearch parses every synonym rule by replaying it through the chain segment that precedes the synonym filter. Both `word_delimiter` and `word_delimiter_graph` emit tokens with `positionLength > 1`, which the synonym rule parser rejects with:

```
java.lang.RuntimeException: Failed to create search index: search-index-syn9602623
 (illegal_argument_exception: OpenSearch exception
  [type=illegal_argument_exception,
   reason=Token filter [std_word_delimiter] cannot be used to parse synonyms]
  - server : [envoy]
  [rootCause=illegal_argument_exception: OpenSearch exception
   [type=illegal_argument_exception,
    reason=Token filter [std_word_delimiter] cannot be used to parse synonyms]
   - server : [envoy]])
    at OpenSearchManagerImpl.createIndex(OpenSearchManagerImpl.java:190)
    ... SearchIndexLifecycleManagerImpl.buildIndex(SearchIndexLifecycleManagerImpl.java:255)
    at SearchIndexLifecycleManagerImpl.handleCreate(SearchIndexLifecycleManagerImpl.java:175)
    at SearchIndexLifecycleWorker.processMessage(SearchIndexLifecycleWorker.java:56)
Caused by: org.opensearch.client.opensearch._types.OpenSearchException:
  Request failed: [illegal_argument_exception]
  Token filter [std_word_delimiter] cannot be used to parse synonyms
```

This blocked index creation outright for any analyzer whose declared `filterOrder` placed `word_delimiter*` before the synonym filter.

### Problem 2 — bulk indexing rejected documents with `startOffset must be non-negative…`

After Problem 1 was masked by reordering filters so the synonym filter ran first, bulk indexing began permanently rejecting a fraction of documents. Observed on `search-index-syn9602624`: 150 of 782 documents rejected. Affected documents contained hyphenated / CamelCase / digit-letter tokens (e.g. `cancer-related`, `messengerRNA`, `mRNA-seq`) overlapping synonym source terms.

```
illegal_argument_exception: startOffset must be non-negative,
  and endOffset must be >= startOffset,
  and offsets must not go backwards
  startOffset=1252, endOffset=1258, lastStartOffset=1254 for field '5'
```

Lucene's `CheckOffsetsAttribute` enforces offset monotonicity when postings store offsets. With the synonym filter ahead of `word_delimiter*` at index time, synonym expansions inherit the source token's offsets while `word_delimiter*` running downstream re-splits at sub-token boundaries, producing offsets that go backwards relative to tokens already emitted.

### Problem 3 — multi-word synonym LHS returned 0 hits at query time

Once Problems 1 and 2 were addressed, single-token synonym pairs (e.g. `AI` ↔ `artificial intelligence`) returned hits, but every multi-word left-hand-side rule returned **0 hits on both sides of the pair**:

| Query text | Expected (MULTI_MATCH) | Observed |
| --- | --- | --- |
| `deep learning` / `DL` | 62 / 62 | 0 / 0 |
| `natural language processing` / `NLP` | 65 / 65 | 0 / 0 |
| `large language model` / `LLM` | 15 / 15 | 0 / 0 |
| `computer vision` / `CV` | 16 / 16 | 0 / 0 |

The plain `synonym` token filter cannot emit multi-position graph tokens, which are required for a multi-word phrase like `"deep learning"` to match a document containing only its abbreviation `DL` (and vice versa).

## Root cause

The single-analyzer model in `registerAnalyzer` baked synonym expansion into the same chain used at both index and search time. That single chain cannot satisfy three constraints simultaneously:

1. The synonym filter must be parseable (no `word_delimiter*` upstream of it).
2. Index-time offsets must remain monotonically non-decreasing (no synonym expansion upstream of `word_delimiter*`).
3. Multi-word LHS must expand to graph tokens at search time (requires `synonym_graph`, not `synonym`).

## Fix

The `TextAnalyzer` schema now exposes the index-time and search-time chains as separate, user-authored fields. The manager registers what's declared — no dynamic reordering, no synthetic filter injection.

- **Schema rename**: `filterOrder` → `indexFilterOrder` (clearer pairing with the new `searchFilterOrder`). Bootstrap-only today, so no production data migration is needed; the bootstrapper rewrites its own rows on startup.
- **New field**: `TextAnalyzerSettings.searchFilterOrder`. Optional. When absent, search reuses `indexFilterOrder` (symmetric analysis). When present, the manager registers a separate `synapse_analyzer_<id>_search` variant from this chain. This handles both synonym analyzers AND non-synonym asymmetric analyzers like AUTOCOMPLETE (edge-ngram at index, plain tokens at search).
- **Validation**: `synonymAware=true` analyzers must declare a `searchFilterOrder` containing the literal `synapse_synonyms` token. Rejected at create/update time with a remediation message — no more silent failures during index build.
- **Bootstrap**: SCIENTIFIC / STANDARD / IDENTIFIER / AUTOCOMPLETE_SEARCH each declare an explicit `searchFilterOrder` of `[lowercase, synapse_synonyms, <word_delimiter_graph>, ...]` so synonym rule-parsing sees lowercased single-position tokens (Problem 1 ✓) and `word_delimiter_graph` runs downstream of synonym expansion on the synonym-expanded stream (Problem 2 ✓). `synonym_graph` (not plain `synonym`) is what the system registers, preserving multi-word LHS expansion (Problem 3 ✓).
- **Case-insensitive synonym authoring**: `buildSynonymRules` now emits each user-authored rule plus a lowercased duplicate (deduped if identical). A rule authored as `BRCA1, breast cancer 1` matches queries in any casing — `BRCA1`, `brca1`, `Brca1` — without the user having to lowercase the rule themselves or know where `lowercase` sits in the chain.
- **`ColumnAnalyzerOverrideEntry.searchAnalyzer` docs clarified**: most asymmetric analysis is now expressed by setting `searchFilterOrder` on the analyzer; the override field is for the rarer case where search needs a different *analyzer record* than indexing.

## How the fix works

### Before — single chain used at both index and search time

```mermaid
flowchart TD
    B1["raw text"]
    B2["word_delimiter<br/>(positionLength &gt; 1)"]
    B3["lowercase"]
    B4["synonym (plain)"]
    B1 --> B2 --> B3 --> B4
    B4 --> E1["Problem 1:<br/>createIndex 400<br/>parser rejects<br/>word_delimiter output"]
    B4 --> E2["Problem 2:<br/>bulk-index offsets<br/>go backwards<br/>after re-split"]
    B4 --> E3["Problem 3:<br/>plain synonym cannot<br/>emit graph tokens<br/>for multi-word LHS"]
```

### After — explicit indexFilterOrder + searchFilterOrder per analyzer

```mermaid
flowchart LR
    subgraph TA["TextAnalyzer (e.g. STANDARD, synonymAware=true)"]
        IF["indexFilterOrder:<br/>[std_word_delimiter,<br/> lowercase]"]
        SF["searchFilterOrder:<br/>[lowercase,<br/> synapse_synonyms,<br/> std_word_delimiter]"]
    end
    IF -->|registered as| IDX["synapse_analyzer_&lt;id&gt;<br/>(index time)"]
    SF -->|registered as| SRCH["synapse_analyzer_&lt;id&gt;_search<br/>(search time)"]
    IDX --> IO["clean offsets,<br/>no synonym expansion<br/>(Problem 2 ✓)"]
    SRCH --> SO["lowercase first → synapse_synonyms parses<br/>(Problem 1 ✓), synonym_graph emits<br/>multi-word expansions (Problem 3 ✓),<br/>word_delimiter_graph runs downstream"]
```

```mermaid
flowchart TD
    R1["User-authored synonym rule:<br/>BRCA1, breast cancer 1"]
    R1 --> RD["buildSynonymRules emits both:<br/>BRCA1, breast cancer 1<br/>brca1, breast cancer 1"]
    RD --> RM["Queries in any casing match<br/>(BRCA1 / brca1 / Brca1) →<br/>users author rules in natural casing"]
```

## Test plan

- [x] **Unit tests** — `OpenSearchManagerImplTest` (131), `OpenSearchManagerImplValidateTest` (14), `TextAnalyzerBootstrapperTest` (7), `TextAnalyzerManagerImplTest` (27): 179/179 pass. New tests cover asymmetric non-synonym analyzers, case-sensitive synonymAware variants, lowercase-duplicate emission for explicit/equivalent/already-lowercase rules, and the three new validation rejections.
- [x] **DAO autowired tests** — `TextAnalyzerDaoImplAutowiredTest`, `SynonymSetDaoImplAutowiredTest`, `SearchConfigurationDaoImplAutowiredTest`: 35/35 pass against MySQL.
- [x] **Manager autowired test against live AOSS** — `OpenSearchManagerImplAutoWiredTest`: 17/17 pass, including `testSearchWithMultiWordAndMixedCaseSynonymQueries` (the multi-word + mixed-case regression case).
- [x] **Integration tests via embedded Tomcat** — `ITTextAnalyzerTest`, `ITSynonymSetTest`, `ITSearchConfigurationTest`, `ITSearchIndexEntityTest`: 6/6 pass.
- [ ] **Dev stack verification**: trigger a SearchIndex build over a SynonymSet whose rules include multi-word LHS and confirm `SEARCH_INDEX_STATUS` reaches `AVAILABLE` with no offset errors in logs.
- [ ] **Dev stack verification**: query the index for a multi-word synonym LHS authored in mixed case (e.g. `"BRCA1"` and `"brca1"`) and confirm symmetric hit counts via the auto-duplicated rule.
