### PR TITLE
[PLFM-9638] Add filter and filters bucket aggregations to search DSL

### DIFF
--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/dsl/Aggregation.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/dsl/Aggregation.json
@@ -1,6 +1,6 @@
 {
 	"$recursiveAnchor": true,
-	"description": "<p>A single <a href=\"https://docs.opensearch.org/latest/aggregations/\">OpenSearch aggregation</a> definition. Exactly one of the aggregation-kind properties below may be set; <code>aggregations</code> may additionally carry nested sub-aggregations.</p>",
+	"description": "<p>A single <a href=\"https://docs.opensearch.org/latest/aggregations/\">OpenSearch aggregation</a> definition. Exactly one of the aggregation-kind properties below may be set; <code>aggregations</code> may additionally carry nested sub-aggregations. The <code>filter</code> and <code>filters</code> kinds wrap a <a href=\"${org.sagebionetworks.repo.model.search.dsl.Query}\">Query</a>; that query is validated identically to the top-level <code>query</code> and is scoped by it, so a <code>filter</code> aggregation never counts documents outside the top-level query.</p>",
 	"properties": {
 		"terms": {
 			"$ref": "org.sagebionetworks.repo.model.search.dsl.TermsAggregation",
@@ -57,6 +57,14 @@
 		"cardinality": {
 			"$ref": "org.sagebionetworks.repo.model.search.dsl.CardinalityAggregation",
 			"description": "A <a href=\"https://docs.opensearch.org/latest/aggregations/metric/cardinality/\"><code>cardinality</code></a> metric aggregation."
+		},
+		"filter": {
+			"$ref": "org.sagebionetworks.repo.model.search.dsl.Query",
+			"description": "A <a href=\"https://docs.opensearch.org/latest/aggregations/bucket/filter/\"><code>filter</code></a> single-bucket aggregation. The body is a <a href=\"${org.sagebionetworks.repo.model.search.dsl.Query}\">Query</a> &mdash; validated like the top-level <code>query</code> &mdash; that narrows the documents the nested <code>aggregations</code> see, within the top-level query scope."
+		},
+		"filters": {
+			"$ref": "org.sagebionetworks.repo.model.search.dsl.FiltersAggregation",
+			"description": "A <a href=\"https://docs.opensearch.org/latest/aggregations/bucket/filters/\"><code>filters</code></a> multi-bucket aggregation &mdash; one named bucket per query."
 		},
 		"aggregations": {
 			"type": "map",

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/dsl/FiltersAggregation.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/search/dsl/FiltersAggregation.json
@@ -1,0 +1,27 @@
+{
+	"description": "A <a href=\"https://docs.opensearch.org/latest/aggregations/bucket/filters/\"><code>filters</code></a> multi-bucket aggregation. Each entry of <code>filters</code> is a named bucket whose documents match its <a href=\"${org.sagebionetworks.repo.model.search.dsl.Query}\">Query</a>. The named (keyed) form is the supported contract; each query is validated identically to the top-level <code>query</code> and is scoped by it.",
+	"properties": {
+		"filters": {
+			"type": "map",
+			"key": {
+				"type": "string"
+			},
+			"value": {
+				"$ref": "org.sagebionetworks.repo.model.search.dsl.Query"
+			},
+			"description": "Required. Named buckets, keyed by caller-chosen name; each value is a <a href=\"${org.sagebionetworks.repo.model.search.dsl.Query}\">Query</a> selecting that bucket's documents."
+		},
+		"other_bucket": {
+			"type": "boolean",
+			"description": "Optional. When <code>true</code>, adds a bucket for documents that match none of the named filters."
+		},
+		"other_bucket_key": {
+			"type": "string",
+			"description": "Optional. The key under which the other bucket is returned."
+		},
+		"keyed": {
+			"type": "boolean",
+			"description": "Optional. Whether buckets are returned as a keyed object (default) rather than an array."
+		}
+	}
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchDslValidator.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchDslValidator.java
@@ -8,9 +8,11 @@ import java.util.Set;
 
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.Buckets;
 import org.opensearch.client.opensearch._types.aggregations.CardinalityAggregation;
 import org.opensearch.client.opensearch._types.aggregations.DateHistogramAggregation;
 import org.opensearch.client.opensearch._types.aggregations.DateRangeAggregation;
+import org.opensearch.client.opensearch._types.aggregations.FiltersAggregation;
 import org.opensearch.client.opensearch._types.aggregations.HistogramAggregation;
 import org.opensearch.client.opensearch._types.aggregations.RangeAggregation;
 import org.opensearch.client.opensearch._types.aggregations.TermsAggregation;
@@ -143,15 +145,23 @@ final class SearchDslValidator {
 
 	/**
 	 * Aggregation kinds a caller may use. Bucket aggregations may carry nested
-	 * sub-aggregations via {@code aggregations()}. Intentionally excludes
-	 * {@code ScriptedMetric}, pipeline aggregations (e.g. {@code BucketScript},
-	 * {@code BucketSelector}), and the {@code Filter}/{@code Filters} aggregations (whose
-	 * bodies are queries that would need separate query-DSL validation).
+	 * sub-aggregations via {@code aggregations()}. The {@code Filter}/{@code Filters} aggregations
+	 * wrap a query body, which is validated through the same path as the top-level query
+	 * ({@link #validateQuery}) in {@link #walkAggregation}.
+	 * <p>
+	 * Intentionally excludes {@code ScriptedMetric} and pipeline aggregations (e.g.
+	 * {@code BucketScript}, {@code BucketSelector}). Also intentionally excludes {@code Global}
+	 * (and any other aggregation that resets or escapes the query scope): a {@code Global}
+	 * aggregation deliberately runs outside the current search context, so it would see documents
+	 * the top-level query &mdash; and the future server-side row-level ACL filter layered into that
+	 * query's {@code bool.must} &mdash; excludes. {@code Filter}/{@code Filters} are safe because
+	 * they run <i>inside</i> the search context and so remain scoped by the top-level query.
 	 */
 	static final Set<Aggregation.Kind> ALLOWED_AGGREGATION_KINDS = EnumSet.of(
 			// bucket
 			Aggregation.Kind.Terms, Aggregation.Kind.Histogram, Aggregation.Kind.DateHistogram,
 			Aggregation.Kind.Range, Aggregation.Kind.DateRange, Aggregation.Kind.Missing,
+			Aggregation.Kind.Filter, Aggregation.Kind.Filters,
 			// metric
 			Aggregation.Kind.Min, Aggregation.Kind.Max, Aggregation.Kind.Avg,
 			Aggregation.Kind.Sum, Aggregation.Kind.Stats, Aggregation.Kind.ExtendedStats,
@@ -411,6 +421,21 @@ final class SearchDslValidator {
 		checkBoundsShape(aggregation.path("date_histogram"), "date_histogram");
 		checkRangesShape(aggregation.path("range"), "range");
 		checkRangesShape(aggregation.path("date_range"), "date_range");
+
+		// `filter` / `filters` bodies are full query subtrees; their opaque leaf slots must pass the
+		// same shape gate as the top-level query (mirrors how a highlight_query body is gated).
+		JsonNode filter = aggregation.get("filter");
+		if (filter != null && filter.isObject()) {
+			validateQueryLeafShapes(filter);
+		}
+		// The filters slot is either a keyed object (name to query) or an array of queries; iterating
+		// a JsonNode yields the map values in the first case and the elements in the second.
+		JsonNode filters = aggregation.path("filters").get("filters");
+		if (filters != null) {
+			for (JsonNode query : filters) {
+				validateQueryLeafShapes(query);
+			}
+		}
 
 		validateAggregationLeafShapes(aggregation.get("aggregations"));
 	}
@@ -886,6 +911,15 @@ final class SearchDslValidator {
 		case Cardinality:
 			validateCardinalityAgg(agg.cardinality());
 			break;
+		case Filter:
+			// The filter body is a query clause; validate it through the same depth/clause caps and
+			// per-kind checks as the top-level query, sharing the aggregation's clause counter so a
+			// filter body cannot smuggle additional clauses past QUERY_MAX_CLAUSES.
+			walkQuery(agg.filter(), depth + 1, count);
+			break;
+		case Filters:
+			walkFilters(agg.filters(), depth + 1, count);
+			break;
 		default:
 			// Allowlisted aggregations with no additional caps to enforce (Missing, Min, Max, Avg,
 			// Sum, Stats, ExtendedStats, ValueCount). Any kind outside ALLOWED_AGGREGATION_KINDS is not
@@ -896,6 +930,28 @@ final class SearchDslValidator {
 		Map<String, Aggregation> subAggregations = agg.aggregations();
 		if (!subAggregations.isEmpty()) {
 			walkAggregationMap(subAggregations, depth + 1, count);
+		}
+	}
+
+	/**
+	 * Validate the query bodies carried by a {@code filters} aggregation. The {@code filters} slot is
+	 * a tagged union of either a keyed map (name to query) or an array of queries; each query is run
+	 * through {@link #walkQuery} with the shared clause counter, exactly like the single-bucket
+	 * {@code filter} body.
+	 */
+	static void walkFilters(FiltersAggregation filters, int depth, int[] count) {
+		Buckets<Query> buckets = filters.filters();
+		if (buckets == null) {
+			return;
+		}
+		if (buckets.isKeyed()) {
+			for (Query query : buckets.keyed().values()) {
+				walkQuery(query, depth, count);
+			}
+		} else if (buckets.isArray()) {
+			for (Query query : buckets.array()) {
+				walkQuery(query, depth, count);
+			}
 		}
 	}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchFieldRewriter.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchFieldRewriter.java
@@ -305,6 +305,15 @@ final class SearchFieldRewriter {
 					// A highlight_query body is a full Query subtree — switch surfaces so the
 					// query allowlist + auto-routing applies inside.
 					walk(value, ctx, Surface.QUERY, RoutingMode.BARE);
+				} else if (surface == Surface.AGGREGATIONS && "filter".equals(key) && value.isObject()) {
+					walk(value, ctx, Surface.QUERY, RoutingMode.BARE);
+				} else if (surface == Surface.AGGREGATIONS && "filters".equals(key) && value.isObject()) {
+					JsonNode inner = value.get("filters");
+					if (inner != null) {
+						for (JsonNode query : inner) {
+							walk(query, ctx, Surface.QUERY, RoutingMode.BARE);
+						}
+					}
 				} else {
 					RoutingMode childMode = kindMap.getOrDefault(key, RoutingMode.BARE);
 					if (SHORTHAND_FIELD_KEYED_KINDS.contains(key) && value.isObject()) {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -47,6 +47,7 @@ import org.sagebionetworks.repo.model.search.dsl.ConstantScoreQuery;
 import org.sagebionetworks.repo.model.search.dsl.DisMaxQuery;
 import org.sagebionetworks.repo.model.search.dsl.ExistsQuery;
 import org.sagebionetworks.repo.model.search.dsl.FieldCollapse;
+import org.sagebionetworks.repo.model.search.dsl.FiltersAggregation;
 import org.sagebionetworks.repo.model.search.dsl.FuzzyFieldOptions;
 import org.sagebionetworks.repo.model.search.dsl.Highlight;
 import org.sagebionetworks.repo.model.search.dsl.HighlightField;
@@ -214,6 +215,90 @@ public class OpenSearchManagerImplAutoWiredTest {
 			assertTrue(titleValue.contains("mitochondria"),
 					"Title field should contain 'mitochondria', got: " + titleValue);
 		});
+	}
+
+	@Test
+	public void testFilterAggregationRespectsTopLevelQueryScope() {
+		// ACL-scope invariant: a `filter` (and `filters`) aggregation runs *inside* the search
+		// context, so it must only ever count documents the top-level query already admits. When
+		// row-level ACL filtering lands it will be injected into the top-level bool.must; this test
+		// simulates that restricting clause with a top-level `term category=public` and proves the
+		// filter aggregation's buckets never count the excluded `private` rows — even though the
+		// filter body would match them on their own. This is the guardrail that keeps the feature
+		// from surfacing rows the caller is not authorized to see.
+		List<ColumnModel> columns = List.of(
+				new ColumnModel().setId("1").setName("category").setColumnType(ColumnType.STRING),
+				new ColumnModel().setId("2").setName("tag").setColumnType(ColumnType.STRING)
+		);
+		openSearchManager.createIndex(indexName, columns, null,
+				Collections.emptyList(), defaultAnalyzers);
+		openSearchManager.waitForIndexWritable(indexName);
+
+		// Tag "shared" appears on BOTH a public and a private row. The public row alone is in scope.
+		List<BulkOperation> operations = List.of(
+				buildBulkOp(indexName, "1", Map.of("_row_id", 1L, "_row_version", 1L, "1", "public", "2", "shared")),
+				buildBulkOp(indexName, "2", Map.of("_row_id", 2L, "_row_version", 1L, "1", "public", "2", "alpha")),
+				buildBulkOp(indexName, "3", Map.of("_row_id", 3L, "_row_version", 1L, "1", "private", "2", "shared")),
+				buildBulkOp(indexName, "4", Map.of("_row_id", 4L, "_row_version", 1L, "1", "private", "2", "beta"))
+		);
+		assertEquals(4L, openSearchManager.bulkIndex(indexName, operations));
+
+		// Top-level query restricts to category=public (the future ACL clause). Two aggregations:
+		//  - "tag_shared_filter": filter tag=shared, child terms on category
+		//  - "by_category_filters": named filters, one bucket per category value
+		// term/terms/range clauses auto-route text columns to .keyword, so reference tag/category by
+		// name and let the field rewriter resolve the keyword sub-field.
+		Aggregation filterAgg = new Aggregation()
+				.setFilter(new Query().setTerm(Map.of("tag", new TermFieldOptions().setValue("shared"))))
+				.setAggregations(Map.of("by_category",
+						new Aggregation().setTerms(new TermsAggregation().setField("category"))));
+		Aggregation filtersAgg = new Aggregation().setFilters(new FiltersAggregation().setFilters(Map.of(
+				"public_bucket", new Query().setTerm(Map.of("category", new TermFieldOptions().setValue("public"))),
+				"private_bucket", new Query().setTerm(Map.of("category", new TermFieldOptions().setValue("private"))))));
+
+		Map<String, Aggregation> aggregations = new LinkedHashMap<>();
+		aggregations.put("tag_shared_filter", filterAgg);
+		aggregations.put("by_category_filters", filtersAgg);
+
+		SearchQuery body = new SearchQuery()
+				.setQuery(new Query().setTerm(Map.of("category", new TermFieldOptions().setValue("public"))))
+				.setSize(10L)
+				.setFrom(0L)
+				.setAggregations(aggregations);
+
+		// Only the two public rows are in scope.
+		SearchQueryResults results = waitForSearch(body, columns, 2L);
+		assertEquals(2L, results.getTotalHits());
+
+		assertNotNull(results.getAggregationResults(), "aggregations were requested");
+		JsonNode aggResults = SearchOpaqueJsonUtil.parse(results.getAggregationResults());
+
+		// The filter agg matched tag=shared. There are two shared rows globally, but only the public
+		// one is in the top-level query scope — so doc_count MUST be 1, never 2.
+		JsonNode filterNode = aggResults.path("tag_shared_filter");
+		assertEquals(1, filterNode.path("doc_count").asInt(),
+				"filter agg must count only the in-scope (public) shared row, not the excluded private one: "
+						+ results.getAggregationResults());
+		// Its child terms-on-category bucket must contain only `public`. OpenSearch returns nested
+		// named sub-aggregations with a typed-key prefix (e.g. "sterms#by_category"), so locate the
+		// child by its caller-chosen suffix rather than an exact key.
+		JsonNode categoryBuckets = childAggBuckets(filterNode, "by_category");
+		assertTrue(categoryBuckets.isArray());
+		Set<String> categoriesSeen = new java.util.HashSet<>();
+		for (JsonNode bucket : categoryBuckets) {
+			categoriesSeen.add(bucket.path("key").asText());
+		}
+		assertEquals(Set.of("public"), categoriesSeen,
+				"filter agg sub-bucket must never surface the excluded `private` category");
+
+		// The filters agg: the public_bucket sees the 2 public rows; the private_bucket — whose query
+		// matches category=private — must be EMPTY, because those rows are outside the top-level scope.
+		JsonNode filtersBuckets = aggResults.path("by_category_filters").path("buckets");
+		assertEquals(2, filtersBuckets.path("public_bucket").path("doc_count").asInt(),
+				"filters public_bucket must count both in-scope public rows");
+		assertEquals(0, filtersBuckets.path("private_bucket").path("doc_count").asInt(),
+				"filters private_bucket must be empty — its rows are excluded by the top-level query: "
+						+ results.getAggregationResults());
 	}
 
 	@Test
@@ -614,6 +699,23 @@ public class OpenSearchManagerImplAutoWiredTest {
 				"hit value must preserve original casing of indexed text — lowercase filter applies to the inverted index only");
 		assertEquals("EHR data extraction", descriptionOf(ehrSimple),
 				"hit value must preserve original casing of indexed text — lowercase filter applies to the inverted index only");
+	}
+
+	/**
+	 * Find the {@code buckets} node of a named child sub-aggregation under {@code parent}. OpenSearch
+	 * prefixes nested named aggregations with a typed key (e.g. {@code "sterms#by_category"}), so
+	 * match either the exact name or any {@code <type>#<name>} variant.
+	 */
+	private static JsonNode childAggBuckets(JsonNode parent, String name) {
+		java.util.Iterator<Map.Entry<String, JsonNode>> fields = parent.fields();
+		while (fields.hasNext()) {
+			Map.Entry<String, JsonNode> entry = fields.next();
+			String key = entry.getKey();
+			if (key.equals(name) || key.endsWith("#" + name)) {
+				return entry.getValue().path("buckets");
+			}
+		}
+		return com.fasterxml.jackson.databind.node.MissingNode.getInstance();
 	}
 
 	private static String descriptionOf(SearchQueryResults results) {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchDslValidatorTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchDslValidatorTest.java
@@ -5,6 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -13,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.FieldSort;
 import org.opensearch.client.opensearch._types.FieldValue;
@@ -295,6 +302,14 @@ public class SearchDslValidatorTest {
 		aggs.put("a_extended_stats", Aggregation.of(b -> b.extendedStats(m -> m.field("f"))));
 		aggs.put("a_value_count", Aggregation.of(b -> b.valueCount(m -> m.field("f"))));
 		aggs.put("a_cardinality", Aggregation.of(b -> b.cardinality(m -> m.field("f"))));
+		aggs.put("a_filter", Aggregation.of(b -> b
+				.filter(f -> f.term(t -> t.field("f").value(FieldValue.of("x"))))
+				.aggregations("by_value", c -> c.terms(t -> t.field("f")))));
+		aggs.put("a_filters", Aggregation.of(b -> b
+				.filters(fs -> fs.filters(bk -> bk.keyed(Map.of(
+						"hits", Query.of(q -> q.term(t -> t.field("f").value(FieldValue.of("x")))),
+						"misses", Query.of(q -> q.term(t -> t.field("f").value(FieldValue.of("y"))))))))
+				.aggregations("by_value", c -> c.terms(t -> t.field("f")))));
 		// call under test
 		SearchDslValidator.validateAggregations(aggs);
 
@@ -402,6 +417,125 @@ public class SearchDslValidatorTest {
 		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
 				() -> SearchDslValidator.validateAggregations(aggs));
 		assertTrue(ex.getMessage().contains("nested too deeply"));
+	}
+
+	@Test
+	public void testValidateAggregationsWithFilterValid() {
+		// A well-formed single-bucket filter aggregation (a valid query body + a child agg) passes,
+		// and the filter body is routed through walkQuery — the same path a top-level query takes.
+		Query filterBody = Query.of(q -> q.term(t -> t.field("f").value(FieldValue.of("x"))));
+		Map<String, Aggregation> aggs = new LinkedHashMap<>();
+		aggs.put("a", Aggregation.of(b -> b
+				.filter(filterBody)
+				.aggregations("by_value", c -> c.terms(t -> t.field("f")))));
+
+		try (MockedStatic<SearchDslValidator> mocked =
+				mockStatic(SearchDslValidator.class, CALLS_REAL_METHODS)) {
+			// call under test
+			SearchDslValidator.validateAggregations(aggs);
+			// The filter body reaches the shared query-validation path exactly once.
+			mocked.verify(() -> SearchDslValidator.walkQuery(eq(filterBody), anyInt(), any()), times(1));
+		}
+	}
+
+	@Test
+	public void testValidateAggregationsWithFilterCrossIndexTermsLookupRejected() {
+		// A cross-index terms lookup smuggled inside a filter body is rejected exactly as it is at
+		// the top level.
+		Map<String, Aggregation> aggs = new LinkedHashMap<>();
+		aggs.put("a", Aggregation.of(b -> b
+				.filter(f -> f.terms(t -> t.field("foo").terms(TermsQueryField.of(qf -> qf
+						.lookup(TermsLookup.of(l -> l.index("other-index").id("1").path("p")))))))
+				.aggregations("by_value", c -> c.terms(t -> t.field("f")))));
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> SearchDslValidator.validateAggregations(aggs));
+		assertTrue(ex.getMessage().contains("terms lookup form"));
+	}
+
+	@Test
+	public void testValidateAggregationsWithFilterExcessiveClauseCount() {
+		// A filter body's clauses count against the shared QUERY_MAX_CLAUSES budget, so it cannot
+		// smuggle an unbounded number of clauses past the cap.
+		List<Query> many = new ArrayList<>();
+		for (int i = 0; i < SearchDslValidator.QUERY_MAX_CLAUSES + 2; i++) {
+			many.add(Query.of(b -> b.matchAll(m -> m)));
+		}
+		Map<String, Aggregation> aggs = new LinkedHashMap<>();
+		aggs.put("a", Aggregation.of(b -> b
+				.filter(f -> f.bool(bb -> bb.must(many)))
+				.aggregations("by_value", c -> c.terms(t -> t.field("f")))));
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> SearchDslValidator.validateAggregations(aggs));
+		assertTrue(ex.getMessage().contains("too many clauses"));
+	}
+
+	@Test
+	public void testValidateAggregationsWithFiltersKeyedValid() {
+		// A well-formed keyed filters aggregation passes, and every named bucket query is routed
+		// through walkQuery.
+		Query hits = Query.of(q -> q.term(t -> t.field("f").value(FieldValue.of("x"))));
+		Query misses = Query.of(q -> q.term(t -> t.field("f").value(FieldValue.of("y"))));
+		Map<String, Aggregation> aggs = new LinkedHashMap<>();
+		aggs.put("a", Aggregation.of(b -> b
+				.filters(fs -> fs.filters(bk -> bk.keyed(Map.of("hits", hits, "misses", misses))))
+				.aggregations("by_value", c -> c.terms(t -> t.field("f")))));
+
+		try (MockedStatic<SearchDslValidator> mocked =
+				mockStatic(SearchDslValidator.class, CALLS_REAL_METHODS)) {
+			// call under test
+			SearchDslValidator.validateAggregations(aggs);
+			mocked.verify(() -> SearchDslValidator.walkQuery(eq(hits), anyInt(), any()), times(1));
+			mocked.verify(() -> SearchDslValidator.walkQuery(eq(misses), anyInt(), any()), times(1));
+		}
+	}
+
+	@Test
+	public void testValidateAggregationsWithFiltersArrayValid() {
+		// The array (non-keyed) form is also accepted, and each query is routed through walkQuery.
+		Query first = Query.of(q -> q.term(t -> t.field("f").value(FieldValue.of("x"))));
+		Query second = Query.of(q -> q.term(t -> t.field("f").value(FieldValue.of("y"))));
+		Map<String, Aggregation> aggs = new LinkedHashMap<>();
+		aggs.put("a", Aggregation.of(b -> b
+				.filters(fs -> fs.filters(bk -> bk.array(List.of(first, second))))
+				.aggregations("by_value", c -> c.terms(t -> t.field("f")))));
+
+		try (MockedStatic<SearchDslValidator> mocked =
+				mockStatic(SearchDslValidator.class, CALLS_REAL_METHODS)) {
+			// call under test
+			SearchDslValidator.validateAggregations(aggs);
+			mocked.verify(() -> SearchDslValidator.walkQuery(eq(first), anyInt(), any()), times(1));
+			mocked.verify(() -> SearchDslValidator.walkQuery(eq(second), anyInt(), any()), times(1));
+		}
+	}
+
+	@Test
+	public void testValidateAggregationsWithFiltersKeyedCrossIndexTermsLookupRejected() {
+		// Each named query in a keyed filters bucket is validated identically to the top-level query.
+		Map<String, Aggregation> aggs = new LinkedHashMap<>();
+		aggs.put("a", Aggregation.of(b -> b
+				.filters(fs -> fs.filters(bk -> bk.keyed(Map.of(
+						"ok", Query.of(q -> q.term(t -> t.field("f").value(FieldValue.of("x")))),
+						"bad", Query.of(q -> q.terms(t -> t.field("foo").terms(TermsQueryField.of(qf -> qf
+								.lookup(TermsLookup.of(l -> l.index("other-index").id("1").path("p")))))))))))
+				.aggregations("by_value", c -> c.terms(t -> t.field("f")))));
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> SearchDslValidator.validateAggregations(aggs));
+		assertTrue(ex.getMessage().contains("terms lookup form"));
+	}
+
+	@Test
+	public void testValidateAggregationsWithFiltersArrayCrossIndexTermsLookupRejected() {
+		// The array (non-keyed) form is validated the same way as the keyed form.
+		Map<String, Aggregation> aggs = new LinkedHashMap<>();
+		aggs.put("a", Aggregation.of(b -> b
+				.filters(fs -> fs.filters(bk -> bk.array(List.of(
+						Query.of(q -> q.term(t -> t.field("f").value(FieldValue.of("x")))),
+						Query.of(q -> q.terms(t -> t.field("foo").terms(TermsQueryField.of(qf -> qf
+								.lookup(TermsLookup.of(l -> l.index("other-index").id("1").path("p")))))))))))
+				.aggregations("by_value", c -> c.terms(t -> t.field("f")))));
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> SearchDslValidator.validateAggregations(aggs));
+		assertTrue(ex.getMessage().contains("terms lookup form"));
 	}
 
 	// -----------------------------------------------------------------------------
@@ -1379,6 +1513,42 @@ public class SearchDslValidatorTest {
 								+ "\"aggregations\":{\"inner\":{\"histogram\":{\"field\":\"age\","
 								+ "\"extended_bounds\":{\"min\":{\"bad\":1},\"max\":10}}}}}}"));
 		assertTrue(ex.getMessage().contains("histogram.extended_bounds.min"));
+	}
+
+	@Test
+	public void testValidateAggregationLeafShapesWithFilterObjectQueryValueRejected() throws Exception {
+		// A filter body is a query subtree, so its opaque leaf slots pass the same shape gate as the
+		// top-level query — an object where a scalar is required is rejected.
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				// call under test
+				() -> validateAggregationLeafShapes(
+						"{\"a\":{\"filter\":{\"term\":{\"status\":{\"value\":{\"bad\":1}}}},"
+								+ "\"aggregations\":{\"inner\":{\"terms\":{\"field\":\"f\"}}}}}"));
+		assertTrue(ex.getMessage().contains("term['status'].'value'"));
+	}
+
+	@Test
+	public void testValidateAggregationLeafShapesWithFiltersKeyedObjectQueryValueRejected() throws Exception {
+		// Each named query in a keyed filters bucket passes through the query leaf-shape gate.
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				// call under test
+				() -> validateAggregationLeafShapes(
+						"{\"a\":{\"filters\":{\"filters\":{"
+								+ "\"ok\":{\"term\":{\"status\":{\"value\":\"y\"}}},"
+								+ "\"bad\":{\"term\":{\"status\":{\"value\":{\"nested\":1}}}}}}}}"));
+		assertTrue(ex.getMessage().contains("term['status'].'value'"));
+	}
+
+	@Test
+	public void testValidateAggregationLeafShapesWithFiltersArrayObjectQueryValueRejected() throws Exception {
+		// The array (non-keyed) filters form is gated the same way.
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				// call under test
+				() -> validateAggregationLeafShapes(
+						"{\"a\":{\"filters\":{\"filters\":["
+								+ "{\"term\":{\"status\":{\"value\":\"y\"}}},"
+								+ "{\"term\":{\"status\":{\"value\":{\"nested\":1}}}}]}}}"));
+		assertTrue(ex.getMessage().contains("term['status'].'value'"));
 	}
 
 	// -----------------------------------------------------------------------------

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchFieldRewriterTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchFieldRewriterTest.java
@@ -823,6 +823,59 @@ public class SearchFieldRewriterTest {
 		assertEquals("title", dsl.get("by_title").get("terms").get("field").asText());
 	}
 
