### PR TITLE
Fix S->X lock-upgrade deadlock in DBODiscussionThreadDAOImpl.updateThreadView

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/discussion/DBODiscussionThreadDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/discussion/DBODiscussionThreadDAOImpl.java
@@ -349,9 +349,14 @@ public class DBODiscussionThreadDAOImpl implements DiscussionThreadDAO {
 	@WriteTransaction
 	@Override
 	public void updateThreadView(long threadId, long userId) {
-		jdbcTemplate.update(SQL_UPDATE_THREAD_VIEW_TABLE, threadId, userId);
+		// Update the parent DISCUSSION_THREAD row first so this transaction takes an
+		// exclusive (X) lock directly. If we INSERTed into the child DISCUSSION_THREAD_VIEW
+		// first, the FK check would take a shared (S) lock on the parent row, and a
+		// concurrent caller doing the same would also hold S; both would then try to
+		// upgrade to X for this UPDATE, producing an S->X deadlock on DISCUSSION_THREAD.
 		String etag = UUID.randomUUID().toString();
 		jdbcTemplate.update(SQL_UPDATE_THREAD_ETAG, etag, threadId);
+		jdbcTemplate.update(SQL_UPDATE_THREAD_VIEW_TABLE, threadId, userId);
 	}
 
 	@Override

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/discussion/DBODiscussionThreadDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/discussion/DBODiscussionThreadDAOImplTest.java
@@ -19,11 +19,24 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Resource;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.sagebionetworks.StackConfigurationSingleton;
 import org.sagebionetworks.ids.IdGenerator;
 import org.sagebionetworks.ids.IdType;
@@ -88,6 +101,11 @@ public class DBODiscussionThreadDAOImplTest {
 	private RequestDAO requestDao;
 	@Autowired
 	private SubmissionDAO submissionDao;
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Resource(name = "txManager")
+	private PlatformTransactionManager transactionManager;
 
 	private Long userId = null;
 	private Long userId2 = null;
@@ -1095,5 +1113,76 @@ public class DBODiscussionThreadDAOImplTest {
 	public void testGetSubmissionIdForNonExistingThread() {
 		// call under test
 		assertFalse(threadDao.getSubmissionIdForThread("999999").isPresent());
+	}
+
+	/**
+	 * The two writes in updateThreadView (INSERT IGNORE INTO DISCUSSION_THREAD_VIEW
+	 * then UPDATE DISCUSSION_THREAD SET ETAG) take an FK-induced shared lock on the
+	 * parent thread row before upgrading to an exclusive lock; concurrent callers
+	 * therefore deadlock on the upgrade. Each iteration deletes the prior view row
+	 * so the INSERT IGNORE actually inserts and the FK shared lock is taken.
+	 * ConcurrencyFailureException covers both DeadlockLoserDataAccessException
+	 * (deadlock victim) and CannotAcquireLockException (lock-wait timeout).
+	 */
+	@Test
+	public void testUpdateThreadViewWithConcurrentCallers() throws Exception {
+		final int iterations = 200;
+
+		UserGroup other = new UserGroup();
+		other.setIsIndividual(true);
+		other.setRealmId(AuthorizationConstants.DEFAULT_REALM_ID);
+		Long secondUserId = userGroupDAO.create(other);
+
+		try {
+			threadDao.createThread(forumId, threadId.toString(), "deadlock-title",
+					"deadlock-key-" + UUID.randomUUID(), userId);
+
+			ExecutorService pool = Executors.newFixedThreadPool(2);
+			try {
+				CountDownLatch start = new CountDownLatch(1);
+				AtomicInteger deadlocks = new AtomicInteger();
+
+				// call under test
+				Future<?> fa = pool.submit(buildUpdateThreadViewLoop(start, userId, iterations, deadlocks));
+				Future<?> fb = pool.submit(buildUpdateThreadViewLoop(start, secondUserId, iterations, deadlocks));
+
+				start.countDown();
+
+				fa.get(2, TimeUnit.MINUTES);
+				fb.get(2, TimeUnit.MINUTES);
+
+				if (deadlocks.get() > 0) {
+					org.junit.Assert.fail("Observed " + deadlocks.get() + " deadlocks across "
+							+ (iterations * 2) + " concurrent updateThreadView calls; "
+							+ "updateThreadView is not safe under concurrency.");
+				}
+			} finally {
+				pool.shutdownNow();
+			}
+		} finally {
+			userGroupDAO.delete(secondUserId.toString());
+		}
+	}
+
+	private Runnable buildUpdateThreadViewLoop(CountDownLatch start, Long viewerId, int iterations,
+			AtomicInteger deadlocks) {
+		final TransactionTemplate tx = new TransactionTemplate(transactionManager,
+				new DefaultTransactionDefinition());
+		return () -> {
+			try {
+				start.await();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return;
+			}
+			for (int i = 0; i < iterations; i++) {
+				jdbcTemplate.update("DELETE FROM DISCUSSION_THREAD_VIEW WHERE THREAD_ID = ?", threadId);
+				try {
+					tx.executeWithoutResult(status -> threadDao.updateThreadView(threadId, viewerId));
+				} catch (ConcurrencyFailureException e) {
+					deadlocks.incrementAndGet();
+				}
+			}
+		};
 	}
 }


### PR DESCRIPTION
## Summary

Production was hitting `Deadlock found when trying to get lock; SQL [UPDATE DISCUSSION_THREAD SET ETAG = ? WHERE ID = ?]` on `prod590`. Cause: an InnoDB S→X lock-upgrade race in `DBODiscussionThreadDAOImpl.updateThreadView`. The original order ran `INSERT IGNORE INTO DISCUSSION_THREAD_VIEW` first; that statement's FK check takes a **shared (S) record lock** on the parent `DISCUSSION_THREAD` row. The next statement (`UPDATE … SET ETAG`) then needs an **exclusive (X) lock** on the same row. Two concurrent callers on the same `threadId` both hold S and both wait to upgrade to X — one is killed.

The fix reorders the two writes so the parent `UPDATE` runs first, taking X directly. The subsequent `INSERT IGNORE`'s FK-check is satisfied by the X lock the same transaction already holds, so no additional shared lock is taken and no upgrade ever happens. Atomicity, isolation, visibility, and the post-commit change-message are unchanged — this is purely a statement-ordering fix.

PR #5604 (PLFM-9542) is a **contributor**, not the regression. It added an AR-forum reply path whose `createReply` calls `threadManager.getThread`, which routes through `updateThreadView`, increasing the rate of concurrent callers per `threadId`. The lock-upgrade pattern itself predates 5604.

## Evidence the bug exists

### 1. Production InnoDB diagnostic (verbatim from the bug report)

```
*** (1) UPDATE DISCUSSION_THREAD SET ETAG = '11108758-...' WHERE ID = 7704
    HOLDS lock mode S locks rec but not gap (heap no 74 — row 7704)
    WAITING lock_mode X locks rec but not gap (same row)

*** (2) UPDATE DISCUSSION_THREAD SET ETAG = 'ce31e16e-...' WHERE ID = 7704
    HOLDS lock mode S locks rec but not gap (same row)
    WAITING lock_mode X locks rec but not gap (same row)
```

Two transactions, both holding S, both waiting for X on the same record. Textbook S→X upgrade deadlock.

### 2. Reproduced locally as a JUnit autowired test

`DBODiscussionThreadDAOImplTest#testUpdateThreadViewWithConcurrentCallers` drives two threads through `updateThreadView` for the same `threadId`. On unfixed code:

```
[ERROR] testUpdateThreadViewWithConcurrentCallers ... Failures: 1
[ERROR]   Observed 199 deadlocks across 400 concurrent updateThreadView calls;
          updateThreadView is not safe under concurrency.
```

Spring surfaces the underlying MySQL exception:

```
DeadlockLoserDataAccessException: PreparedStatementCallback;
SQL [UPDATE DISCUSSION_THREAD SET ETAG = ? WHERE ID = ?];
Deadlock found when trying to get lock; try restarting transaction
```

— exact match for the production signature.

### 3. Direct InnoDB lock observation

Two single-session experiments against MySQL 8.0.33, observing `performance_schema.data_locks` after each statement on the same parent thread row.

**Original order — INSERT IGNORE (child) first:**

```
-- after INSERT IGNORE INTO DISCUSSION_THREAD_VIEW
DISCUSSION_THREAD       PRIMARY  RECORD  S,REC_NOT_GAP  GRANTED  data=999999999
DISCUSSION_THREAD_VIEW  NULL     TABLE   IX             GRANTED

-- after UPDATE DISCUSSION_THREAD SET ETAG
DISCUSSION_THREAD       PRIMARY  RECORD  S,REC_NOT_GAP  GRANTED  data=999999999
DISCUSSION_THREAD       PRIMARY  RECORD  X,REC_NOT_GAP  GRANTED  data=999999999
DISCUSSION_THREAD_VIEW  NULL     TABLE   IX             GRANTED
```

The FK check left an S record lock on the parent thread row. The UPDATE then upgraded to X — both locks visible simultaneously.

**Fixed order — UPDATE (parent) first:**

```
-- after UPDATE DISCUSSION_THREAD SET ETAG
DISCUSSION_THREAD  PRIMARY  RECORD  X,REC_NOT_GAP  GRANTED  data=999999999

-- after INSERT IGNORE INTO DISCUSSION_THREAD_VIEW
DISCUSSION_THREAD       PRIMARY  RECORD  X,REC_NOT_GAP  GRANTED  data=999999999
DISCUSSION_THREAD_VIEW  NULL     TABLE   IX             GRANTED
```

Only X on the parent — no S, no upgrade. The FK check sees the transaction already holds X (which subsumes the S it would have requested) and adds no extra record lock. Two concurrent transactions in this order serialize cleanly: one gets X first, the other waits for X, then runs.

### 4. Documentation backing the FK shared-lock claim

MySQL Reference Manual, *"InnoDB and FOREIGN KEY Constraints"*: *"If a `FOREIGN KEY` constraint is defined on a table, any insert, update, or delete that requires the constraint condition to be checked sets shared record-level locks on the records that it looks at to check the constraint."* — exactly the `S,REC_NOT_GAP` lock observed above.

## Evidence the fix solves it

- After the reorder, `testUpdateThreadViewWithConcurrentCallers` runs **0 deadlocks across 400 concurrent calls** — same test, same code path, same DB, fixed code.
- Direct lock observation under the fixed order shows no S→X upgrade ever occurs (section 3 above).
- All existing observable-behavior tests for `updateThreadView` still pass on the reordered code:
  - `DBODiscussionThreadDAOImplTest#testCountThreadView` — INSERT IGNORE still inserts and deduplicates correctly
  - `DBODiscussionThreadDAOImplTest#testCountThreadViewForNonExistingThread` — non-existent thread → 0, no FK crash
  - `DBODiscussionThreadDAOImplTest#testCountThreadViewForExistingThreadZeroView` — zero-view case
  - `DBODiscussionThreadDAOImplTest#testUpdateThreadViewTriggerThreadEtagChange` — ETAG actually rotates
  - `DiscussionThreadManagerImplTest` — full 81-test suite, including the post-commit message wiring

## Test plan

- [x] `mvn test -pl lib/jdomodels -Dtest='DBODiscussionThreadDAOImplTest#testUpdateThreadViewWithConcurrentCallers'` — green on fixed code, fails with 199/400 deadlocks on unfixed code
- [x] `mvn test -pl lib/jdomodels -Dtest='DBODiscussionThreadDAOImplTest#testCountThreadView+testCountThreadViewForNonExistingThread+testCountThreadViewForExistingThreadZeroView+testUpdateThreadViewTriggerThreadEtagChange'` — green
- [x] `mvn test -pl services/repository-managers -Dtest=DiscussionThreadManagerImplTest` — 81/81 green
- [ ] CI runs on PR
- [ ] Post-deploy: CloudWatch query for `Deadlock found when trying to get lock` against `DISCUSSION_THREAD` should drop to zero