### PR TITLE
[PLFM-9676] Restore migration bridges for legacy search backup shapes

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/search/ColumnAnalyzerOverrideDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/search/ColumnAnalyzerOverrideDaoImpl.java
@@ -18,11 +18,18 @@ import org.sagebionetworks.repo.model.search.table.ColumnAnalyzerOverride;
 import org.sagebionetworks.repo.model.search.table.ColumnAnalyzerOverrideEntry;
 import org.sagebionetworks.repo.transactions.WriteTransaction;
 import org.sagebionetworks.repo.web.NotFoundException;
+import org.sagebionetworks.util.TemporaryCode;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @Repository
 public class ColumnAnalyzerOverrideDaoImpl implements ColumnAnalyzerOverrideDao {
@@ -35,6 +42,8 @@ public class ColumnAnalyzerOverrideDaoImpl implements ColumnAnalyzerOverrideDao 
 		this.idGenerator = idGenerator;
 	}
 
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
 	private static final RowMapper<ColumnAnalyzerOverride> ROW_MAPPER = (rs, rowNum) -> {
 		ColumnAnalyzerOverride dto = new ColumnAnalyzerOverride();
 		dto.setId(String.valueOf(rs.getLong("ID")));
@@ -43,13 +52,54 @@ public class ColumnAnalyzerOverrideDaoImpl implements ColumnAnalyzerOverrideDao 
 		dto.setName(rs.getString("NAME"));
 		dto.setDescription(rs.getString("DESCRIPTION"));
 		dto.setOverrides(JDOSecondaryPropertyUtils.readJsonToEntityList(
-				rs.getString("OVERRIDES"), ColumnAnalyzerOverrideEntry.class));
+				bridgeLegacyOverridesJson(rs.getString("OVERRIDES")), ColumnAnalyzerOverrideEntry.class));
 		dto.setCreatedBy(String.valueOf(rs.getLong("CREATED_BY")));
 		dto.setCreatedOn(new Date(rs.getTimestamp("CREATED_ON").getTime()));
 		dto.setModifiedBy(String.valueOf(rs.getLong("MODIFIED_BY")));
 		dto.setModifiedOn(new Date(rs.getTimestamp("MODIFIED_ON").getTime()));
 		return dto;
 	};
+
+	// Bridge for prod-restored rows whose OVERRIDES JSON still carries the legacy
+	// `indexAnalyzer` / `searchAnalyzer` fields: rename `indexAnalyzer` to `analyzer` and
+	// drop `searchAnalyzer`. Remove in the stack that immediately follows the first prod
+	// stack written with the new `analyzer`-only override JSON shape — by then every
+	// COLUMN_ANALYZER_OVERRIDE row's OVERRIDES JSON has been re-saved into the new shape
+	// (either by the curator hand-editing or by the next migration cycle re-restoring the
+	// table from a backup that was itself produced by a stack already on the new shape).
+	@TemporaryCode(author = "BryanFauble",
+			comment = "PLFM-9676: Remove in the stack after the first prod stack writes COLUMN_ANALYZER_OVERRIDE.OVERRIDES with `analyzer` only. Verify by sampling a few prod backups.")
+	static String bridgeLegacyOverridesJson(String json) {
+		if (json == null || json.isEmpty()) {
+			return json;
+		}
+		try {
+			JsonNode root = MAPPER.readTree(json);
+			if (!(root instanceof ArrayNode)) {
+				return json;
+			}
+			boolean changed = false;
+			ArrayNode arr = (ArrayNode) root;
+			for (int i = 0; i < arr.size(); i++) {
+				JsonNode entry = arr.get(i);
+				if (!(entry instanceof ObjectNode)) {
+					continue;
+				}
+				ObjectNode obj = (ObjectNode) entry;
+				if (!obj.has("analyzer") && obj.has("indexAnalyzer")) {
+					obj.set("analyzer", obj.remove("indexAnalyzer"));
+					changed = true;
+				}
+				if (obj.has("searchAnalyzer")) {
+					obj.remove("searchAnalyzer");
+					changed = true;
+				}
+			}
+			return changed ? MAPPER.writeValueAsString(arr) : json;
+		} catch (JsonProcessingException e) {
+			return json;
+		}
+	}
 
 	@Override
 	@WriteTransaction

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/search/DBOSearchConfiguration.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/search/DBOSearchConfiguration.java
@@ -24,9 +24,9 @@ import java.util.Objects;
 import org.sagebionetworks.repo.model.dbo.FieldColumn;
 import org.sagebionetworks.repo.model.dbo.MigratableDatabaseObject;
 import org.sagebionetworks.repo.model.dbo.TableMapping;