+	@Test
+	public void testRewriteRequestFieldsWithFilterAggDescendsAsQuerySurface() throws IOException {
+		// A filter aggregation's body is a Query subtree; the walker must switch to the query surface
+		// so a term on a text column auto-routes to .keyword (the agg surface would route differently
+		// and the column-name key must still resolve to its id).
+		JsonNode dsl = parse("{\"by_status\":{"
+				+ "\"filter\":{\"term\":{\"title\":\"abc\"}},"
+				+ "\"aggregations\":{\"avg_count\":{\"avg\":{\"field\":\"count\"}}}"
+				+ "}}");
+
+		// call under test
+		SearchFieldRewriter.rewriteRequestFields(dsl, ROUTING, Surface.AGGREGATIONS);
+
+		// The filter body's term on text routes to .keyword and the column name maps to its id.
+		assertEquals("abc",
+				dsl.get("by_status").get("filter").get("term").get("100.keyword").asText());
+		// The sibling sub-aggregation still routes on the aggregations surface (numeric → bare).
+		assertEquals("102",
+				dsl.get("by_status").get("aggregations").get("avg_count").get("avg").get("field").asText());
+	}
+
+	@Test
+	public void testRewriteRequestFieldsWithFiltersKeyedDescendsAsQuerySurface() throws IOException {
+		// Each named query in a keyed filters bucket is a Query subtree routed on the query surface.
+		JsonNode dsl = parse("{\"by_status\":{\"filters\":{\"filters\":{"
+				+ "\"hits\":{\"term\":{\"title\":\"a\"}},"
+				+ "\"misses\":{\"term\":{\"name\":\"b\"}}"
+				+ "}}}}");
+
+		// call under test
+		SearchFieldRewriter.rewriteRequestFields(dsl, ROUTING, Surface.AGGREGATIONS);
+
+		JsonNode buckets = dsl.get("by_status").get("filters").get("filters");
+		assertEquals("a", buckets.get("hits").get("term").get("100.keyword").asText());
+		assertEquals("b", buckets.get("misses").get("term").get("101.keyword").asText());
+	}
+
+	@Test
+	public void testRewriteRequestFieldsWithFiltersArrayDescendsAsQuerySurface() throws IOException {
+		// The array (non-keyed) filters form descends into each query the same way.
+		JsonNode dsl = parse("{\"by_status\":{\"filters\":{\"filters\":["
+				+ "{\"term\":{\"title\":\"a\"}},"
+				+ "{\"term\":{\"name\":\"b\"}}"
+				+ "]}}}");
+
+		// call under test
+		SearchFieldRewriter.rewriteRequestFields(dsl, ROUTING, Surface.AGGREGATIONS);
+
+		JsonNode buckets = dsl.get("by_status").get("filters").get("filters");
+		assertEquals("a", buckets.get(0).get("term").get("100.keyword").asText());
+		assertEquals("b", buckets.get(1).get("term").get("101.keyword").asText());
+	}
+
 	// -----------------------------------------------------------------------------
 	// Surface enum coverage guard
 	// -----------------------------------------------------------------------------


