### PR TITLE
PLFM-9358

### DIFF
--- a/lib/lib-shared-models/src/main/java/org/sagebionetworks/repo/model/AsynchJobFailedException.java
+++ b/lib/lib-shared-models/src/main/java/org/sagebionetworks/repo/model/AsynchJobFailedException.java
@@ -23,6 +23,11 @@ public class AsynchJobFailedException extends Exception {
 		this.status = status;
 	}
 
+	public AsynchJobFailedException(AsynchronousJobStatus status, Throwable throwable) {
+		super(extractMessage(status), throwable);
+		this.status = status;
+	}
+
 	/**
 	 * When this exception is thrown it will always include the status of the table.
 	 * 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/asynch/AsynchJobUtils.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/asynch/AsynchJobUtils.java
@@ -48,7 +48,7 @@ public class AsynchJobUtils {
 					// here
 				}
 				if (exception != null) {
-					throw exception;
+					throw new AsynchJobFailedException(jobStatus, exception);
 				}
 			}
 			throw new AsynchJobFailedException(jobStatus);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/asynch/AsynchJobUtilsTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/asynch/AsynchJobUtilsTest.java
@@ -75,7 +75,7 @@ public class AsynchJobUtilsTest {
 		jobStatus.setException(exception.getClass().getName());
 		jobStatus.setErrorDetails(exception.getMessage());
 		jobStatus.setErrorMessage(exception.getMessage());
-		IllegalArgumentException result = assertThrows(IllegalArgumentException.class, ()->{
+		AsynchJobFailedException result = assertThrows(AsynchJobFailedException.class, ()->{
 			// call under test
 			AsynchJobUtils.throwExceptionIfFailed(jobStatus);
 		});


### PR DESCRIPTION
Seems like any exception occurring in an async' job should be thrown as an AsynchJobFailedException, wrapping the original exception.