-import org.sagebionetworks.repo.model.dbo.migration.BasicMigratableTableTranslation;
 import org.sagebionetworks.repo.model.dbo.migration.MigratableTableTranslation;
 import org.sagebionetworks.repo.model.migration.MigrationType;
+import org.sagebionetworks.util.TemporaryCode;
 
 public class DBOSearchConfiguration implements MigratableDatabaseObject<DBOSearchConfiguration, DBOSearchConfiguration> {
 
@@ -55,6 +55,12 @@ public class DBOSearchConfiguration implements MigratableDatabaseObject<DBOSearc
 	private Timestamp createdOn;
 	private Long modifiedBy;
 	private Timestamp modifiedOn;
+
+	// Legacy backups still serialize the <synonymSetsJson> XML element (the dropped JSON
+	// column). Caught here so deserialization does not fail; the translator below
+	// discards it. No FieldColumn entry — never read from or written to the database.
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Can be removed after one migration cycle.")
+	private String synonymSetsJson;
 
 	private static final TableMapping<DBOSearchConfiguration> TABLE_MAPPING = new TableMapping<>() {
 		@Override
@@ -105,8 +111,31 @@ public class DBOSearchConfiguration implements MigratableDatabaseObject<DBOSearc
 		return MigrationType.SEARCH_CONFIGURATION;
 	}
 
+	// Production backups still serialize the legacy <synonymSetsJson> element from the
+	// previous interior shape; the translator nulls it on restore. Both
+	// columnAnalyzerOverrides and defaultAnalyzer changed shape in this PR — overrides moved
+	// from List<String> qnames to a heterogeneous List<Object> of $ref-or-inline, and
+	// defaultAnalyzer moved from a bare qname string to a $ref-or-inline object. The
+	// safest restore path is to discard the legacy values; curators recreate via REST.
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Replace with BasicMigratableTableTranslation after the next stack flushes legacy backup shapes.")
 	private static final MigratableTableTranslation<DBOSearchConfiguration, DBOSearchConfiguration> MIGRATION_TRANSLATOR =
-			new BasicMigratableTableTranslation<>();
+			new MigratableTableTranslation<DBOSearchConfiguration, DBOSearchConfiguration>() {
+		@Override
+		public DBOSearchConfiguration createDatabaseObjectFromBackup(DBOSearchConfiguration backup) {
+			backup.setColumnAnalyzerOverridesJson(null);
+			backup.setSynonymSetsJson(null);
+			// Legacy defaultAnalyzer column held a bare qname; the new JSON column requires a
+			// JSON value. Either upgrade the bare qname to a $ref shape or drop it. Drop here:
+			// the schema reshape is a clean break, and curators are expected to re-save.
+			backup.setDefaultAnalyzer(null);
+			return backup;
+		}
+
+		@Override
+		public DBOSearchConfiguration createBackupFromDatabaseObject(DBOSearchConfiguration dbo) {
+			return dbo;
+		}
+	};
 
 	@Override
 	public MigratableTableTranslation<DBOSearchConfiguration, DBOSearchConfiguration> getTranslator() {
@@ -179,6 +208,17 @@ public class DBOSearchConfiguration implements MigratableDatabaseObject<DBOSearc
 
 	public DBOSearchConfiguration setDefaultAnalyzer(String defaultAnalyzer) {
 		this.defaultAnalyzer = defaultAnalyzer;
+		return this;
+	}
+
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Can be removed after one migration cycle.")
+	public String getSynonymSetsJson() {
+		return synonymSetsJson;
+	}
+
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Can be removed after one migration cycle.")
+	public DBOSearchConfiguration setSynonymSetsJson(String synonymSetsJson) {
+		this.synonymSetsJson = synonymSetsJson;
 		return this;
 	}
 

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/search/DBOSynonymSet.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/search/DBOSynonymSet.java
@@ -22,9 +22,9 @@ import java.util.Objects;
 import org.sagebionetworks.repo.model.dbo.FieldColumn;
 import org.sagebionetworks.repo.model.dbo.MigratableDatabaseObject;
 import org.sagebionetworks.repo.model.dbo.TableMapping;
-import org.sagebionetworks.repo.model.dbo.migration.BasicMigratableTableTranslation;
 import org.sagebionetworks.repo.model.dbo.migration.MigratableTableTranslation;
 import org.sagebionetworks.repo.model.migration.MigrationType;
+import org.sagebionetworks.util.TemporaryCode;
 
 public class DBOSynonymSet implements MigratableDatabaseObject<DBOSynonymSet, DBOSynonymSet> {
 
@@ -90,8 +90,38 @@ public class DBOSynonymSet implements MigratableDatabaseObject<DBOSynonymSet, DB
 		}
 	};
 
+	// Migration bridge:a valid (empty) OpenSearch synonym_graph token-filter definition.
+	// Written into the DEFINITION column for any row whose backup carries the legacy
+	// <rules> shape, so the NOT NULL constraint passes on restore. Curators are expected to
+	// DELETE & re-POST these rows through the SynonymSet REST API after migration.
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Remove after the new stack has rolled to prod and the next migration cycle has flushed legacy backup shapes.")
+	static final String PLACEHOLDER_DEFINITION = "{\"type\":\"synonym_graph\",\"synonyms\":[]}";
+
+	// Migration bridge:production backups still serialize the legacy <rules> XML element
+	// (a JSON array of {ruleType, ...} entries). Catch it here so deserialization does not
+	// fail. The translator below discards the value and writes PLACEHOLDER_DEFINITION into
+	// the new DEFINITION column. No FieldColumn entry — this field is never read from or
+	// written to the database.
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Remove after the new stack has rolled to prod and the next migration cycle has flushed legacy backup shapes.")
+	private String rules;
+
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Replace with BasicMigratableTableTranslation after legacy <rules> backups can no longer arrive.")
 	private static final MigratableTableTranslation<DBOSynonymSet, DBOSynonymSet> MIGRATION_TRANSLATOR =
-			new BasicMigratableTableTranslation<>();
+			new MigratableTableTranslation<DBOSynonymSet, DBOSynonymSet>() {
+		@Override
+		public DBOSynonymSet createDatabaseObjectFromBackup(DBOSynonymSet backup) {
+			if (backup.getDefinition() == null) {
+				backup.setDefinition(PLACEHOLDER_DEFINITION);
+			}
+			backup.setRules(null);
+			return backup;
+		}
+
+		@Override
+		public DBOSynonymSet createBackupFromDatabaseObject(DBOSynonymSet dbo) {
+			return dbo;
+		}
+	};
 
 	@Override
 	public TableMapping<DBOSynonymSet> getTableMapping() {
@@ -174,6 +204,17 @@ public class DBOSynonymSet implements MigratableDatabaseObject<DBOSynonymSet, DB
 
 	public DBOSynonymSet setDefinition(String definition) {
 		this.definition = definition;
+		return this;
+	}
+
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Remove after the new stack has rolled to prod and the next migration cycle has flushed legacy backup shapes.")
+	public String getRules() {
+		return rules;
+	}
+
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Remove after the new stack has rolled to prod and the next migration cycle has flushed legacy backup shapes.")
+	public DBOSynonymSet setRules(String rules) {
+		this.rules = rules;
 		return this;
 	}
 

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/search/DBOTextAnalyzer.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/search/DBOTextAnalyzer.java
@@ -9,9 +9,9 @@ import java.util.Objects;
 import org.sagebionetworks.repo.model.dbo.FieldColumn;
 import org.sagebionetworks.repo.model.dbo.MigratableDatabaseObject;
 import org.sagebionetworks.repo.model.dbo.TableMapping;
-import org.sagebionetworks.repo.model.dbo.migration.BasicMigratableTableTranslation;
 import org.sagebionetworks.repo.model.dbo.migration.MigratableTableTranslation;
 import org.sagebionetworks.repo.model.migration.MigrationType;
+import org.sagebionetworks.util.TemporaryCode;
 
 public class DBOTextAnalyzer implements MigratableDatabaseObject<DBOTextAnalyzer, DBOTextAnalyzer> {
 
@@ -38,6 +38,13 @@ public class DBOTextAnalyzer implements MigratableDatabaseObject<DBOTextAnalyzer
 	private Timestamp createdOn;
 	private Long modifiedBy;
 	private Timestamp modifiedOn;
+
+	// A valid (empty) opaque-JSON analyzer settings blob. Written into the SETTINGS column
+	// for any backup whose settings JSON still uses the legacy typed shape (presence of
+	// "tokenFilters" / "indexFilterOrder" keys), so the column passes validation on restore.
+	// Curators are expected to PUT the row through the TextAnalyzer REST API to re-author.
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Can be removed after one migration cycle.")
+	static final String PLACEHOLDER_SETTINGS = "{\"analyzer\":{\"default\":{\"type\":\"custom\",\"tokenizer\":\"standard\"}}}";
 
 	private static final TableMapping<DBOTextAnalyzer> TABLE_MAPPING = new TableMapping<>() {
 		@Override
@@ -87,8 +94,28 @@ public class DBOTextAnalyzer implements MigratableDatabaseObject<DBOTextAnalyzer
 		return MigrationType.TEXT_ANALYZER;
 	}
 
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Can be removed after one migration cycle.")
 	private static final MigratableTableTranslation<DBOTextAnalyzer, DBOTextAnalyzer> MIGRATION_TRANSLATOR =
-			new BasicMigratableTableTranslation<>();
+			new MigratableTableTranslation<DBOTextAnalyzer, DBOTextAnalyzer>() {
+		@Override
+		public DBOTextAnalyzer createDatabaseObjectFromBackup(DBOTextAnalyzer backup) {
+			// Detect the legacy typed-settings shape (presence of "tokenFilters" or
+			// "indexFilterOrder" keys) and replace with a placeholder opaque-JSON blob.
+			// Curators recreate via the REST API on the bridge stack.
+			String s = backup.getSettings();
+			if (s != null && (s.contains("\"tokenFilters\"") || s.contains("\"indexFilterOrder\"")
+					|| s.contains("\"searchFilterOrder\"") || s.contains("\"charFilters\"")
+					|| s.contains("\"charFilterOrder\"") || s.contains("\"positionIncrementGap\""))) {
+				backup.setSettings(PLACEHOLDER_SETTINGS);
+			}
+			return backup;
+		}
+
+		@Override
+		public DBOTextAnalyzer createBackupFromDatabaseObject(DBOTextAnalyzer dbo) {
+			return dbo;
+		}
+	};
 
 	@Override
 	public MigratableTableTranslation<DBOTextAnalyzer, DBOTextAnalyzer> getTranslator() {

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/search/DBOSearchConfigurationTranslatorTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/search/DBOSearchConfigurationTranslatorTest.java
@@ -1,0 +1,84 @@
+package org.sagebionetworks.repo.model.dbo.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.Test;
+import org.sagebionetworks.util.TemporaryCode;
+
+@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Delete alongside the DBOSearchConfiguration bridge once legacy <synonymSetsJson> backups can no longer arrive.")
+public class DBOSearchConfigurationTranslatorTest {
+
+	private static DBOSearchConfiguration backupRow() {
+		return new DBOSearchConfiguration()
+				.setId(42L)
+				.setEtag("etag-1")
+				.setOrganizationName("sage")
+				.setName("default")
+				.setDescription("Carried over from a pre-refactor stack.")
+				.setDefaultAnalyzer("sage-STANDARD")
+				.setSynonymSetsJson("[{\"ruleType\":\"EQUIVALENT\"}]")
+				.setColumnAnalyzerOverridesJson("[{\"columnName\":\"x\",\"analyzer\":\"old\"}]")
+				.setCreatedBy(1L)
+				.setCreatedOn(new Timestamp(0L))
+				.setModifiedBy(1L)
+				.setModifiedOn(new Timestamp(0L));
+	}
+
+	@Test
+	public void testCreateDatabaseObjectFromBackupWithLegacyShape() {
+		// A backup carrying the legacy <synonymSetsJson> XML element, an old-shape
+		// COLUMN_ANALYZER_OVERRIDES JSON, and a bare-qname DEFAULT_ANALYZER varchar value.
+		// The translator nulls all three: the column types changed (DEFAULT_ANALYZER is now
+		// JSON, accepting a $ref-or-inline shape that the old qname doesn't satisfy), and
+		// curators are expected to re-save SearchConfigurations on the new stack.
+		DBOSearchConfiguration backup = backupRow();
+
+		// call under test
+		DBOSearchConfiguration result = new DBOSearchConfiguration().getTranslator().createDatabaseObjectFromBackup(backup);
+
+		assertNull(result.getDefaultAnalyzer(),
+				"legacy bare-qname default analyzer must be dropped — column is now JSON ref-or-inline");
+		assertNull(result.getSynonymSetsJson(), "legacy interior shape must not be persisted");
+		assertNull(result.getColumnAnalyzerOverridesJson(), "legacy interior shape must not be persisted");
+		// identity / audit fields flow through untouched
+		assertEquals(42L, result.getId());
+		assertEquals("etag-1", result.getEtag());
+		assertEquals("sage", result.getOrganizationName());
+		assertEquals("default", result.getName());
+	}
+
+	@Test
+	public void testCreateDatabaseObjectFromBackupWithNewShape() {
+		// A row authored on the new stack — DEFAULT_ANALYZER carries a $ref JSON object,
+		// the legacy interior shapes are absent. The translator drops DEFAULT_ANALYZER
+		// across the board for this stack (clean break); curators recreate via REST.
+		DBOSearchConfiguration backup = backupRow()
+				.setDefaultAnalyzer("{\"$ref\":\"sage-SCIENTIFIC\"}")
+				.setSynonymSetsJson(null)
+				.setColumnAnalyzerOverridesJson(null);
+
+		// call under test
+		DBOSearchConfiguration result = new DBOSearchConfiguration().getTranslator().createDatabaseObjectFromBackup(backup);
+
+		assertNull(result.getDefaultAnalyzer());
+		assertNull(result.getSynonymSetsJson());
+		assertNull(result.getColumnAnalyzerOverridesJson());
+	}
+
+	@Test
+	public void testCreateBackupFromDatabaseObjectIsIdentity() {
+		DBOSearchConfiguration dbo = backupRow()
+				.setDefaultAnalyzer("{\"$ref\":\"sage-STANDARD\"}")
+				.setSynonymSetsJson(null)
+				.setColumnAnalyzerOverridesJson(null);
+
+		// call under test
+		DBOSearchConfiguration result = new DBOSearchConfiguration().getTranslator().createBackupFromDatabaseObject(dbo);
+
+		assertSame(dbo, result);
+	}
+}

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/search/DBOSynonymSetTranslatorTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/search/DBOSynonymSetTranslatorTest.java
@@ -1,0 +1,68 @@
+package org.sagebionetworks.repo.model.dbo.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.Test;
+import org.sagebionetworks.util.TemporaryCode;
+
+@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Delete alongside the DBOSynonymSet bridge once legacy <rules> backups can no longer arrive.")
+public class DBOSynonymSetTranslatorTest {
+
+	private static DBOSynonymSet legacyBackup() {
+		return new DBOSynonymSet()
+				.setId(123L)
+				.setEtag("etag-1")
+				.setOrganizationName("sage")
+				.setName("medical_terms")
+				.setDescription("Carried over from a pre-refactor stack.")
+				.setRules("[{\"ruleType\":\"EQUIVALENT\",\"terms\":[\"tumor\",\"neoplasm\"]}]")
+				.setCreatedBy(1L)
+				.setCreatedOn(new Timestamp(0L))
+				.setModifiedBy(1L)
+				.setModifiedOn(new Timestamp(0L));
+	}
+
+	@Test
+	public void testCreateDatabaseObjectFromBackupWithLegacyRulesField() {
+		DBOSynonymSet backup = legacyBackup();
+
+		// call under test
+		DBOSynonymSet result = new DBOSynonymSet().getTranslator().createDatabaseObjectFromBackup(backup);
+
+		assertEquals(DBOSynonymSet.PLACEHOLDER_DEFINITION, result.getDefinition());
+		assertNull(result.getRules(), "bridge field should be cleared after translation");
+		// identity / audit fields flow through untouched
+		assertEquals(123L, result.getId());
+		assertEquals("etag-1", result.getEtag());
+		assertEquals("sage", result.getOrganizationName());
+		assertEquals("medical_terms", result.getName());
+		assertEquals("Carried over from a pre-refactor stack.", result.getDescription());
+	}
+
+	@Test
+	public void testCreateDatabaseObjectFromBackupWithDefinitionAlreadyPresent() {
+		// Post-migration row (or a row authored on the new stack) — the translator must not
+		// overwrite an existing definition with the placeholder.
+		String existing = "{\"type\":\"synonym_graph\",\"synonyms\":[\"a, b\"]}";
+		DBOSynonymSet backup = legacyBackup().setDefinition(existing).setRules(null);
+
+		// call under test
+		DBOSynonymSet result = new DBOSynonymSet().getTranslator().createDatabaseObjectFromBackup(backup);
+
+		assertEquals(existing, result.getDefinition());
+	}
+
+	@Test
+	public void testCreateBackupFromDatabaseObjectIsIdentity() {
+		DBOSynonymSet dbo = legacyBackup().setDefinition("{\"type\":\"synonym_graph\",\"synonyms\":[]}").setRules(null);
+
+		// call under test
+		DBOSynonymSet result = new DBOSynonymSet().getTranslator().createBackupFromDatabaseObject(dbo);
+
+		assertSame(dbo, result);
+	}
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapper.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapper.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.repo.manager.search;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import org.json.JSONObject;
 import org.opensearch.client.opensearch._types.analysis.Analyzer;
@@ -14,6 +15,7 @@ import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.dbo.search.TextAnalyzerDao;
 import org.sagebionetworks.repo.model.schema.Organization;
 import org.sagebionetworks.repo.model.search.table.TextAnalyzer;
+import org.sagebionetworks.util.TemporaryCode;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Service;
 
@@ -145,6 +147,8 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 		Long adminUserId = AuthorizationConstants.BOOTSTRAP_PRINCIPAL.THE_ADMIN_USER.getPrincipalId();
 		String organizationName = organization.getName();
 
+		dropLegacyAutocompleteSearchAnalyzer();
+
 		textAnalyzerDao.createOrUpdateSystemAnalyzerForBootstrapOnly(SCIENTIFIC_ID, buildAnalyzer(
 				"SCIENTIFIC",
 				"English stemming, stop words, lowercase. Best for scientific metadata.",
@@ -189,5 +193,18 @@ public class TextAnalyzerBootstrapper implements TextAnalyzerBootstrap {
 				.setDescription(description)
 				.setSettings(new JSONObject(settings.toJsonString()));
 	}
+
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Remove after every stack has been redeployed and the legacy AUTOCOMPLETE_SEARCH row from before AUTOCOMPLETE absorbed default_search no longer arrives. The name check guards the id from being clobbered if the slot is later reclaimed.")
+	private void dropLegacyAutocompleteSearchAnalyzer() {
+		Optional<TextAnalyzer> existing = textAnalyzerDao.get(LEGACY_AUTOCOMPLETE_SEARCH_ID);
+		if (existing.isPresent() && LEGACY_AUTOCOMPLETE_SEARCH_NAME.equals(existing.get().getName())) {
+			textAnalyzerDao.delete(LEGACY_AUTOCOMPLETE_SEARCH_ID);
+		}
+	}
+
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Remove alongside dropLegacyAutocompleteSearchAnalyzer.")
+	private static final long LEGACY_AUTOCOMPLETE_SEARCH_ID = 6L;
+	@TemporaryCode(author = "BryanFauble", comment = "PLFM-9676: Remove alongside dropLegacyAutocompleteSearchAnalyzer.")
+	private static final String LEGACY_AUTOCOMPLETE_SEARCH_NAME = "AUTOCOMPLETE_SEARCH";
 
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapperTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/TextAnalyzerBootstrapperTest.java
@@ -95,6 +95,40 @@ public class TextAnalyzerBootstrapperTest {
 		}
 	}
 
+	// --- Stale-row migration for the dropped AUTOCOMPLETE_SEARCH_ID=6 ---
+
+	@Test
+	public void testBootstrapDeletesStaleAutocompleteSearchRowWhenNameMatches() {
+		when(textAnalyzerDao.get(6L)).thenReturn(
+				Optional.of(new TextAnalyzer().setName("AUTOCOMPLETE_SEARCH")));
+
+		// call under test
+		new TextAnalyzerBootstrapper(textAnalyzerDao, synapseSchemaBootstrap, userManager);
+
+		verify(textAnalyzerDao).delete(6L);
+	}
+
+	@Test
+	public void testBootstrapLeavesId6AloneWhenNameDoesNotMatch() {
+		when(textAnalyzerDao.get(6L)).thenReturn(
+				Optional.of(new TextAnalyzer().setName("RECLAIMED")));
+
+		// call under test
+		new TextAnalyzerBootstrapper(textAnalyzerDao, synapseSchemaBootstrap, userManager);
+
+		verify(textAnalyzerDao, never()).delete(6L);
+	}
+
+	@Test
+	public void testBootstrapLeavesId6AloneWhenAbsent() {
+		when(textAnalyzerDao.get(6L)).thenReturn(Optional.empty());
+
+		// call under test
+		new TextAnalyzerBootstrapper(textAnalyzerDao, synapseSchemaBootstrap, userManager);
+
+		verify(textAnalyzerDao, never()).delete(6L);
+	}
+
 	// --- helpers ---
 
 	private Map<Long, TextAnalyzer> captureAllUpserts() {


### PR DESCRIPTION
## Summary

This reverts PR #5646 on `release-592` so the `@TemporaryCode` migration bridges for legacy search backup shapes are restored. The bridges were removed prematurely — production has not yet rolled to the new shape on this stack, so legacy backup shapes can still arrive on restore and the bridges are still needed.

This restores:

- **`DBOSynonymSet`** — `rules` bridge field and accessors, `PLACEHOLDER_DEFINITION`, and the legacy-shape translator.
- **`DBOSearchConfiguration`** — `synonymSetsJson` bridge field and accessors, and the translator that nulls legacy `defaultAnalyzer` / `columnAnalyzerOverrides` / `synonymSetsJson`.
- **`DBOTextAnalyzer`** — `PLACEHOLDER_SETTINGS` and the legacy typed-settings detection translator.
- **`ColumnAnalyzerOverrideDaoImpl`** — `bridgeLegacyOverridesJson` and its Jackson `ObjectMapper` plumbing; row mapper reads `OVERRIDES` through the bridge again.
- **`TextAnalyzerBootstrapper`** — `dropLegacyAutocompleteSearchAnalyzer()` and the `LEGACY_AUTOCOMPLETE_SEARCH_*` constants.
- The two bridge unit tests (`DBOSynonymSetTranslatorTest`, `DBOSearchConfigurationTranslatorTest`) and the `TextAnalyzerBootstrapper` stale-row tests.

Implemented as a clean `git revert -m 1` of the #5646 merge commit (`9c0aa56962`), net +368 / -7 across 8 files — the exact inverse of the removal.

## Test plan

- [x] `mvn test-compile -pl lib/jdomodels -am`
- [x] `mvn test-compile -pl services/repository-managers -am`

🤖 Generated with [Claude Code](https://claude.com/claude-code)