### PR TITLE
[PLFM-9673]: INTEGER facet results return null bucket values

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -30,6 +30,7 @@ import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.LongTermsBucketKey;
 import org.opensearch.client.opensearch._types.analysis.CharFilter;
 import org.opensearch.client.opensearch._types.analysis.CharFilterDefinition;
 import org.opensearch.client.opensearch._types.analysis.TokenFilter;
@@ -1168,7 +1169,8 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 				facets.add(buildFacetResult(columnName, valueCounts));
 			} else if (aggregate.isLterms()) {
 				List<FacetColumnResultValueCount> valueCounts = aggregate.lterms().buckets().array().stream()
-						.map(bucket -> buildFacetValueCount(bucket.keyAsString(), bucket.docCount()))
+						.map(bucket -> buildFacetValueCount(
+								longBucketKeyToString(bucket.keyAsString(), bucket.key()), bucket.docCount()))
 						.collect(Collectors.toList());
 				facets.add(buildFacetResult(columnName, valueCounts));
 			} else if (aggregate.isDterms()) {
@@ -1195,6 +1197,18 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		vc.setCount(docCount);
 		vc.setIsSelected(false);
 		return vc;
+	}
+
+	// LongTermsBucket.keyAsString() is populated for fields with an implicit format
+	// (BOOLEAN → "true"/"false", date → ISO string) but is null for plain LONG fields
+	// because we don't set an explicit `format` on the terms aggregation. Prefer it
+	// when present so booleans render as "true"/"false" rather than "1"/"0", and fall
+	// back to the typed key for the LONG case.
+	static String longBucketKeyToString(String keyAsString, LongTermsBucketKey key) {
+		if (keyAsString != null) {
+			return keyAsString;
+		}
+		return key.isSigned() ? String.valueOf(key.signed()) : key.unsigned();
 	}
 
 	/**

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.Optional;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
@@ -29,6 +30,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.sagebionetworks.repo.model.dbo.search.TextAnalyzerDao;
+import org.sagebionetworks.repo.model.search.FacetRequest;
 import org.sagebionetworks.repo.model.search.SearchFieldValue;
 import org.sagebionetworks.repo.model.search.SearchQuery;
 import org.sagebionetworks.repo.model.search.SearchQueryPart;
@@ -38,6 +40,9 @@ import org.sagebionetworks.repo.model.search.table.TextAnalyzer;
 import org.sagebionetworks.repo.model.search.table.TextAnalyzerSettings;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
+import org.sagebionetworks.repo.model.table.FacetColumnResult;
+import org.sagebionetworks.repo.model.table.FacetColumnResultValueCount;
+import org.sagebionetworks.repo.model.table.FacetColumnResultValues;
 import org.sagebionetworks.util.RetryException;
 import org.sagebionetworks.util.TimeUtils;
 import org.sagebionetworks.workers.util.aws.message.RecoverableMessageException;
@@ -620,10 +625,21 @@ public class OpenSearchManagerImplAutoWiredTest {
 
 		assertEquals(1L, indexed);
 
+		// Request facets on every terms-aggregable column in the same call so the
+		// numeric (lterms / dterms) and text (sterms) bucket-key paths all run
+		// against live AOSS — regression for PLFM-9673 (lterms.keyAsString() is
+		// null without an explicit `format`, so INTEGER facets came back with
+		// null `value`).
+		List<FacetRequest> facetRequests = columns.stream()
+				.filter(c -> casesByType.get(c.getColumnType()).expectedFacetValues != null)
+				.map(c -> new FacetRequest().setColumnName(c.getName()))
+				.collect(Collectors.toList());
+
 		SearchQuery query = new SearchQuery();
 		query.setQueryType(SearchQueryType.MATCH_ALL);
 		query.setLimit(10L);
 		query.setOffset(0L);
+		query.setFacetRequests(facetRequests);
 		SearchQueryResults results = waitForSearch(query, columns, 1L);
 
 		assertEquals(1L, results.getTotalHits());
@@ -644,30 +660,51 @@ public class OpenSearchManagerImplAutoWiredTest {
 			assertEquals(casesByType.get(type).expectedReturned, actual,
 					"round-trip mismatch for " + type);
 		}
+
+		Map<String, FacetColumnResultValues> facetsByColumn = results.getFacets().stream()
+				.collect(Collectors.toMap(FacetColumnResult::getColumnName,
+						f -> (FacetColumnResultValues) f));
+		for (ColumnModel column : columns) {
+			ColumnType type = column.getColumnType();
+			Set<String> expectedValues = casesByType.get(type).expectedFacetValues;
+			if (expectedValues == null) {
+				continue;
+			}
+			FacetColumnResultValues facet = facetsByColumn.get(column.getName());
+			assertNotNull(facet, "missing facet result for " + type);
+			Set<String> actualValues = facet.getFacetValues().stream()
+					.map(FacetColumnResultValueCount::getValue)
+					.collect(Collectors.toSet());
+			assertEquals(expectedValues, actualValues,
+					"facet bucket values for " + type + " must match (PLFM-9673: null on "
+							+ "numeric types prior to fix)");
+		}
 	}
 
 	private static Map<ColumnType, RoundTripCase> buildEveryColumnTypeCase() {
 		Map<ColumnType, RoundTripCase> casesByType = new LinkedHashMap<>();
-		casesByType.put(ColumnType.STRING,        new RoundTripCase("alpha",                              "alpha",                                  "alpha"));
-		casesByType.put(ColumnType.STRING_LIST,   new RoundTripCase("[\"alpha\",\"beta\"]",               List.of("alpha", "beta"),                 "[\"alpha\",\"beta\"]"));
-		casesByType.put(ColumnType.MEDIUMTEXT,    new RoundTripCase("alpha beta gamma",                   "alpha beta gamma",                       "alpha beta gamma"));
-		casesByType.put(ColumnType.LARGETEXT,     new RoundTripCase("alpha beta gamma",                   "alpha beta gamma",                       "alpha beta gamma"));
-		casesByType.put(ColumnType.LINK,          new RoundTripCase("https://example.org/a",              "https://example.org/a",                  "https://example.org/a"));
-		casesByType.put(ColumnType.INTEGER,       new RoundTripCase("123",                                123,                                      "123"));
-		casesByType.put(ColumnType.INTEGER_LIST,  new RoundTripCase("[1,2,3]",                            List.of(1, 2, 3),                         "[1,2,3]"));
-		casesByType.put(ColumnType.DATE,          new RoundTripCase("1609459200000",                      1609459200000L,                           "1609459200000"));
-		casesByType.put(ColumnType.DATE_LIST,     new RoundTripCase("[1609459200000,1609545600000]",      List.of(1609459200000L, 1609545600000L),  "[1609459200000,1609545600000]"));
-		casesByType.put(ColumnType.FILEHANDLEID,  new RoundTripCase("9876543",                            9876543,                                  "9876543"));
-		casesByType.put(ColumnType.SUBMISSIONID,  new RoundTripCase("555",                                555,                                      "555"));
-		casesByType.put(ColumnType.EVALUATIONID,  new RoundTripCase("777",                                777,                                      "777"));
-		casesByType.put(ColumnType.ENTITYID,      new RoundTripCase("syn123456",                          "syn123456",                              "syn123456"));
-		casesByType.put(ColumnType.USERID,        new RoundTripCase("3412396",                            "3412396",                                "3412396"));
-		casesByType.put(ColumnType.ENTITYID_LIST, new RoundTripCase("[\"syn1\",\"syn2\"]",                List.of("syn1", "syn2"),                  "[\"syn1\",\"syn2\"]"));
-		casesByType.put(ColumnType.USERID_LIST,   new RoundTripCase("[\"100\",\"200\"]",                  List.of("100", "200"),                    "[\"100\",\"200\"]"));
-		casesByType.put(ColumnType.DOUBLE,        new RoundTripCase("1.5",                                1.5,                                      "1.5"));
-		casesByType.put(ColumnType.BOOLEAN,       new RoundTripCase("true",                               Boolean.TRUE,                             "true"));
-		casesByType.put(ColumnType.BOOLEAN_LIST,  new RoundTripCase("[true,false]",                       List.of(true, false),                     "[true,false]"));
-		casesByType.put(ColumnType.JSON,          new RoundTripCase("{\"a\":1,\"b\":\"x\"}",              Map.of("a", 1, "b", "x"),                 "{\"a\":1,\"b\":\"x\"}"));
+		// JSON fields are mapped to OpenSearch `object` and are not terms-aggregable, so
+		// `expectedFacetValues` is null for JSON only and the test skips it for facets.
+		casesByType.put(ColumnType.STRING,        new RoundTripCase("alpha",                              "alpha",                                  "alpha",                                  Set.of("alpha")));
+		casesByType.put(ColumnType.STRING_LIST,   new RoundTripCase("[\"alpha\",\"beta\"]",               List.of("alpha", "beta"),                 "[\"alpha\",\"beta\"]",                   Set.of("alpha", "beta")));
+		casesByType.put(ColumnType.MEDIUMTEXT,    new RoundTripCase("alpha beta gamma",                   "alpha beta gamma",                       "alpha beta gamma",                       Set.of("alpha beta gamma")));
+		casesByType.put(ColumnType.LARGETEXT,     new RoundTripCase("alpha beta gamma",                   "alpha beta gamma",                       "alpha beta gamma",                       Set.of("alpha beta gamma")));
+		casesByType.put(ColumnType.LINK,          new RoundTripCase("https://example.org/a",              "https://example.org/a",                  "https://example.org/a",                  Set.of("https://example.org/a")));
+		casesByType.put(ColumnType.INTEGER,       new RoundTripCase("123",                                123,                                      "123",                                    Set.of("123")));
+		casesByType.put(ColumnType.INTEGER_LIST,  new RoundTripCase("[1,2,3]",                            List.of(1, 2, 3),                         "[1,2,3]",                                Set.of("1", "2", "3")));
+		casesByType.put(ColumnType.DATE,          new RoundTripCase("1609459200000",                      1609459200000L,                           "1609459200000",                          Set.of("1609459200000")));
+		casesByType.put(ColumnType.DATE_LIST,     new RoundTripCase("[1609459200000,1609545600000]",      List.of(1609459200000L, 1609545600000L),  "[1609459200000,1609545600000]",          Set.of("1609459200000", "1609545600000")));
+		casesByType.put(ColumnType.FILEHANDLEID,  new RoundTripCase("9876543",                            9876543,                                  "9876543",                                Set.of("9876543")));
+		casesByType.put(ColumnType.SUBMISSIONID,  new RoundTripCase("555",                                555,                                      "555",                                    Set.of("555")));
+		casesByType.put(ColumnType.EVALUATIONID,  new RoundTripCase("777",                                777,                                      "777",                                    Set.of("777")));
+		casesByType.put(ColumnType.ENTITYID,      new RoundTripCase("syn123456",                          "syn123456",                              "syn123456",                              Set.of("syn123456")));
+		casesByType.put(ColumnType.USERID,        new RoundTripCase("3412396",                            "3412396",                                "3412396",                                Set.of("3412396")));
+		casesByType.put(ColumnType.ENTITYID_LIST, new RoundTripCase("[\"syn1\",\"syn2\"]",                List.of("syn1", "syn2"),                  "[\"syn1\",\"syn2\"]",                    Set.of("syn1", "syn2")));
+		casesByType.put(ColumnType.USERID_LIST,   new RoundTripCase("[\"100\",\"200\"]",                  List.of("100", "200"),                    "[\"100\",\"200\"]",                      Set.of("100", "200")));
+		casesByType.put(ColumnType.DOUBLE,        new RoundTripCase("1.5",                                1.5,                                      "1.5",                                    Set.of("1.5")));
+		casesByType.put(ColumnType.BOOLEAN,       new RoundTripCase("true",                               Boolean.TRUE,                             "true",                                   Set.of("true")));
+		casesByType.put(ColumnType.BOOLEAN_LIST,  new RoundTripCase("[true,false]",                       List.of(true, false),                     "[true,false]",                           Set.of("true", "false")));
+		casesByType.put(ColumnType.JSON,          new RoundTripCase("{\"a\":1,\"b\":\"x\"}",              Map.of("a", 1, "b", "x"),                 "{\"a\":1,\"b\":\"x\"}",                  null));
 		return casesByType;
 	}
 
@@ -675,10 +712,14 @@ public class OpenSearchManagerImplAutoWiredTest {
 		final String raw;
 		final Object expected;
 		final String expectedReturned;
-		RoundTripCase(String raw, Object expected, String expectedReturned) {
+		// Expected bucket value strings when this column is requested as a facet.
+		// Null for column types that are not terms-aggregable (e.g. JSON object fields).
+		final Set<String> expectedFacetValues;
+		RoundTripCase(String raw, Object expected, String expectedReturned, Set<String> expectedFacetValues) {
 			this.raw = raw;
 			this.expected = expected;
 			this.expectedReturned = expectedReturned;
+			this.expectedFacetValues = expectedFacetValues;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Search facets on INTEGER (and other LONG-mapped) columns were returning bucket entries with `count` and `isSelected` but no `value` — clients saw `{count: 23, isSelected: false}` instead of `{value: "2022", count: 23, isSelected: false}`. STRING and DOUBLE facets were unaffected.

Reported against the `nf-datasets` SearchIndex (`syn75081630`), where the `yearProcessed` facet rendered as untitled bars in the portal UI.

## Root cause

`OpenSearchManagerImpl.convertAggregations` reads each long-terms bucket via `bucket.keyAsString()`. In the OpenSearch Java client (`opensearch-java`), `keyAsString` is `@Nullable` — it is only populated when the terms aggregation is built with an explicit numeric `format`. Our `buildAggregations(...)` does not set a `format`, so every long-terms bucket comes back with `keyAsString() == null`, and `FacetColumnResultValueCount.value` ends up null for every numeric column.

The fix prefers `keyAsString()` when present (so BOOLEAN buckets still render as `"true"`/`"false"` rather than `"1"`/`"0"`) and falls back to the typed `LongTermsBucketKey` for plain LONG fields. The DOUBLE branch (`dterms`) was already using the typed key directly and needed no change.

## Why this was not caught before

`OpenSearchManagerImplAutoWiredTest.testCRUDWithEveryColumnType` indexes one document per `ColumnType` and round-trips the values, but it did not request `FacetRequest`s — so the bucket-key extraction code path was never exercised against live AOSS for any column type.

This PR extends that existing test to request facets on every terms-aggregable column and assert the bucket value round-trips. Without the production fix, the extended test now fails with:

```
facet bucket values for INTEGER must match (PLFM-9673: null on numeric types prior to fix)
  ==> expected: <[123]> but was: <[null]>
```

verified by reverting the fix locally and re-running `OpenSearchManagerImplAutoWiredTest#testCRUDWithEveryColumnType` against live AOSS.

## Test plan

- [x] `mvn test -pl services/repository-managers -Dtest=OpenSearchManagerImplTest` — 131/131 pass
- [x] `mvn test -pl services/repository-managers -Dtest=OpenSearchManagerImplAutoWiredTest` — 23/23 pass against live AOSS
- [x] Reverted the production fix and confirmed `testCRUDWithEveryColumnType` fails with the null-bucket-value assertion (regression coverage proven).