### PR TITLE
[PLFM-9713] Stabilize OpenSearchManagerImplAutoWiredTest AOSS round-trip tests

### DIFF
--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -1131,7 +1131,7 @@ public class OpenSearchManagerImplAutoWiredTest {
 		for (Map.Entry<Kind, Supplier<SearchQuery>> entry : queries.entrySet()) {
 			SearchQuery body = entry.getValue().get();
 			// call under test — every kind must round-trip without throwing
-			SearchQueryResults result = openSearchManager.search(indexName, body, columns,
+			SearchQueryResults result = searchWithRetry(body, columns,
 					EnumSet.of(SearchQueryPart.HITS, SearchQueryPart.TOTAL_HITS));
 			assertNotNull(result, "kind " + entry.getKey() + " produced null result");
 			assertNotNull(result.getTotalHits(), "kind " + entry.getKey() + " missing totalHits");
@@ -1237,8 +1237,8 @@ public class OpenSearchManagerImplAutoWiredTest {
 				.setFrom(0L);
 
 		// call under test — post_filter narrows hits; aggregations stay at full population
-		SearchQueryResults results = openSearchManager.search(indexName, body, columns,
-				EnumSet.of(SearchQueryPart.HITS, SearchQueryPart.TOTAL_HITS));
+		SearchQueryResults results = waitForSearchHits(body, columns,
+				EnumSet.of(SearchQueryPart.HITS, SearchQueryPart.TOTAL_HITS), 2);
 
 		assertEquals(2L, results.getTotalHits(),
 				"totalHits must reflect post_filter narrowing — only ACTIVE rows");
@@ -1286,8 +1286,8 @@ public class OpenSearchManagerImplAutoWiredTest {
 				.setFrom(0L);
 
 		// call under test — highlight payload round-trips and SearchHit.highlights is populated
-		SearchQueryResults results = openSearchManager.search(indexName, body, columns,
-				EnumSet.of(SearchQueryPart.HITS, SearchQueryPart.TOTAL_HITS));
+		SearchQueryResults results = waitForSearchHits(body, columns,
+				EnumSet.of(SearchQueryPart.HITS, SearchQueryPart.TOTAL_HITS), 3);
 
 		assertEquals(3L, results.getTotalHits());
 		assertNotNull(results.getHits());


### PR DESCRIPTION
## Problem

[PLFM-9713](https://sagebionetworks.jira.com/browse/PLFM-9713): `OpenSearchManagerImplAutoWiredTest.testSearchWithEveryAllowedQueryKindRoundTrips()` failed ~2/3 of runs with:

```
java.lang.IllegalStateException: Search index is still building. Please try again later.
Caused by: OpenSearchException: [index_not_found_exception] no such index [test-index-...]
```

## Root cause

AOSS (OpenSearch Serverless) replicas are eventually consistent. A freshly created index that one node has acknowledged can briefly be absent on another node, which `OpenSearchManagerImpl.executeSearch` surfaces as `IllegalStateException("Search index is still building...")`.

The test waited once (`waitForSearch(matchAllBody(), ...)`) and then issued its real queries through **raw, un-retried** `openSearchManager.search(...)` calls. Three such raw call sites had this gap; any one could land on a replica that hadn't caught up yet.

## Fix

Route all three raw `search(...)` sites through the file's existing retry helpers — no production change:

| Test | Was | Now |
|------|-----|-----|
| `testSearchWithEveryAllowedQueryKindRoundTrips` | raw `search(...)` | `searchWithRetry(...)` — per-kind hit counts vary, so retry-on-`index_not_found` only |
| `testSearchWithPostFilter` | raw `search(...)` | `waitForSearchHits(..., 2)` — retries until exact count |
| `testSearchWithHighlight` | raw `search(...)` | `waitForSearchHits(..., 3)` — retries until exact count |

Left untouched: the `search(...)` calls inside the retry helpers themselves and the deliberate negative test (expects the throw on a nonexistent index). All assertions are unchanged — the helpers return the same `SearchQueryResults`.

## Verification

Ran the three affected tests against live AOSS **3 times** — all green (`Tests run: 3, Failures: 0, Errors: 0` each run). Original failure reproduced ~2/3 of the time, so 3 consecutive passes confirms the gap is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PLFM-9713]: https://sagebionetworks.jira.com/browse/PLFM-9713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