### PR TITLE
PLFM-9599

### DIFF
--- a/lib/lib-worker/pom.xml
+++ b/lib/lib-worker/pom.xml
@@ -37,6 +37,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.sagebionetworks</groupId>
+			<artifactId>lib-logging</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.sagebionetworks</groupId>
 			<artifactId>schema-to-pojo-org-json</artifactId>
 		</dependency>
 

--- a/lib/lib-worker/src/main/java/org/sagebionetworks/asynchronous/workers/concurrent/ConcurrentWorkerStack.java
+++ b/lib/lib-worker/src/main/java/org/sagebionetworks/asynchronous/workers/concurrent/ConcurrentWorkerStack.java
@@ -3,11 +3,13 @@ package org.sagebionetworks.asynchronous.workers.concurrent;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.sagebionetworks.cloudwatch.WorkerLogger;
 import org.sagebionetworks.util.ValidateArgument;
 import org.sagebionetworks.workers.util.aws.message.MessageDrivenRunner;
 
@@ -57,6 +59,7 @@ public class ConcurrentWorkerStack implements Runnable {
 	private final int semaphoreLockAndMessageVisibilityTimeoutSec;
 	private final int maxThreadsPerMachine;
 	private final MessageDrivenRunner worker;
+	private final WorkerLogger workerLogger;
 
 	// derived parameters
 	private final int lockRefreshFrequencyMS;
@@ -81,6 +84,7 @@ public class ConcurrentWorkerStack implements Runnable {
 		semaphoreLockAndMessageVisibilityTimeoutSec = -1;
 		maxThreadsPerMachine = -1;
 		worker = null;
+		workerLogger = null;
 		lockRefreshFrequencyMS = -1;
 		queueUrl = null;
 		waitTimeMs = MIN_WAIT_TIME;
@@ -89,7 +93,7 @@ public class ConcurrentWorkerStack implements Runnable {
 
 	private ConcurrentWorkerStack(ConcurrentManager manager, Boolean canRunInReadOnly, String semaphoreLockKey,
 			Integer semaphoreMaxLockCount, Integer semaphoreLockAndMessageVisibilityTimeoutSec,
-			Integer maxThreadsPerMachine, MessageDrivenRunner worker, String queueName) {
+			Integer maxThreadsPerMachine, MessageDrivenRunner worker, String queueName, WorkerLogger workerLogger) {
 		super();
 		ValidateArgument.required(manager, "manager");
 		ValidateArgument.required(semaphoreLockKey, "semaphoreLockKey");
@@ -104,6 +108,7 @@ public class ConcurrentWorkerStack implements Runnable {
 				"maxThreadsPerMachine must be greater than or equal to 1.");
 		ValidateArgument.required(worker, "worker");
 		ValidateArgument.required(queueName, "queueName");
+		ValidateArgument.required(workerLogger, "workerLogger");
 
 		this.manager = manager;
 		this.canRunInReadOnly = Boolean.TRUE.equals(canRunInReadOnly);
@@ -112,6 +117,7 @@ public class ConcurrentWorkerStack implements Runnable {
 		this.semaphoreLockAndMessageVisibilityTimeoutSec = semaphoreLockAndMessageVisibilityTimeoutSec;
 		this.maxThreadsPerMachine = maxThreadsPerMachine;
 		this.worker = worker;
+		this.workerLogger = workerLogger;
 		this.lockRefreshFrequencyMS = (semaphoreLockAndMessageVisibilityTimeoutSec * 1000) / 3;
 		this.queueUrl = manager.getSqsQueueUrl(queueName);
 		this.isFifo = queueName.toLowerCase().endsWith("fifo");
@@ -283,8 +289,30 @@ public class ConcurrentWorkerStack implements Runnable {
 			runningJobs.forEach(job -> {
 				job.getListener().progressMade();
 			});
+			emitConcurrencyMetrics();
 			resetNextRefreshTimeMS();
 		}
+	}
+
+	/**
+	 * Publish two CloudWatch gauges on every refresh tick (only while this JVM
+	 * holds the semaphore lock and is running the infinite loop):
+	 * <ul>
+	 *   <li>{@link WorkerLogger#METRIC_NAME_CONCURRENT_WORKER_COUNT} =
+	 *       {@code runningJobs.size()} — per-JVM concurrency. Sum across the
+	 *       fleet reveals total cluster-wide concurrent runners.</li>
+	 *   <li>{@link WorkerLogger#METRIC_NAME_WORKER_LOCK_HELD} = 1 — emitted
+	 *       once per JVM that holds the lock. Sum across the fleet reveals
+	 *       how many JVMs currently hold the semaphore for this worker, which
+	 *       must be {@code <= semaphoreMaxLockCount}.</li>
+	 * </ul>
+	 * Both metrics carry the {@link WorkerLogger#DIMENSION_WORKER_NAME}
+	 * dimension set to {@code semaphoreLockKey}.
+	 */
+	void emitConcurrencyMetrics() {
+		Map<String, String> dims = Map.of(WorkerLogger.DIMENSION_WORKER_NAME, semaphoreLockKey);
+		workerLogger.logCount(WorkerLogger.METRIC_NAME_CONCURRENT_WORKER_COUNT, runningJobs.size(), dims);
+		workerLogger.logCount(WorkerLogger.METRIC_NAME_WORKER_LOCK_HELD, 1.0, dims);
 	}
 	
 	ConcurrentProgressCallback getLockCallback() {
@@ -338,6 +366,7 @@ public class ConcurrentWorkerStack implements Runnable {
 		private Integer maxThreadsPerMachine;
 		private String queueName;
 		private MessageDrivenRunner worker;
+		private WorkerLogger workerLogger;
 
 		/**
 		 * Wrapper of all of the stack's dependencies. Note: {@link ConcurrentManager}
@@ -437,9 +466,23 @@ public class ConcurrentWorkerStack implements Runnable {
 			return this;
 		}
 
+		/**
+		 * The {@link WorkerLogger} used to publish per-stack concurrency gauges
+		 * ({@link WorkerLogger#METRIC_NAME_CONCURRENT_WORKER_COUNT} and
+		 * {@link WorkerLogger#METRIC_NAME_WORKER_LOCK_HELD}) on each lock-refresh tick.
+		 * Required.
+		 *
+		 * @param workerLogger
+		 * @return
+		 */
+		public Builder withWorkerLogger(WorkerLogger workerLogger) {
+			this.workerLogger = workerLogger;
+			return this;
+		}
+
 		public ConcurrentWorkerStack build() {
 			return new ConcurrentWorkerStack(singleton, canRunInReadOnly, semaphoreLockKey, semaphoreMaxLockCount,
-					semaphoreLockAndMessageVisibilityTimeoutSec, maxThreadsPerMachine, worker, queueName);
+					semaphoreLockAndMessageVisibilityTimeoutSec, maxThreadsPerMachine, worker, queueName, workerLogger);
 		}
 	}
 

--- a/lib/lib-worker/src/test/java/org/sagebionetworks/asynchronous/workers/concurrent/ConcurrentWorkerStackTest.java
+++ b/lib/lib-worker/src/test/java/org/sagebionetworks/asynchronous/workers/concurrent/ConcurrentWorkerStackTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -32,6 +33,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.asynchronous.workers.concurrent.ConcurrentWorkerStack.StackState;
+import org.sagebionetworks.cloudwatch.WorkerLogger;
 import org.sagebionetworks.util.progress.ProgressListener;
 import org.sagebionetworks.workers.util.aws.message.MessageDrivenRunner;
 
@@ -42,6 +44,8 @@ public class ConcurrentWorkerStackTest {
 	private ConcurrentManager mockManager;
 	@Mock
 	private MessageDrivenRunner mockWorker;
+	@Mock
+	private WorkerLogger mockWorkerLogger;
 	@Mock
 	private ProgressListener mockProgressListenerOne;
 	@Mock
@@ -84,7 +88,8 @@ public class ConcurrentWorkerStackTest {
 		return ConcurrentWorkerStack.builder().withSingleton(mockManager).withCanRunInReadOnly(canRunInReadOnly)
 				.withSemaphoreLockKey(semaphoreLockKey).withSemaphoreMaxLockCount(semaphoreMaxLockCount)
 				.withSemaphoreLockAndMessageVisibilityTimeoutSec(semaphoreLockAndMessageVisibilityTimeoutSec)
-				.withMaxThreadsPerMachine(maxThreadsPerMachine).withWorker(mockWorker).withQueueName(queueName).build();
+				.withMaxThreadsPerMachine(maxThreadsPerMachine).withWorker(mockWorker).withQueueName(queueName)
+				.withWorkerLogger(mockWorkerLogger).build();
 	}
 
 	@Test
@@ -106,6 +111,16 @@ public class ConcurrentWorkerStackTest {
 			createStack();
 		}).getMessage();
 		assertEquals("worker is required.", message);
+	}
+
+	@Test
+	public void testBuildWithNullWorkerLogger() {
+		mockWorkerLogger = null;
+		String message = assertThrows(IllegalArgumentException.class, () -> {
+			// call under test
+			createStack();
+		}).getMessage();
+		assertEquals("workerLogger is required.", message);
 	}
 	
 	@Test
@@ -465,10 +480,13 @@ public class ConcurrentWorkerStackTest {
 		verify(mockProgressListenerTwo, never()).progressMade();
 		verify(mockProgressListenerThree, never()).progressMade();
 		verify(mockManager, times(3)).getCurrentTimeMS();
+		verify(mockWorkerLogger, never()).logCount(any(), Mockito.anyDouble(), any());
 		assertEquals(10_002L, stack.getNextRefreshTimeMS());
 
-		reset(mockProgressListenerOne, mockProgressListenerTwo, mockProgressListenerThree, mockManager);
+		reset(mockProgressListenerOne, mockProgressListenerTwo, mockProgressListenerThree, mockManager, mockWorkerLogger);
 		when(mockManager.getCurrentTimeMS()).thenReturn(10_002L, 10_003L);
+
+		Map<String, String> expectedDims = Map.of(WorkerLogger.DIMENSION_WORKER_NAME, semaphoreLockKey);
 
 		// call under test
 		stack.refreshLocksIfNeeded();
@@ -476,6 +494,8 @@ public class ConcurrentWorkerStackTest {
 		verify(mockProgressListenerTwo).progressMade();
 		verify(mockProgressListenerThree).progressMade();
 		verify(mockManager, times(2)).getCurrentTimeMS();
+		verify(mockWorkerLogger).logCount(WorkerLogger.METRIC_NAME_CONCURRENT_WORKER_COUNT, 2.0, expectedDims);
+		verify(mockWorkerLogger).logCount(WorkerLogger.METRIC_NAME_WORKER_LOCK_HELD, 1.0, expectedDims);
 		assertEquals(20_003L, stack.getNextRefreshTimeMS());
 
 		reset(mockProgressListenerOne, mockProgressListenerTwo, mockProgressListenerThree, mockManager);
@@ -499,6 +519,37 @@ public class ConcurrentWorkerStackTest {
 		verify(mockProgressListenerThree).progressMade();
 		verify(mockManager, times(2)).getCurrentTimeMS();
 		assertEquals(30_009L, stack.getNextRefreshTimeMS());
+	}
+
+	@Test
+	public void testEmitConcurrencyMetricsWithEmptyRunningJobs() {
+		when(mockManager.getSqsQueueUrl(any())).thenReturn(queueUrl);
+		ConcurrentWorkerStack stack = createStack();
+		stack.resetAllState();
+		Map<String, String> expectedDims = Map.of(WorkerLogger.DIMENSION_WORKER_NAME, semaphoreLockKey);
+
+		// call under test
+		stack.emitConcurrencyMetrics();
+
+		verify(mockWorkerLogger).logCount(WorkerLogger.METRIC_NAME_CONCURRENT_WORKER_COUNT, 0.0, expectedDims);
+		verify(mockWorkerLogger).logCount(WorkerLogger.METRIC_NAME_WORKER_LOCK_HELD, 1.0, expectedDims);
+	}
+
+	@Test
+	public void testEmitConcurrencyMetricsWithRunningJobs() {
+		when(mockManager.getSqsQueueUrl(any())).thenReturn(queueUrl);
+		ConcurrentWorkerStack stack = createStack();
+		stack.resetAllState();
+		stack.getRunningJobs().add(new WorkerJob(futureOne, mockProgressListenerOne));
+		stack.getRunningJobs().add(new WorkerJob(futureTwo, mockProgressListenerTwo));
+		stack.getRunningJobs().add(new WorkerJob(futureThree, mockProgressListenerThree));
+		Map<String, String> expectedDims = Map.of(WorkerLogger.DIMENSION_WORKER_NAME, semaphoreLockKey);
+
+		// call under test
+		stack.emitConcurrencyMetrics();
+
+		verify(mockWorkerLogger).logCount(WorkerLogger.METRIC_NAME_CONCURRENT_WORKER_COUNT, 3.0, expectedDims);
+		verify(mockWorkerLogger).logCount(WorkerLogger.METRIC_NAME_WORKER_LOCK_HELD, 1.0, expectedDims);
 	}
 
 	@Test

--- a/lib/logging/src/main/java/org/sagebionetworks/cloudwatch/WorkerLogger.java
+++ b/lib/logging/src/main/java/org/sagebionetworks/cloudwatch/WorkerLogger.java
@@ -18,7 +18,10 @@ public interface WorkerLogger {
 	String DIMENSION_OBJECT_TYPE = "objectType";
 	String DIMENSION_STACK_TRACE = "stackTrace";
 	String DIMENSION_WORKER_CLASS = "workerClass";
+	String DIMENSION_WORKER_NAME = "workerName";
 	String METRIC_NAME_WORKER_TIME = "workerTime";
+	String METRIC_NAME_CONCURRENT_WORKER_COUNT = "ConcurrentWorkerCount";
+	String METRIC_NAME_WORKER_LOCK_HELD = "WorkerLockHeld";
 
 	/**
 	 * Log a change message driven worker event. The given class name (Class.getName) will be used as
@@ -70,8 +73,19 @@ public interface WorkerLogger {
 
 	/**
 	 * Log a custom metric
-	 * 
+	 *
 	 * @param pd
 	 */
 	void logCustomMetric(ProfileData pd);
+
+	/**
+	 * Publish a Count gauge in the worker namespace (stack-instance enriched).
+	 * Use this for instantaneous gauges like "ConcurrentWorkerCount" where
+	 * SUM aggregations across the fleet are meaningful.
+	 *
+	 * @param metricName the metric name
+	 * @param value the gauge value
+	 * @param dimensions optional dimensions (e.g. workerName)
+	 */
+	void logCount(String metricName, double value, Map<String, String> dimensions);
 }

--- a/lib/logging/src/main/java/org/sagebionetworks/cloudwatch/WorkerLogger.java
+++ b/lib/logging/src/main/java/org/sagebionetworks/cloudwatch/WorkerLogger.java
@@ -22,6 +22,7 @@ public interface WorkerLogger {
 	String METRIC_NAME_WORKER_TIME = "workerTime";
 	String METRIC_NAME_CONCURRENT_WORKER_COUNT = "ConcurrentWorkerCount";
 	String METRIC_NAME_WORKER_LOCK_HELD = "WorkerLockHeld";
+	String METRIC_NAME_WORKER_CONTAINER_COUNT = "WorkerContainerCount";
 
 	/**
 	 * Log a change message driven worker event. The given class name (Class.getName) will be used as

--- a/lib/logging/src/main/java/org/sagebionetworks/cloudwatch/WorkerLoggerImpl.java
+++ b/lib/logging/src/main/java/org/sagebionetworks/cloudwatch/WorkerLoggerImpl.java
@@ -87,6 +87,16 @@ public class WorkerLoggerImpl implements WorkerLogger {
 		}
 		consumer.addProfileData(profileData);
 	}
+
+	@Override
+	public void logCount(String metricName, double value, Map<String, String> dimensions) {
+		if (!shouldProfile) {
+			return;
+		}
+		ValidateArgument.required(metricName, "metricName");
+		ProfileData data = buildProfileData(new Date(), metricName, StandardUnit.Count, value, dimensions);
+		consumer.addProfileData(data);
+	}
 	
 	/**
 	 * Makes transfer object and returns it.

--- a/services/workers/src/main/java/org/sagebionetworks/worker/WorkerContainerHeartbeat.java
+++ b/services/workers/src/main/java/org/sagebionetworks/worker/WorkerContainerHeartbeat.java
@@ -1,0 +1,30 @@
+package org.sagebionetworks.worker;
+
+import java.util.Map;
+
+import org.sagebionetworks.cloudwatch.WorkerLogger;
+import org.sagebionetworks.util.ValidateArgument;
+
+/**
+ * Emits a per-JVM heartbeat metric so the live count of workers-WAR Spring
+ * containers can be derived from CloudWatch. Each running container publishes
+ * {@link WorkerLogger#METRIC_NAME_WORKER_CONTAINER_COUNT} = 1 on every Quartz
+ * tick. With no dimensions on the emission, summing the metric across the
+ * fleet over a one-minute window yields the number of live containers.
+ */
+public class WorkerContainerHeartbeat {
+
+	private final WorkerLogger workerLogger;
+
+	public WorkerContainerHeartbeat(WorkerLogger workerLogger) {
+		ValidateArgument.required(workerLogger, "workerLogger");
+		this.workerLogger = workerLogger;
+	}
+
+	/**
+	 * Called from a Quartz timer.
+	 */
+	public void onTimerFired() {
+		workerLogger.logCount(WorkerLogger.METRIC_NAME_WORKER_CONTAINER_COUNT, 1.0, Map.of());
+	}
+}

--- a/services/workers/src/main/java/org/sagebionetworks/worker/config/AsyncJobWorkersConfig.java
+++ b/services/workers/src/main/java/org/sagebionetworks/worker/config/AsyncJobWorkersConfig.java
@@ -4,6 +4,7 @@ import org.sagebionetworks.StackConfiguration;
 import org.sagebionetworks.agent.worker.AgentChatWorker;
 import org.sagebionetworks.asynchronous.workers.concurrent.ConcurrentManager;
 import org.sagebionetworks.asynchronous.workers.concurrent.ConcurrentWorkerStack;
+import org.sagebionetworks.cloudwatch.WorkerLogger;
 import org.sagebionetworks.database.semaphore.CountingSemaphore;
 import org.sagebionetworks.doi.worker.DoiWorker;
 import org.sagebionetworks.download.worker.AddToDownloadListStatsWorker;
@@ -60,15 +61,17 @@ public class AsyncJobWorkersConfig {
 	private UserManager userManager;
 	private CountingSemaphore countingSemaphore;
 	private StackStatusGate stackStatusGate;
+	private WorkerLogger workerLogger;
 
 	public AsyncJobWorkersConfig(AmazonSQSClient amazonSQSClient, StackConfiguration stackConfig, AsynchJobStatusManager jobStatusManager,
-			UserManager userManager, CountingSemaphore countingSemaphore, StackStatusGate stackStatusGate) {
+			UserManager userManager, CountingSemaphore countingSemaphore, StackStatusGate stackStatusGate, WorkerLogger workerLogger) {
 		this.amazonSQSClient = amazonSQSClient;
 		this.stackConfig = stackConfig;
 		this.jobStatusManager = jobStatusManager;
 		this.userManager = userManager;
 		this.countingSemaphore = countingSemaphore;
 		this.stackStatusGate = stackStatusGate;
+		this.workerLogger = workerLogger;
 	}
 
 	@Bean
@@ -87,6 +90,7 @@ public class AsyncJobWorkersConfig {
 				.withCanRunInReadOnly(false)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(2187)
@@ -110,6 +114,7 @@ public class AsyncJobWorkersConfig {
 				.withCanRunInReadOnly(false)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(2180)
@@ -590,6 +595,7 @@ public class AsyncJobWorkersConfig {
 				.withCanRunInReadOnly(false)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(2187)
@@ -613,6 +619,7 @@ public class AsyncJobWorkersConfig {
 				.withCanRunInReadOnly(false)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(987)
@@ -771,6 +778,7 @@ public class AsyncJobWorkersConfig {
 						.withCanRunInReadOnly(false)
 						.withQueueName(queueName)
 						.withWorker(worker)
+						.withWorkerLogger(workerLogger)
 						.build()
 				)
 				.withRepeatInterval(2039)

--- a/services/workers/src/main/java/org/sagebionetworks/worker/config/ChangeMessageWorkersConfig.java
+++ b/services/workers/src/main/java/org/sagebionetworks/worker/config/ChangeMessageWorkersConfig.java
@@ -9,6 +9,7 @@ import org.sagebionetworks.StackConfiguration;
 import org.sagebionetworks.asynchronous.workers.changes.ChangeMessageBatchProcessor;
 import org.sagebionetworks.asynchronous.workers.concurrent.ConcurrentManager;
 import org.sagebionetworks.asynchronous.workers.concurrent.ConcurrentWorkerStack;
+import org.sagebionetworks.cloudwatch.WorkerLogger;
 import org.sagebionetworks.database.semaphore.CountingSemaphore;
 import org.sagebionetworks.file.worker.FileHandleStreamWorker;
 import org.sagebionetworks.grid.workers.GridSessionIndexWorker;
@@ -44,12 +45,14 @@ public class ChangeMessageWorkersConfig {
 	private AmazonSQSClient amazonSQSClient;
 	private StackConfiguration stackConfig;
 	private CountingSemaphore countingSemaphore;
-	
-	public ChangeMessageWorkersConfig(ConcurrentManager concurrentStackManager, AmazonSQSClient amazonSQSClient, StackConfiguration stackConfig, CountingSemaphore countingSemaphore) {
+	private WorkerLogger workerLogger;
+
+	public ChangeMessageWorkersConfig(ConcurrentManager concurrentStackManager, AmazonSQSClient amazonSQSClient, StackConfiguration stackConfig, CountingSemaphore countingSemaphore, WorkerLogger workerLogger) {
 		this.concurrentStackManager = concurrentStackManager;
 		this.amazonSQSClient = amazonSQSClient;
 		this.stackConfig = stackConfig;
 		this.countingSemaphore = countingSemaphore;
+		this.workerLogger = workerLogger;
 	}
 
 	@Bean
@@ -68,6 +71,7 @@ public class ChangeMessageWorkersConfig {
 				.withCanRunInReadOnly(true)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(553)
@@ -91,6 +95,7 @@ public class ChangeMessageWorkersConfig {
 				.withCanRunInReadOnly(false)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(2034)
@@ -114,6 +119,7 @@ public class ChangeMessageWorkersConfig {
 				.withCanRunInReadOnly(true)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(1797)
@@ -137,6 +143,7 @@ public class ChangeMessageWorkersConfig {
 				.withCanRunInReadOnly(true)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(750)
@@ -160,6 +167,7 @@ public class ChangeMessageWorkersConfig {
 				.withCanRunInReadOnly(true)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(750)
@@ -212,6 +220,7 @@ public class ChangeMessageWorkersConfig {
 				.withCanRunInReadOnly(true)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(1979)
@@ -236,6 +245,7 @@ public class ChangeMessageWorkersConfig {
 						.withCanRunInReadOnly(true)
 						.withQueueName(queueName)
 						.withWorker(worker)
+						.withWorkerLogger(workerLogger)
 						.build()
 				)
 				.withRepeatInterval(2010)
@@ -259,6 +269,7 @@ public class ChangeMessageWorkersConfig {
 				.withCanRunInReadOnly(true)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(2000)
@@ -282,6 +293,7 @@ public class ChangeMessageWorkersConfig {
 				.withCanRunInReadOnly(false)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(1532)
@@ -305,6 +317,7 @@ public class ChangeMessageWorkersConfig {
 				.withCanRunInReadOnly(false)
 				.withQueueName(queueName)
 				.withWorker(worker)
+				.withWorkerLogger(workerLogger)
 				.build()
 			)
 			.withRepeatInterval(2053)

--- a/services/workers/src/main/java/org/sagebionetworks/worker/config/MessageDrivenWorkersConfig.java
+++ b/services/workers/src/main/java/org/sagebionetworks/worker/config/MessageDrivenWorkersConfig.java
@@ -3,6 +3,7 @@ package org.sagebionetworks.worker.config;
 import org.sagebionetworks.StackConfiguration;
 import org.sagebionetworks.asynchronous.workers.concurrent.ConcurrentManager;
 import org.sagebionetworks.asynchronous.workers.concurrent.ConcurrentWorkerStack;
+import org.sagebionetworks.cloudwatch.WorkerLogger;
 import org.sagebionetworks.database.semaphore.CountingSemaphore;
 import org.sagebionetworks.file.worker.FileEventRecordWorker;
 import org.sagebionetworks.file.worker.FileHandleAssociationScanRangeWorker;
@@ -39,20 +40,22 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class MessageDrivenWorkersConfig {
 	
 	private ConcurrentManager concurrentStackManager;
-	private StackStatusGate stackStatusGate; 
+	private StackStatusGate stackStatusGate;
 	private AmazonSQSClient amazonSQSClient;
 	private StackConfiguration stackConfig;
 	private CountingSemaphore countingSemaphore;
 	private ObjectMapper objectMapper;
+	private WorkerLogger workerLogger;
 
 	public MessageDrivenWorkersConfig(ConcurrentManager concurrentStackManager, StackStatusGate stackStatusGate, AmazonSQSClient amazonSQSClient, StackConfiguration stackConfig, CountingSemaphore countingSemaphore,
-			ObjectMapper objectMapper) {
+			ObjectMapper objectMapper, WorkerLogger workerLogger) {
 		this.concurrentStackManager = concurrentStackManager;
 		this.stackStatusGate = stackStatusGate;
 		this.amazonSQSClient = amazonSQSClient;
 		this.stackConfig = stackConfig;
 		this.countingSemaphore = countingSemaphore;
 		this.objectMapper = objectMapper;
+		this.workerLogger = workerLogger;
 	}
 
 	@Bean
@@ -71,6 +74,7 @@ public class MessageDrivenWorkersConfig {
 			.withCanRunInReadOnly(true)
 			.withQueueName(queueName)
 			.withWorker(worker)
+			.withWorkerLogger(workerLogger)
 			.build()
 		)
 		.withRepeatInterval(934)
@@ -166,6 +170,7 @@ public class MessageDrivenWorkersConfig {
 			.withCanRunInReadOnly(true)
 			.withQueueName(queueName)
 			.withWorker(worker)
+			.withWorkerLogger(workerLogger)
 			.build()
 		)
 		.withRepeatInterval(937)
@@ -189,6 +194,7 @@ public class MessageDrivenWorkersConfig {
 						.withCanRunInReadOnly(true)
 						.withQueueName(queueName)
 						.withWorker(worker)
+						.withWorkerLogger(workerLogger)
 						.build()
 				)
 				.withRepeatInterval(934)
@@ -212,6 +218,7 @@ public class MessageDrivenWorkersConfig {
 						.withCanRunInReadOnly(true)
 						.withQueueName(queueName)
 						.withWorker(worker)
+						.withWorkerLogger(workerLogger)
 						.build()
 				)
 				.withRepeatInterval(934)
@@ -234,6 +241,7 @@ public class MessageDrivenWorkersConfig {
 						.withCanRunInReadOnly(false)
 						.withQueueName(queueName)
 						.withWorker(webhookMessageWorker)
+						.withWorkerLogger(workerLogger)
 						.build()
 				)
 				.withRepeatInterval(2064)
@@ -257,6 +265,7 @@ public class MessageDrivenWorkersConfig {
 						.withCanRunInReadOnly(false)
 						.withQueueName(queueName)
 						.withWorker(worker)
+						.withWorkerLogger(workerLogger)
 						.build()
 				)
 				.withRepeatInterval(2064)
@@ -280,6 +289,7 @@ public class MessageDrivenWorkersConfig {
 						.withCanRunInReadOnly(false)
 						.withQueueName(queueName)
 						.withWorker(worker)
+						.withWorkerLogger(workerLogger)
 						.build()
 				)
 				.withRepeatInterval(2564)
@@ -302,6 +312,7 @@ public class MessageDrivenWorkersConfig {
 						.withCanRunInReadOnly(false)
 						.withQueueName(queueName)
 						.withWorker(gridMessageBroker)
+						.withWorkerLogger(workerLogger)
 						.build()
 				)
 				.withRepeatInterval(989)
@@ -324,6 +335,7 @@ public class MessageDrivenWorkersConfig {
 						.withCanRunInReadOnly(false)
 						.withQueueName(queueName)
 						.withWorker(worker)
+						.withWorkerLogger(workerLogger)
 						.build()
 				)
 				.withRepeatInterval(981)
@@ -346,6 +358,7 @@ public class MessageDrivenWorkersConfig {
 						.withCanRunInReadOnly(false)
 						.withQueueName(queueName)
 						.withWorker(worker)
+						.withWorkerLogger(workerLogger)
 						.build()
 				)
 				.withRepeatInterval(971)
@@ -368,6 +381,7 @@ public class MessageDrivenWorkersConfig {
 						.withCanRunInReadOnly(false)
 						.withQueueName(queueName)
 						.withWorker(worker)
+						.withWorkerLogger(workerLogger)
 						.build()
 				)
 				.withRepeatInterval(971)

--- a/services/workers/src/main/resources/external-triggers-spb.xml
+++ b/services/workers/src/main/resources/external-triggers-spb.xml
@@ -25,5 +25,23 @@
 		<property name="repeatInterval" value="10" />
 	</bean>
 
+	<!-- Per-JVM heartbeat: sums to the live container count for the workers WAR. -->
+	<bean id="workerContainerHeartbeat" class="org.sagebionetworks.worker.WorkerContainerHeartbeat">
+		<constructor-arg ref="workerLogger" />
+	</bean>
+
+	<bean id="workerContainerHeartbeatTrigger"
+		class="org.springframework.scheduling.quartz.SimpleTriggerFactoryBean">
+		<property name="jobDetail">
+			<bean
+				class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+				<property name="targetObject" ref="workerContainerHeartbeat" />
+				<property name="targetMethod" value="onTimerFired" />
+				<property name="concurrent" value="false" />
+			</bean>
+		</property>
+		<property name="startDelay" value="1000" />
+		<property name="repeatInterval" value="60000" />
+	</bean>
 
 </beans>

--- a/services/workers/src/main/resources/main-scheduler-spb.xml
+++ b/services/workers/src/main/resources/main-scheduler-spb.xml
@@ -116,6 +116,7 @@
 		<ref bean="jobIntervalProcessorTrigger" />
 		<ref bean="idGeneratorCleanuSynchTrigger" />
 		<ref bean="memoryLoggerTrigger" />
+		<ref bean="workerContainerHeartbeatTrigger" />
 		<ref bean="semaphoreGarbageCollectionTrigger" />
 		<ref bean="athenaPartitionScannerTrigger" />
 		<ref bean="statisticsMonthlyStatusWatcherWorkerTrigger" /> 

--- a/services/workers/src/test/java/org/sagebionetworks/worker/WorkerContainerHeartbeatTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/worker/WorkerContainerHeartbeatTest.java
@@ -1,0 +1,37 @@
+package org.sagebionetworks.worker;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sagebionetworks.cloudwatch.WorkerLogger;
+
+@ExtendWith(MockitoExtension.class)
+public class WorkerContainerHeartbeatTest {
+
+	@Mock
+	private WorkerLogger mockWorkerLogger;
+
+	@Test
+	public void testOnTimerFired() {
+		WorkerContainerHeartbeat heartbeat = new WorkerContainerHeartbeat(mockWorkerLogger);
+
+		// call under test
+		heartbeat.onTimerFired();
+
+		verify(mockWorkerLogger).logCount(WorkerLogger.METRIC_NAME_WORKER_CONTAINER_COUNT, 1.0, Map.of());
+		verifyNoMoreInteractions(mockWorkerLogger);
+	}
+
+	@Test
+	public void testConstructorWithNullLogger() {
+		// call under test
+		assertThrows(IllegalArgumentException.class, () -> new WorkerContainerHeartbeat(null));
+	}
+}


### PR DESCRIPTION
This PR adds three metrics to help track the activity of asynchronous workers:
- WorkerContainerCount counts the number of Spring containers;
- WorkerLockHeld counts the number of semaphores/locks held;
- ConcurrentWorkerCount counts the number of active workers of each type;

Note: This PR targets the `release-587` branch with the aim of testing that stack.

There was a question of how often the metrics are pushed to Cloudwatch. The answer is:


_Here's how the cadence works — it's a two-stage pipeline:_

## Stage 1 — when emitConcurrencyMetrics() is called (queued into the in-memory buffer):

emitConcurrencyMetrics() is invoked from refreshLocksIfNeeded() (ConcurrentWorkerStack.java:286-295), which fires whenever now() >= nextRefreshTimeMS. The interval is set at line 121:

this.lockRefreshFrequencyMS = (semaphoreLockAndMessageVisibilityTimeoutSec * 1000) / 3;

So the gauges are queued once per lock-refresh tick — i.e., every semaphoreLockAndMessageVisibilityTimeoutSec / 3 seconds, per worker stack. The validator at line 104 enforces a minimum of 30s on that timeout, so the fastest possible tick is 10 seconds; in practice each worker's tick depends on the timeout it's configured with.

## Stage 2 — when the buffer is flushed to CloudWatch:

WorkerLogger.logCount(...) does not call PutMetricData synchronously — it appends to a ConcurrentLinkedQueue in Consumer (lib/logging/src/main/java/org/sagebionetworks/cloudwatch/Consumer.java). A Quartz SimpleTrigger named cloudwatchTrigger (lib/logging/src/main/resources/cloudwatch-trigger-spb.xml) calls consumer.executeCloudWatchPut() on a fixed cadence controlled by the property org.sagebionetworks.cloud.watch.trigger, which defaults to 60000 ms (60 s) in stack.properties.

Net result: every refresh tick (≥10s, but typically more depending on the per-worker timeout) the gauges land in the local buffer, and the buffer is drained to CloudWatch once per 60 seconds. So in CloudWatch you'll see one PutMetricData batch per JVM per minute, containing however many ticks accumulated in that window.
