### PR TITLE
Migrate Synapse-Build pipeline to CodeConnections; split CI for fork-PR safety

### DIFF
--- a/.github/workflows/aws_pipeline.yml
+++ b/.github/workflows/aws_pipeline.yml
@@ -1,0 +1,179 @@
+---
+#
+# Triggers the AWS CodePipeline (Synapse-Build-<user>) for fork PRs and upstream
+# pushes. Uses pull_request_target so we get id-token: write and access to
+# upstream secrets/OIDC, which pull_request from a fork cannot grant.
+#
+# SECURITY MODEL — read before editing:
+# - This workflow runs the version of the file from the BASE branch (develop).
+#   Modifications in a PR DO NOT take effect until merged. That's why this
+#   trigger is safe with secrets.
+# - We deliberately DO NOT run actions/checkout against the PR head, and we DO
+#   NOT execute any code from the PR (no scripts, no Maven, no pre-commit).
+#   Static analysis lives in build_and_test.yml under `pull_request`, where it
+#   has no secrets.
+# - The PR's code is fetched and built INSIDE AWS CodeBuild, which runs as its
+#   own service role. The PR cannot exfiltrate the GitHub OIDC token from this
+#   workflow because it never executes here.
+# - Recommended GitHub setting: Settings -> Actions -> General -> Fork pull
+#   request workflows from outside collaborators -> "Require approval for
+#   first-time contributors". Defense-in-depth.
+#
+# These parameters can be overridden with repo' action variables:
+# - USER, STACK_BUILDER_REPO_OWNER, STACK_BUILDER_BRANCH, FULL_BUILD, EXTRA_ARGS
+#
+name: aws-pipeline
+
+on:
+  pull_request_target:
+    branches: ['**']
+  push:
+    branches: [develop, 'release-*']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  capture_credentials:
+    permissions:
+      contents: read
+      id-token: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Determine Pipeline Parameters
+        id: pipeline-params
+        run: |
+          # The pipeline sources from upstream (Sage-Bionetworks) via CodeConnections,
+          # so the relevant ref is whatever GitHub exposes on upstream:
+          #   - pull_request_target events: refs/pull/<n>/head with HEAD SHA at github.event.pull_request.head.sha
+          #   - push events: the upstream branch (develop or release-*)
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            SYNAPSE_BRANCH=refs/pull/${{ github.event.pull_request.number }}/head
+            SYNAPSE_SHA=${{ github.event.pull_request.head.sha }}
+            DEFAULT_USER=${{ github.event.pull_request.user.login }}
+          else
+            SYNAPSE_BRANCH=${GITHUB_REF#refs/heads/}
+            SYNAPSE_SHA=${{ github.sha }}
+            DEFAULT_USER=$GITHUB_REPOSITORY_OWNER
+          fi
+          echo "SYNAPSE_SHA=$SYNAPSE_SHA" >> $GITHUB_OUTPUT
+          # get the 'user' parameter, either from the repo' env or derived from the PR/push author
+          if [ ${{ vars.USER }} ]; then
+            USER=${{ vars.USER }}
+          else
+            USER=$(echo "${DEFAULT_USER//[^[:alnum:]]/}" | tr '[:upper:]' '[:lower:]' | cut -c1-7)
+          fi
+          echo "USER=$USER" >> $GITHUB_OUTPUT
+          # get repo' and branch specifying the version of the stack builder to use
+          if [ ${{ vars.STACK_BUILDER_REPO_OWNER }} ]; then
+            STACK_BUILDER_REPO_OWNER=${{ vars.STACK_BUILDER_REPO_OWNER }}
+          else
+            STACK_BUILDER_REPO_OWNER=Sage-Bionetworks
+          fi
+          if [ ${{ vars.STACK_BUILDER_BRANCH }} ]; then
+            STACK_BUILDER_BRANCH=${{ vars.STACK_BUILDER_BRANCH }}
+          else
+            STACK_BUILDER_BRANCH=develop
+          fi
+          FULL_BUILD=${{ vars.FULL_BUILD }}
+          EXTRA_ARGS=${{ vars.EXTRA_ARGS }}
+          # publish build artifacts only for upstream pushes to develop/release-*
+          if [[ "${{ github.event_name }}" == "push" && "$GITHUB_REPOSITORY_OWNER" == "Sage-Bionetworks" ]]; then
+            if [[ $SYNAPSE_BRANCH == "develop" ]]; then
+              ARTIFACT_VERSION=$(date +%Y-%m-%d_%H-%M)"_"${SYNAPSE_SHA:0:7}
+            elif [[ $SYNAPSE_BRANCH =~ "release-" ]]; then
+              # release-* tag resolution requires a checkout. We deliberately
+              # skip checking out PR-head code under pull_request_target; this
+              # branch only fires on `push` to upstream so a checkout here is safe.
+              git init -q && git remote add origin https://github.com/${{ github.repository }}.git
+              git fetch --tags --depth=1 origin "+refs/tags/*:refs/tags/*"
+              ARTIFACT_VERSION=$(git describe --tags ${SYNAPSE_SHA} 2>/dev/null || echo "")
+            fi
+          fi
+          if [[ $ARTIFACT_VERSION ]]; then
+            echo "ARTIFACT_VERSION=$ARTIFACT_VERSION" >> $GITHUB_OUTPUT
+          fi
+          # Note: CodeConnectionsArn is intentionally not in this list. The CFN template
+          # defaults it to the upstream connection ARN (it is non-sensitive and account-scoped).
+          PIPELINE_PARAMETERS=\
+          "SynapseBranch=$SYNAPSE_BRANCH,\
+          SynapseRepoOwner=Sage-Bionetworks,\
+          BuildParamUser=$USER,\
+          StackBuilderBranch=$STACK_BUILDER_BRANCH,\
+          StackBuilderRepoOwner=$STACK_BUILDER_REPO_OWNER,\
+          FullBuild=$FULL_BUILD,\
+          MavenExtraArgs=$EXTRA_ARGS,\
+          ArtifactVersion=$ARTIFACT_VERSION"
+          echo "PIPELINE_PARAMETERS=$PIPELINE_PARAMETERS" >> $GITHUB_OUTPUT
+
+      - id: display-artifact-version
+        name: Display Artifact Version
+        run: |
+          if [[ "${{ steps.pipeline-params.outputs.ARTIFACT_VERSION }}" ]]; then
+            echo "Build will publish artifacts with version" ${{ steps.pipeline-params.outputs.ARTIFACT_VERSION }}
+          else
+            echo "Artifacts will not be published for this build"
+          fi
+
+      - id: oidc
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: arn:aws:iam::449435941126:role/sagebase-github-oidc-sage-bionetworks-synapse-build
+          aws-region: us-east-1
+          # eight hours
+          role-duration-seconds: 28800
+
+      - name: Capture Session Credentials
+        run: |
+          # CodeBuild creates an STS session of one hour duration and there is no way to override.
+          # The Synapse build needs a longer-lived session, so we stash the OIDC-issued credentials
+          # in Secrets Manager for the buildspec to consume (configuration/build/buildspec.yml).
+          SECRET_NAME="/build/session-token/${{ steps.pipeline-params.outputs.USER }}"
+          SECRET_VALUE='{"AwsAccessKeyId":"${{ env.AWS_ACCESS_KEY_ID }}", "AwsSecretAccessKey":"${{ env.AWS_SECRET_ACCESS_KEY }}", "AwsSessionToken":"${{ env.AWS_SESSION_TOKEN }}"}'
+          if aws secretsmanager put-secret-value \
+              --secret-id "$SECRET_NAME" \
+              --secret-string "$SECRET_VALUE" \
+              2>/dev/null; then
+              echo "Secret updated successfully"
+          else
+              echo "Secret doesn't exist, creating new secret..."
+              if aws secretsmanager create-secret \
+                  --name "$SECRET_NAME" \
+                  --secret-string "$SECRET_VALUE" \
+                  --description "Build credentials for ${{ steps.pipeline-params.outputs.USER }}"; then
+                  echo "Secret created successfully"
+              else
+                  echo "Failed to create secret"
+                  exit 1
+              fi
+          fi
+
+    outputs:
+      USER: ${{ steps.pipeline-params.outputs.USER }}
+      PIPELINE_PARAMETERS: ${{ steps.pipeline-params.outputs.PIPELINE_PARAMETERS }}
+      SYNAPSE_SHA: ${{ steps.pipeline-params.outputs.SYNAPSE_SHA }}
+
+  invoke_workflow:
+    needs: capture_credentials
+    uses: Sage-Bionetworks/Synapse-Code-Pipeline/.github/workflows/execute_code_pipeline.yml@main
+    with:
+      CODE_PIPELINE_CF_TEMPLATE: configuration/build/codepipeline_cf_template.yaml
+      PIPELINE_NAME: Synapse-Build-${{ needs.capture_credentials.outputs.USER }}
+      CODE_PIPELINE_SOURCE_REVISIONS: "actionName=CheckoutSynapseRepo,revisionType=COMMIT_ID,revisionValue=${{ needs.capture_credentials.outputs.SYNAPSE_SHA }}"
+      PIPELINE_PARAMETERS: ${{ needs.capture_credentials.outputs.PIPELINE_PARAMETERS }}
+      ROLE_TO_ASSUME: arn:aws:iam::449435941126:role/sagebase-github-oidc-sage-bionetworks-synapse-build
+      STATUS_REPO_OWNER: Sage-Bionetworks
+      STATUS_REPOSITORY: Synapse-Repository-Services
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+      security-events: write
+      statuses: write
+      actions: write
+      checks: write
+...

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,6 +18,8 @@
 name: main
 
 on:
+  pull_request:
+    branches: ['**']
   push:
     branches: ['*']
 
@@ -42,19 +44,48 @@ jobs:
       - name: Static Analysis
         uses: pre-commit/action@v3.0.0
 
+      # On fork pushes the AWS pipeline cannot run from the fork (CodeConnections is installed
+      # on upstream only). If there's no upstream PR for this commit, fail-fast with a clear
+      # message; if there is, skip the rest of this job and let the pull_request event do the work.
+      - name: Check upstream PR for fork push
+        id: fork-pr-check
+        if: github.event_name == 'push' && github.repository_owner != 'Sage-Bionetworks'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_COUNT=$(gh api "repos/Sage-Bionetworks/Synapse-Repository-Services/commits/${{ github.sha }}/pulls" --jq 'length' || echo 0)
+          if [[ "$PR_COUNT" == "0" ]]; then
+            echo "::error::This commit is on a fork branch with no open upstream PR. Open a (draft) PR against Sage-Bionetworks/Synapse-Repository-Services to run AWS CI."
+            exit 1
+          fi
+          echo "Fork push has $PR_COUNT associated upstream PR(s); the pull_request event will run AWS CI."
+          echo "skip_aws_run=true" >> $GITHUB_OUTPUT
+
       - name: Determine Pipeline Parameters
+        if: steps.fork-pr-check.outputs.skip_aws_run != 'true'
         id: pipeline-params
         run: |
-          # get the 'user' parameter, either from the repo' env or repo' owner if not set
+          # The pipeline now sources from upstream (Sage-Bionetworks) via CodeConnections,
+          # so the relevant ref is whatever GitHub exposes on upstream:
+          #   - pull_request events: refs/pull/<n>/head, with HEAD SHA at github.event.pull_request.head.sha
+          #   - push events: the upstream branch (develop or release-*)
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            SYNAPSE_BRANCH=refs/pull/${{ github.event.pull_request.number }}/head
+            SYNAPSE_SHA=${{ github.event.pull_request.head.sha }}
+            DEFAULT_USER=${{ github.event.pull_request.user.login }}
+          else
+            SYNAPSE_BRANCH=${GITHUB_REF#refs/heads/}
+            SYNAPSE_SHA=${{ github.sha }}
+            DEFAULT_USER=$GITHUB_REPOSITORY_OWNER
+          fi
+          echo "SYNAPSE_SHA=$SYNAPSE_SHA" >> $GITHUB_OUTPUT
+          # get the 'user' parameter, either from the repo' env or derived from the PR/push author
           if [ ${{ vars.USER }} ]; then
             USER=${{ vars.USER }}
           else
-            alpha_only_trunc_repo_name=$(echo "${GITHUB_REPOSITORY_OWNER//[^[:alnum:]]/}" | tr '[:upper:]' '[:lower:]' | cut -c1-7)
-            USER=$alpha_only_trunc_repo_name
+            USER=$(echo "${DEFAULT_USER//[^[:alnum:]]/}" | tr '[:upper:]' '[:lower:]' | cut -c1-7)
           fi
           echo "USER=$USER" >> $GITHUB_OUTPUT
-          # capture the current branch as an environment variable
-          BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
           # get repo' and branch specifying the version of the stack builder to use
           if [ ${{ vars.STACK_BUILDER_REPO_OWNER }} ]; then
             STACK_BUILDER_REPO_OWNER=${{ vars.STACK_BUILDER_REPO_OWNER }}
@@ -68,12 +99,11 @@ jobs:
           fi
           FULL_BUILD=${{ vars.FULL_BUILD }}
           EXTRA_ARGS=${{ vars.EXTRA_ARGS }}
-          # for builds in Sage-Bionetworks repo', publish build artifacts
-          if [[ $GITHUB_REPOSITORY_OWNER == "Sage-Bionetworks" ]]; then
-            if [[ $BRANCH == "develop" ]]; then
-              GIT_COMMIT=${{ github.sha }}
-              ARTIFACT_VERSION=$(date +%Y-%m-%d_%H-%M)"_"${GIT_COMMIT:0:7}
-            elif [[ $BRANCH =~ "release-" ]]; then
+          # publish build artifacts only for upstream pushes to develop/release-*
+          if [[ "${{ github.event_name }}" == "push" && "$GITHUB_REPOSITORY_OWNER" == "Sage-Bionetworks" ]]; then
+            if [[ $SYNAPSE_BRANCH == "develop" ]]; then
+              ARTIFACT_VERSION=$(date +%Y-%m-%d_%H-%M)"_"${SYNAPSE_SHA:0:7}
+            elif [[ $SYNAPSE_BRANCH =~ "release-" ]]; then
               git fetch --tags
               ARTIFACT_VERSION=$(git describe --tags)
             fi
@@ -81,9 +111,11 @@ jobs:
           if [[ $ARTIFACT_VERSION ]]; then
             echo "ARTIFACT_VERSION=$ARTIFACT_VERSION" >> $GITHUB_OUTPUT
           fi
+          # Note: CodeConnectionsArn is intentionally not in this list. The CFN template
+          # defaults it to the upstream connection ARN (it is non-sensitive and account-scoped).
           PIPELINE_PARAMETERS=\
-          "SynapseBranch=$BRANCH,\
-          SynapseRepoOwner=${{ github.repository_owner }},\
+          "SynapseBranch=$SYNAPSE_BRANCH,\
+          SynapseRepoOwner=Sage-Bionetworks,\
           BuildParamUser=$USER,\
           StackBuilderBranch=$STACK_BUILDER_BRANCH,\
           StackBuilderRepoOwner=$STACK_BUILDER_REPO_OWNER,\
@@ -94,6 +126,7 @@ jobs:
 
       - id: display-artifact-version
         name: Display Artifact Version
+        if: steps.fork-pr-check.outputs.skip_aws_run != 'true'
         run: |
           if [[ "${{ steps.pipeline-params.outputs.ARTIFACT_VERSION }}" ]]; then
             echo "Build will publish artifacts with version" ${{ steps.pipeline-params.outputs.ARTIFACT_VERSION }}
@@ -102,6 +135,7 @@ jobs:
           fi
 
       - id: oidc
+        if: steps.fork-pr-check.outputs.skip_aws_run != 'true'
         uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: arn:aws:iam::449435941126:role/sagebase-github-oidc-sage-bionetworks-synapse-build
@@ -110,6 +144,7 @@ jobs:
           role-duration-seconds: 28800
 
       - name: Capture Session Credentials
+        if: steps.fork-pr-check.outputs.skip_aws_run != 'true'
         run: |
           # We will capture the long-lived session token to use for the build
           # Note: We cannot pass the credentials as inputs to code pipeline
@@ -138,14 +173,17 @@ jobs:
     outputs:
       USER: ${{ steps.pipeline-params.outputs.USER }}
       PIPELINE_PARAMETERS: ${{ steps.pipeline-params.outputs.PIPELINE_PARAMETERS }}
+      SYNAPSE_SHA: ${{ steps.pipeline-params.outputs.SYNAPSE_SHA }}
+      SKIP_AWS_RUN: ${{ steps.fork-pr-check.outputs.skip_aws_run }}
 
   invoke_workflow:
     needs: build_and_test
+    if: needs.build_and_test.outputs.SKIP_AWS_RUN != 'true'
     uses: Sage-Bionetworks/Synapse-Code-Pipeline/.github/workflows/execute_code_pipeline.yml@main
     with:
       CODE_PIPELINE_CF_TEMPLATE: configuration/build/codepipeline_cf_template.yaml
       PIPELINE_NAME: Synapse-Build-${{ needs.build_and_test.outputs.USER }}
-      CODE_PIPELINE_SOURCE_REVISIONS: "actionName=CheckoutSynapseRepo,revisionType=COMMIT_ID,revisionValue=${{ github.sha }}"
+      CODE_PIPELINE_SOURCE_REVISIONS: "actionName=CheckoutSynapseRepo,revisionType=COMMIT_ID,revisionValue=${{ needs.build_and_test.outputs.SYNAPSE_SHA }}"
       PIPELINE_PARAMETERS: ${{ needs.build_and_test.outputs.PIPELINE_PARAMETERS }}
       ROLE_TO_ASSUME: arn:aws:iam::449435941126:role/sagebase-github-oidc-sage-bionetworks-synapse-build
       STATUS_REPO_OWNER: Sage-Bionetworks

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,201 +1,36 @@
 ---
 #
-# This workflow runs the Synapse Stack Builder and then builds and runs the tests
-# for the Synapse Repository Services.
+# Static analysis for Synapse Repository Services pull requests and upstream pushes.
 #
-# These parameters can be overridden with repo's action variables:
+# This workflow runs in the PR-head context (so it sees PR-author code), but it
+# has NO access to upstream secrets and NO id-token: write permission. The AWS
+# CodePipeline trigger lives in aws_pipeline.yml, which runs on
+# pull_request_target so it can access the OIDC role.
 #
-# - USER (the 'user' parameter for the Synapse build): defaults to repo' owner.  Should be alphanumeric only.
-# - STACK_BUILDER_REPO_OWNER: defaults to Sage-Bionetworks
-# - STACK_BUILDER_BRANCH: defaults to develop
-# - FULL_BUILD: if true, will do a full build, vs. an abbreviated "feature build"
-# - EXTRA_ARGS: pass extra arguments to maven build
-#
-# The place to set The page where you set the "repository variables" is
-# https://github.com/<owner>/Synapse-Repository-Services/settings/variables/actions
-# where <owner> is the name of one's fork of this repository.
-#
-name: main
+name: validate
 
 on:
   pull_request:
     branches: ['**']
   push:
-    branches: ['*']
+    branches: [develop, 'release-*']
 
-# let only one copy of the workflow run at a time
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
-  build_and_test:
-    permissions:
-      contents: read
-      id-token: write
-
+  static_analysis:
     runs-on: ubuntu-latest
-
     steps:
       - name: checkout
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0 # Fetch all history for git commands to work correctly
+          fetch-depth: 0
 
       - name: Static Analysis
         uses: pre-commit/action@v3.0.0
-
-      # On fork pushes the AWS pipeline cannot run from the fork (CodeConnections is installed
-      # on upstream only). If there's no upstream PR for this commit, fail-fast with a clear
-      # message; if there is, skip the rest of this job and let the pull_request event do the work.
-      - name: Check upstream PR for fork push
-        id: fork-pr-check
-        if: github.event_name == 'push' && github.repository_owner != 'Sage-Bionetworks'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_COUNT=$(gh api "repos/Sage-Bionetworks/Synapse-Repository-Services/commits/${{ github.sha }}/pulls" --jq 'length' || echo 0)
-          if [[ "$PR_COUNT" == "0" ]]; then
-            echo "::error::This commit is on a fork branch with no open upstream PR. Open a (draft) PR against Sage-Bionetworks/Synapse-Repository-Services to run AWS CI."
-            exit 1
-          fi
-          echo "Fork push has $PR_COUNT associated upstream PR(s); the pull_request event will run AWS CI."
-          echo "skip_aws_run=true" >> $GITHUB_OUTPUT
-
-      - name: Determine Pipeline Parameters
-        if: steps.fork-pr-check.outputs.skip_aws_run != 'true'
-        id: pipeline-params
-        run: |
-          # The pipeline now sources from upstream (Sage-Bionetworks) via CodeConnections,
-          # so the relevant ref is whatever GitHub exposes on upstream:
-          #   - pull_request events: refs/pull/<n>/head, with HEAD SHA at github.event.pull_request.head.sha
-          #   - push events: the upstream branch (develop or release-*)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            SYNAPSE_BRANCH=refs/pull/${{ github.event.pull_request.number }}/head
-            SYNAPSE_SHA=${{ github.event.pull_request.head.sha }}
-            DEFAULT_USER=${{ github.event.pull_request.user.login }}
-          else
-            SYNAPSE_BRANCH=${GITHUB_REF#refs/heads/}
-            SYNAPSE_SHA=${{ github.sha }}
-            DEFAULT_USER=$GITHUB_REPOSITORY_OWNER
-          fi
-          echo "SYNAPSE_SHA=$SYNAPSE_SHA" >> $GITHUB_OUTPUT
-          # get the 'user' parameter, either from the repo' env or derived from the PR/push author
-          if [ ${{ vars.USER }} ]; then
-            USER=${{ vars.USER }}
-          else
-            USER=$(echo "${DEFAULT_USER//[^[:alnum:]]/}" | tr '[:upper:]' '[:lower:]' | cut -c1-7)
-          fi
-          echo "USER=$USER" >> $GITHUB_OUTPUT
-          # get repo' and branch specifying the version of the stack builder to use
-          if [ ${{ vars.STACK_BUILDER_REPO_OWNER }} ]; then
-            STACK_BUILDER_REPO_OWNER=${{ vars.STACK_BUILDER_REPO_OWNER }}
-           else
-            STACK_BUILDER_REPO_OWNER=Sage-Bionetworks
-          fi
-          if [ ${{ vars.STACK_BUILDER_BRANCH }} ]; then
-            STACK_BUILDER_BRANCH=${{ vars.STACK_BUILDER_BRANCH }}
-          else
-            STACK_BUILDER_BRANCH=develop
-          fi
-          FULL_BUILD=${{ vars.FULL_BUILD }}
-          EXTRA_ARGS=${{ vars.EXTRA_ARGS }}
-          # publish build artifacts only for upstream pushes to develop/release-*
-          if [[ "${{ github.event_name }}" == "push" && "$GITHUB_REPOSITORY_OWNER" == "Sage-Bionetworks" ]]; then
-            if [[ $SYNAPSE_BRANCH == "develop" ]]; then
-              ARTIFACT_VERSION=$(date +%Y-%m-%d_%H-%M)"_"${SYNAPSE_SHA:0:7}
-            elif [[ $SYNAPSE_BRANCH =~ "release-" ]]; then
-              git fetch --tags
-              ARTIFACT_VERSION=$(git describe --tags)
-            fi
-          fi
-          if [[ $ARTIFACT_VERSION ]]; then
-            echo "ARTIFACT_VERSION=$ARTIFACT_VERSION" >> $GITHUB_OUTPUT
-          fi
-          # Note: CodeConnectionsArn is intentionally not in this list. The CFN template
-          # defaults it to the upstream connection ARN (it is non-sensitive and account-scoped).
-          PIPELINE_PARAMETERS=\
-          "SynapseBranch=$SYNAPSE_BRANCH,\
-          SynapseRepoOwner=Sage-Bionetworks,\
-          BuildParamUser=$USER,\
-          StackBuilderBranch=$STACK_BUILDER_BRANCH,\
-          StackBuilderRepoOwner=$STACK_BUILDER_REPO_OWNER,\
-          FullBuild=$FULL_BUILD,\
-          MavenExtraArgs=$EXTRA_ARGS,\
-          ArtifactVersion=$ARTIFACT_VERSION"
-          echo "PIPELINE_PARAMETERS=$PIPELINE_PARAMETERS" >> $GITHUB_OUTPUT
-
-      - id: display-artifact-version
-        name: Display Artifact Version
-        if: steps.fork-pr-check.outputs.skip_aws_run != 'true'
-        run: |
-          if [[ "${{ steps.pipeline-params.outputs.ARTIFACT_VERSION }}" ]]; then
-            echo "Build will publish artifacts with version" ${{ steps.pipeline-params.outputs.ARTIFACT_VERSION }}
-          else
-            echo "Artifacts will not be published for this build"
-          fi
-
-      - id: oidc
-        if: steps.fork-pr-check.outputs.skip_aws_run != 'true'
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          role-to-assume: arn:aws:iam::449435941126:role/sagebase-github-oidc-sage-bionetworks-synapse-build
-          aws-region: us-east-1
-          # eight hours
-          role-duration-seconds: 28800
-
-      - name: Capture Session Credentials
-        if: steps.fork-pr-check.outputs.skip_aws_run != 'true'
-        run: |
-          # We will capture the long-lived session token to use for the build
-          # Note: We cannot pass the credentials as inputs to code pipeline
-          # since the token exceeded the 1000 character limit for input variables.
-          SECRET_NAME="/build/session-token/${{ steps.pipeline-params.outputs.USER }}"
-          SECRET_VALUE='{"AwsAccessKeyId":"${{ env.AWS_ACCESS_KEY_ID }}", "AwsSecretAccessKey":"${{ env.AWS_SECRET_ACCESS_KEY }}", "AwsSessionToken":"${{ env.AWS_SESSION_TOKEN }}"}'
-          # Try to update the secret value first
-          if aws secretsmanager put-secret-value \
-              --secret-id "$SECRET_NAME" \
-              --secret-string "$SECRET_VALUE" \
-              2>/dev/null; then
-              echo "Secret updated successfully"
-          else
-              echo "Secret doesn't exist, creating new secret..."
-              if aws secretsmanager create-secret \
-                  --name "$SECRET_NAME" \
-                  --secret-string "$SECRET_VALUE" \
-                  --description "Build credentials for ${{ steps.pipeline-params.outputs.USER }}"; then
-                  echo "Secret created successfully"
-              else
-                  echo "Failed to create secret"
-                  exit 1
-              fi
-          fi
-
-    outputs:
-      USER: ${{ steps.pipeline-params.outputs.USER }}
-      PIPELINE_PARAMETERS: ${{ steps.pipeline-params.outputs.PIPELINE_PARAMETERS }}
-      SYNAPSE_SHA: ${{ steps.pipeline-params.outputs.SYNAPSE_SHA }}
-      SKIP_AWS_RUN: ${{ steps.fork-pr-check.outputs.skip_aws_run }}
-
-  invoke_workflow:
-    needs: build_and_test
-    if: needs.build_and_test.outputs.SKIP_AWS_RUN != 'true'
-    uses: Sage-Bionetworks/Synapse-Code-Pipeline/.github/workflows/execute_code_pipeline.yml@main
-    with:
-      CODE_PIPELINE_CF_TEMPLATE: configuration/build/codepipeline_cf_template.yaml
-      PIPELINE_NAME: Synapse-Build-${{ needs.build_and_test.outputs.USER }}
-      CODE_PIPELINE_SOURCE_REVISIONS: "actionName=CheckoutSynapseRepo,revisionType=COMMIT_ID,revisionValue=${{ needs.build_and_test.outputs.SYNAPSE_SHA }}"
-      PIPELINE_PARAMETERS: ${{ needs.build_and_test.outputs.PIPELINE_PARAMETERS }}
-      ROLE_TO_ASSUME: arn:aws:iam::449435941126:role/sagebase-github-oidc-sage-bionetworks-synapse-build
-      STATUS_REPO_OWNER: Sage-Bionetworks
-      STATUS_REPOSITORY: Synapse-Repository-Services
-    secrets: inherit
-    permissions:
-      # https://graphite.dev/guides/github-actions-permissions
-      id-token: write
-      contents: read
-      deployments: write
-      security-events: write
-      statuses: write
-      actions: write
-      checks: write
 ...

--- a/configuration/build/codepipeline_cf_template.yaml
+++ b/configuration/build/codepipeline_cf_template.yaml
@@ -87,9 +87,7 @@ Parameters:
   CodeConnectionsArn:
     Type: String
     Description: ARN of the AWS CodeConnections GitHub connection used by the source actions. The ARN is not sensitive; it is an opaque AWS identifier and grants nothing without IAM permissions.
-    # TODO: replace placeholder with the real ARN after creating the GitHub
-    # connection (see PR description for setup steps).
-    Default: arn:aws:codeconnections:us-east-1:449435941126:connection/REPLACE-ME
+    Default: arn:aws:codeconnections:us-east-1:449435941126:connection/0d3d9ad4-5dfd-4294-80a5-20774dda8409
     AllowedPattern: "arn:aws:codeconnections:.+"
     ConstraintDescription: Must be a CodeConnections ARN.
 Outputs:

--- a/configuration/build/codepipeline_cf_template.yaml
+++ b/configuration/build/codepipeline_cf_template.yaml
@@ -84,6 +84,14 @@ Parameters:
     Default: sg-0818ba0f1872103d4
     AllowedPattern: ".+"
     ConstraintDescription: Parameter cannot be empty.
+  CodeConnectionsArn:
+    Type: String
+    Description: ARN of the AWS CodeConnections GitHub connection used by the source actions. The ARN is not sensitive; it is an opaque AWS identifier and grants nothing without IAM permissions.
+    # TODO: replace placeholder with the real ARN after creating the GitHub
+    # connection (see PR description for setup steps).
+    Default: arn:aws:codeconnections:us-east-1:449435941126:connection/REPLACE-ME
+    AllowedPattern: "arn:aws:codeconnections:.+"
+    ConstraintDescription: Must be a CodeConnections ARN.
 Outputs:
   PipelineName:
     Value: !Ref CodePipeline
@@ -122,6 +130,12 @@ Resources:
                   - codebuild:BatchGetBuilds
                   - codebuild:StartBuild
                 Resource: !GetAtt CodeBuildProject.Arn
+              # Permission to use the CodeConnections GitHub connection from the source actions
+              - Effect: Allow
+                Action:
+                  - codestar-connections:UseConnection
+                  - codeconnections:UseConnection
+                Resource: !Ref CodeConnectionsArn
   CodeBuildServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -164,32 +178,35 @@ Resources:
             - Name: CheckoutStackBuilderRepo
               ActionTypeId:
                 Category: Source
-                Owner: ThirdParty
-                Provider: GitHub
+                Owner: AWS
+                Provider: CodeStarSourceConnection
                 Version: 1
               OutputArtifacts:
                 - Name: StackBuilderRepoSource
               Configuration:
-                Owner: !Ref StackBuilderRepoOwner
-                Repo: !Ref StackBuilderRepository
-                Branch: !Ref StackBuilderBranch
-                OAuthToken: !Ref GitHubToken
-                PollForSourceChanges: false # instead we will trigger from GitHub workflow
+                ConnectionArn: !Ref CodeConnectionsArn
+                FullRepositoryId: !Sub "${StackBuilderRepoOwner}/${StackBuilderRepository}"
+                BranchName: !Ref StackBuilderBranch
+                # Pipeline is started explicitly by the GitHub workflow via start-pipeline-execution.
+                # Leaving this true would let the connection auto-fire on every push the App sees.
+                DetectChanges: false
             - Name: CheckoutSynapseRepo
               Namespace: CheckoutSynapseRepo
               ActionTypeId:
                 Category: Source
-                Owner: ThirdParty
-                Provider: GitHub
+                Owner: AWS
+                Provider: CodeStarSourceConnection
                 Version: 1
               OutputArtifacts:
                 - Name: SynapseRepoSource
               Configuration:
-                Owner: !Ref SynapseRepoOwner
-                Repo: !Ref SynapseRepository
-                Branch: !Ref SynapseBranch
-                OAuthToken: !Ref GitHubToken
-                PollForSourceChanges: false # instead we will trigger from GitHub workflow
+                ConnectionArn: !Ref CodeConnectionsArn
+                FullRepositoryId: !Sub "${SynapseRepoOwner}/${SynapseRepository}"
+                BranchName: !Ref SynapseBranch
+                # Pipeline is started explicitly by the GitHub workflow via start-pipeline-execution
+                # with --source-revisions revisionValue=<sha>. For fork PRs the SHA is reachable on
+                # upstream via refs/pull/N/head; for upstream pushes it lives on the named branch.
+                DetectChanges: false
         - Name: RunStackBuilder
           Actions:
             - Name: RunStackBuilder


### PR DESCRIPTION
## Summary
- The `Synapse-Build-<user>` CFN stacks are failing `UPDATE_FAILED` with `The OAuth token used for the GitHub source action … exceeds the maximum allowed length of 100 characters`. The shared `Sage-Bionetworks/Synapse-Code-Pipeline` workflow appends `GitHubToken=${{ secrets.GITHUB_TOKEN }}` to CFN `parameter-overrides`, and GitHub has migrated `secrets.GITHUB_TOKEN` to a longer opaque format that exceeds the v1 GitHub source action's 100-char cap.
- Migrate both v1 GitHub source actions in `configuration/build/codepipeline_cf_template.yaml` to `CodeStarSourceConnection`. New action uses an ARN instead of an `OAuthToken` and is AWS's supported replacement.
- One CodeConnection lives on upstream `Sage-Bionetworks` and resolves both `Synapse-Repository-Services` and `Synapse-Stack-Builder` commits. The pipeline now sources from upstream — fork PR commits are picked up via `refs/pull/N/head` once a PR is opened.
- Connection ARN is defaulted in the template (non-sensitive — opaque AWS identifier, useless without IAM).
- Companion PR for the buckets pipeline: Sage-Bionetworks/Synapse-Stack-Builder#877.

## CI workflow restructure (security)

GitHub does NOT grant `id-token: write` to `pull_request` events from forks, so the previous unified workflow couldn't authenticate with AWS on fork PRs. The fix is `pull_request_target`, which runs in upstream context with secrets — but ONLY if it never executes PR-author code, otherwise PR authors get secret access.

This PR splits CI along that trust boundary:

- **`build_and_test.yml` (renamed `validate`):** runs on `pull_request` + `push` to `develop`/`release-*`. Checks out PR head, runs `pre-commit`. Has only `contents: read`. **No secrets, no id-token, no AWS.** Worst-case malicious PR runs in an ephemeral runner with read-only `GITHUB_TOKEN`.
- **`aws_pipeline.yml` (new):** runs on `pull_request_target` + `push` to `develop`/`release-*`. Has full upstream secrets and OIDC role. **Does NOT check out PR head and does NOT run any PR code.** Resolves the PR head SHA from event metadata and asks AWS CodePipeline to build it. CodeBuild fetches the source server-side through CodeConnections and runs the build under the CodeBuild service role.

## Pre-work — already completed
- AWS CodeConnection created in account `449435941126` (`us-east-1`):
  ARN `arn:aws:codeconnections:us-east-1:449435941126:connection/0d3d9ad4-5dfd-4294-80a5-20774dda8409` (defaulted in the template).
- Verify the GitHub App install scope is limited to `Synapse-Repository-Services` and `Synapse-Stack-Builder`.

## Required follow-up

### 1. Enable first-time-contributor approval (defense in depth)
- **Settings → Actions → General → Fork pull request workflows from outside collaborators → "Require approval for first-time contributors"**.
- Means a maintainer must click "Approve and run" on a brand-new contributor's first PR before any workflow runs. After that first approval, subsequent pushes to the same PR auto-run.
- Not strictly required (the trust boundary holds without it), but cheap belt-and-suspenders.

### 2. Recover any stuck stacks
For each `Synapse-Build-<user>` stack in `UPDATE_ROLLBACK_FAILED`:
```
aws cloudformation continue-update-rollback --stack-name Synapse-Build-<user> --region us-east-1
```
Stacks in `UPDATE_ROLLBACK_COMPLETE` need no manual recovery — the next run will attempt a normal update.

### 3. Communicate the contributor-flow change
- Fork pushes alone no longer build. Contributors must open a (draft) PR against `Sage-Bionetworks/Synapse-Repository-Services` to get AWS CI.
- The fork's `validate.yml` static analysis still runs on every push to a fork branch, but the AWS pipeline is gated on PR existence.

### 4. Clean up unused GitHub repository secrets (optional)
The migration removed the dependency on `secrets.CODESTAR_CONNECTION_ARN`. If that secret was set anywhere it can be deleted.

## Trust model details
- `DetectChanges: false` keeps the connection from auto-firing on every push the App sees; the pipeline only runs when the workflow explicitly calls `start-pipeline-execution`.
- Credential lifetime widens vs. today: the per-run `GITHUB_TOKEN` is replaced by a long-lived GitHub App install. Mitigated by scoping the App install to only the two repos.
- `pull_request_target` always runs the workflow file from `develop`, not from the PR head, so a malicious PR cannot modify `aws_pipeline.yml` to do something dangerous before it's reviewed and merged.

## Test plan
- [ ] Open a (draft) PR from a fork: `validate` runs pre-commit; `aws-pipeline` invokes CodePipeline and the AWS stack updates without the OAuth-token-length error.
- [ ] In the AWS console, both `CheckoutStackBuilderRepo` and `CheckoutSynapseRepo` show `Source provider: GitHub (via AWS CodeStar)` and pull the expected commits.
- [ ] Push to upstream `develop`: source actions resolve `develop`, pipeline runs, artifacts published.
- [ ] Push to a fork branch with NO upstream PR: only `validate` runs (pre-commit only); no AWS resources touched.
- [ ] Push more commits to a fork branch with an open PR: both `validate` (on the fork side) and `aws-pipeline` (on upstream side) run; the AWS run uses the new HEAD SHA.
- [ ] Confirm the GitHub App install in `Sage-Bionetworks` org settings is scoped only to the two intended repos.
- [ ] Confirm "Require approval for first-time contributors" is enabled in repo settings.