### PR DESCRIPTION
## Use case

Synapse search facets currently can't drive a checkbox-style filter UI. When a user filters by a facet value (e.g. `Resource Type = Biobank`), the only single-query option today (`post_filter`) leaves **every** facet's aggregation computed over **all** rows — so the other columns' counts and plots don't narrow to the selection. As [Jay noted on PLFM-9638](https://sagebionetworks.jira.com/browse/PLFM-9638), that "is not a useful plot."

The desired behavior is the legacy **Query API** behavior:

- The **selected column's** facet keeps showing **all** of its possible values (so the user can broaden the selection without losing the rest of their filter state) — scoped to every *other* active selection.
- **Every other column's** facet counts **do** narrow to the current selection (a column can even drop out entirely when the matched rows have no value for it).

This is exactly what the OpenSearch [`filter` bucket aggregation](https://docs.opensearch.org/latest/aggregations/bucket/filter/) expresses, and it lets us do it in **one** query instead of one HTTP call per facet.

This PR adds the `filter` (single-bucket) and `filters` (named multi-bucket) aggregations to the set the Synapse search API accepts. `filter` was previously rejected with `400: JSON Element in Entity is Unsupported: filter` because its body is a query that needs the same query-DSL validation and column-name → column-id rewriting as a top-level `query`. This wires that in safely.

## How it meets the requested UX

Each facet is wrapped in a `filter` aggregation whose body applies **every active selection except the positive selections on that facet's own column**. The selected column therefore keeps all its options (selected ones still visible), while every other facet narrows to the filtered subset — the exact "selected column widened, other columns narrowed" behavior from Jay's comment.

### Request

A user has selected `resourceType = Biobank`. To render the facets:

- The `resourceType` facet is scoped to all *other* active selections (here, none), so it shows **all** resource types.
- The `investigatorName` facet is scoped to the `resourceType = Biobank` selection, so it narrows.

```json
{
  "concreteType": "org.sagebionetworks.repo.model.search.table.SearchIndexQuery",
  "responseParts": ["TOTAL_HITS", "HITS"],
  "searchIndexId": "syn123",
  "searchQuery": {
    "query": { "match_all": {} },
    "size": 0,
    "aggregations": {
      "resourceType_facet": {
        "filter": { "match_all": {} },
        "aggregations": {
          "values": { "terms": { "field": "resourceType", "size": 25 } }
        }
      },
      "investigatorName_facet": {
        "filter": { "term": { "resourceType": { "value": "Biobank" } } },
        "aggregations": {
          "values": { "terms": { "field": "investigatorName", "size": 25 } }
        }
      }
    }
  }
}
```

### Result

`resourceType_facet` still lists every resource type (so the UI can show `Biobank` checked and the rest unchecked), while `investigatorName_facet` is narrowed to the `Biobank` rows:

```json
{
  "aggregationResults": {
    "resourceType_facet": {
      "doc_count": 120,
      "values": {
        "buckets": [
          { "key": "Biobank", "doc_count": 4 },
          { "key": "Tool", "doc_count": 71 },
          { "key": "Dataset", "doc_count": 45 }
        ]
      }
    },
    "investigatorName_facet": {
      "doc_count": 4,
      "values": {
        "buckets": [
          { "key": "Smith, J.", "doc_count": 3 },
          { "key": "Doe, A.", "doc_count": 1 }
        ]
      }
    }
  }
}
```

The named `filters` aggregation is also supported, for one query that returns several named buckets:

```json
{
  "by_resource_type": {
    "filters": {
      "filters": {
        "biobanks": { "term": { "resourceType": { "value": "Biobank" } } },
        "tools":    { "term": { "resourceType": { "value": "Tool" } } }
      }
    }
  }
}
```

```json
{
  "by_resource_type": {
    "buckets": {
      "biobanks": { "doc_count": 4 },
      "tools":    { "doc_count": 71 }
    }
  }
}
```

## Row-level filtering

These new aggregations are explicitly designed to **respect the global query scope and the planned row-level ACL filter**:

- The caller's query is wrapped server-side as `bool.must(query)` in `SearchOpaqueJsonUtil.applyBodyToRequest()`. That `bool.must` is the single chokepoint where the future server-side row-level ACL filter will be injected.
- An OpenSearch `filter` / `filters` aggregation runs **inside** the current search context, so it inherits that top-level `bool.must` (including the future ACL clause). A `filter` aggregation can therefore never count documents the top-level query — or the ACL filter — excludes.
- The closely-related `global` aggregation deliberately **escapes** the search context and would aggregate over *all* documents, bypassing row-level ACLs. `global` is **not** added to the allowlist and is documented as intentionally excluded; it is not a property of any generated search POJO, so it can only ever arrive as an unknown key and is rejected at the HTTP boundary.
- The embedded `filter` query body goes through the **exact same** validation as a top-level query — clause/depth caps (sharing the query's clause budget), the kind allowlist, leading-wildcard and cross-index `terms`-lookup rejections, and the opaque leaf-shape gate — so a caller cannot smuggle a disallowed clause inside a `filter` body.

This invariant is locked in by a new autowired test against real AOSS (`OpenSearchManagerImplAutoWiredTest#testFilterAggregationRespectsTopLevelQueryScope`): it indexes public and private rows that share a tag, restricts the top-level query to the public rows (simulating the future ACL clause), and asserts the `filter` aggregation counts only the in-scope row — never the excluded private one.
