### PR TITLE
[PLFM-9726] Fix SearchIndex stuck in CREATING when AOSS convergence probe times out

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/ITSearchQueryTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITSearchQueryTest.java
@@ -61,6 +61,7 @@ import org.sagebionetworks.repo.model.search.dsl.TermFieldOptions;
 import org.sagebionetworks.repo.model.search.dsl.TermsAggregation;
 import org.sagebionetworks.repo.model.search.table.SearchAutocompleteRequest;
 import org.sagebionetworks.repo.model.search.table.SearchIndexQuery;
+import org.sagebionetworks.util.TimeUtils;
 
 /**
  * Integration tests for the SearchIndex query path.
@@ -420,8 +421,13 @@ public class ITSearchQueryTest {
 						.setQuery(new Query().setMatch_bool_prefix(
 								Map.of("geneName", new MatchBoolPrefixFieldOptions().setQuery("BRC")))));
 
-		// call under test
-		SearchQueryResults autocompleteResults = synapse.searchAutocomplete(autocompleteRequest);
+		// call under test — AOSS is eventually consistent per query type and per replica, so
+		// the match_all wait above does not guarantee this match_bool_prefix autocomplete sees
+		// every document yet. Poll the autocomplete itself until both BRCA hits surface.
+		SearchQueryResults autocompleteResults = waitForQuery(
+			() -> synapse.searchAutocomplete(autocompleteRequest),
+			r -> r.getHits() != null && r.getHits().size() >= 2,
+			"at least 2 autocomplete hits for 'BRC' (BRCA1, BRCA2)");
 		assertNotNull(autocompleteResults);
 		assertNotNull(autocompleteResults.getHits());
 		assertTrue(autocompleteResults.getHits().size() >= 2,
@@ -451,6 +457,44 @@ public class ITSearchQueryTest {
 		String message = assertThrows(SynapseBadRequestException.class,
 				() -> synapse.startSearchIndexQuery(request)).getMessage();
 		assertEquals("JSON Element in Entity is Unsupported: notPartOfSpecification", message);
+	}
+
+	/**
+	 * A search/autocomplete call against the live cluster that may throw {@link SynapseException}.
+	 */
+	@FunctionalInterface
+	private interface QueryCall {
+		SearchQueryResults call() throws SynapseException;
+	}
+
+	/**
+	 * Poll a synchronous search/autocomplete call until {@code condition} holds, then return the
+	 * matching result. AOSS is eventually consistent per query type and per replica, so a freshly
+	 * built index that already answers a {@code match_all} probe may transiently under-return for a
+	 * different query shape (autocomplete, match, post_filter). Tests asserting on a specific
+	 * synchronous query must poll that exact query rather than trusting a prior wait. Mirrors the
+	 * {@code waitForSearch}/{@code waitForSearchHits} helpers in {@code OpenSearchManagerImplAutoWiredTest}.
+	 *
+	 * @param queryCall   the call under test
+	 * @param condition   the readiness predicate on the result (e.g. expected hit count reached)
+	 * @param description what is being waited for, used in the timeout message
+	 * @return the result that satisfied {@code condition}
+	 */
+	private SearchQueryResults waitForQuery(QueryCall queryCall,
+			java.util.function.Predicate<SearchQueryResults> condition, String description) {
+		SearchQueryResults[] holder = { null };
+		boolean ready = TimeUtils.waitForExponential(MAX_QUERY_TIMEOUT_MS, 1000L, null, (v) -> {
+			try {
+				SearchQueryResults r = queryCall.call();
+				holder[0] = r;
+				return r != null && condition.test(r);
+			} catch (SynapseException e) {
+				// index_not_found / still-propagating — keep polling
+				return false;
+			}
+		});
+		assertTrue(ready, "Timed out waiting for " + description);
+		return holder[0];
 	}
 
 	private void grantPublicRead(String entityId) throws SynapseException {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManager.java
@@ -107,13 +107,16 @@ public interface OpenSearchManager {
 	 * <p>No-op when {@code expectedCount == 0} — an empty index reports zero immediately
 	 * and skipping the call avoids an unnecessary round-trip.</p>
 	 *
+	 * <p>If the index does not converge within the retry budget, a warning is logged and
+	 * the method returns normally — the index is flipped to ACTIVE and AOSS will
+	 * self-correct as writes propagate. This avoids re-running the full bulk-index
+	 * operation on SQS retry for large indexes whose propagation lag exceeds the probe
+	 * budget.</p>
+	 *
 	 * @param indexName     the OpenSearch index name
 	 * @param expectedCount the document count the index must reach before returning
-	 * @throws RecoverableMessageException when the index does not converge within the
-	 *         retry budget, so the SearchIndex lifecycle message goes back on SQS for a
-	 *         later attempt instead of being marked permanently FAILED
 	 */
-	void waitForDocumentCount(String indexName, long expectedCount) throws RecoverableMessageException;
+	void waitForDocumentCount(String indexName, long expectedCount);
 
 	/**
 	 * Execute a search query against the OpenSearch index. The {@code options} set controls

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManager.java
@@ -94,31 +94,6 @@ public interface OpenSearchManager {
 	void waitForIndexWritable(String indexName) throws RecoverableMessageException;
 
 	/**
-	 * Block until {@code indexName} reports a document count of at least
-	 * {@code expectedCount}. AOSS is eventually consistent: a {@code bulkIndex} call can
-	 * return success while the documents are not yet visible to {@code _search} or
-	 * {@code _count}. Polling {@code _count} (allowed on AOSS under
-	 * {@code aoss:ReadDocument}) is the only convergence signal available.
-	 *
-	 * <p>The comparison is {@code actual >= expectedCount} rather than strict equality so
-	 * a leftover readiness-probe sentinel (whose cleanup is best-effort, see
-	 * {@link #waitForIndexWritable}) does not strand convergence one short.</p>
-	 *
-	 * <p>No-op when {@code expectedCount == 0} — an empty index reports zero immediately
-	 * and skipping the call avoids an unnecessary round-trip.</p>
-	 *
-	 * <p>If the index does not converge within the retry budget, a warning is logged and
-	 * the method returns normally — the index is flipped to ACTIVE and AOSS will
-	 * self-correct as writes propagate. This avoids re-running the full bulk-index
-	 * operation on SQS retry for large indexes whose propagation lag exceeds the probe
-	 * budget.</p>
-	 *
-	 * @param indexName     the OpenSearch index name
-	 * @param expectedCount the document count the index must reach before returning
-	 */
-	void waitForDocumentCount(String indexName, long expectedCount);
-
-	/**
 	 * Execute a search query against the OpenSearch index. The {@code options} set controls
 	 * which sections of the OpenSearch request are populated: omitting HITS switches the
 	 * request to {@code size=0}, and omitting TOTAL_HITS disables total-hits tracking.

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -30,8 +30,6 @@ import org.opensearch.client.opensearch._types.mapping.DynamicMapping;
 import org.opensearch.client.opensearch._types.mapping.Property;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
-import org.opensearch.client.opensearch.core.CountRequest;
-import org.opensearch.client.opensearch.core.CountResponse;
 import org.opensearch.client.opensearch.core.DeleteRequest;
 import org.opensearch.client.opensearch.core.IndexRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
@@ -104,13 +102,6 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	// 400s on legitimate analyzers.
 	static int VALIDATE_MAX_RETRIES = 10;
 	static long VALIDATE_INITIAL_BACKOFF_MS = 1000L;
-
-	// Convergence probe for a freshly-finished bulk index. AOSS acknowledges bulk writes
-	// before the documents are visible to _search or _count, so we poll _count until the
-	// index reports the expected number of documents. Same budget as the writability probe
-	// for consistency. Non-final so unit tests can lower the values and avoid real sleeps.
-	static int COUNT_PROBE_MAX_RETRIES = 10;
-	static long COUNT_PROBE_INITIAL_BACKOFF_MS = 10000L;
 
 	// Cleanup retry for the readiness-probe sentinel. AOSS doesn't honor refresh=wait_for,
 	// so a single delete that fails on a transient network blip would orphan the sentinel
@@ -540,52 +531,6 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		} catch (Exception e) {
 			LOG.warn("Failed to delete readiness probe document from index {} after {} attempts: {}",
 					indexName, SENTINEL_CLEANUP_MAX_RETRIES, e.getMessage());
-		}
-	}
-
-	@Override
-	public void waitForDocumentCount(String indexName, long expectedCount) {
-		// Empty indexes report zero immediately; skip the round-trip.
-		if (expectedCount <= 0L) {
-			return;
-		}
-		final int[] attempt = {0};
-		final long[] lastObserved = {-1L};
-		try {
-			TimeUtils.waitForExponentialMaxRetry(COUNT_PROBE_MAX_RETRIES, COUNT_PROBE_INITIAL_BACKOFF_MS,
-					() -> {
-						attempt[0]++;
-						try {
-							CountResponse response = openSearchClient.count(CountRequest.of(r -> r
-									.index(indexName)));
-							long actual = response.count();
-							lastObserved[0] = actual;
-							// >= rather than == so a leftover readiness-probe sentinel cannot
-							// permanently strand convergence one short.
-							if (actual >= expectedCount) {
-								return Boolean.TRUE;
-							}
-							LOG.warn("Index {} not yet converged (attempt {}/{}): {} of {} documents visible",
-									indexName, attempt[0], COUNT_PROBE_MAX_RETRIES, actual, expectedCount);
-							throw new RetryException("count " + actual + " of " + expectedCount);
-						} catch (OpenSearchException e) {
-							LOG.warn("Index {} count probe failed (attempt {}/{}): {}",
-									indexName, attempt[0], COUNT_PROBE_MAX_RETRIES, describeError(e.error()));
-							throw new RetryException(e);
-						} catch (IOException e) {
-							LOG.warn("Index {} count probe failed (attempt {}/{}): {}",
-									indexName, attempt[0], COUNT_PROBE_MAX_RETRIES, e.getMessage());
-							throw new RetryException(e);
-						}
-					});
-		} catch (RetryException e) {
-			LOG.warn("Index {} did not converge to expected count after {} attempts ({} of {}); "
-					+ "flipping to ACTIVE — AOSS will self-correct as writes propagate",
-					indexName, COUNT_PROBE_MAX_RETRIES, lastObserved[0], expectedCount);
-		} catch (RuntimeException e) {
-			throw e;
-		} catch (Exception e) {
-			throw new RuntimeException("Failed convergence probe for search index: " + indexName, e);
 		}
 	}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -544,7 +544,7 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	}
 
 	@Override
-	public void waitForDocumentCount(String indexName, long expectedCount) throws RecoverableMessageException {
+	public void waitForDocumentCount(String indexName, long expectedCount) {
 		// Empty indexes report zero immediately; skip the round-trip.
 		if (expectedCount <= 0L) {
 			return;
@@ -579,12 +579,9 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 						}
 					});
 		} catch (RetryException e) {
-			LOG.error("Index {} did not converge to expected count after {} attempts ({} of {})",
+			LOG.warn("Index {} did not converge to expected count after {} attempts ({} of {}); "
+					+ "flipping to ACTIVE — AOSS will self-correct as writes propagate",
 					indexName, COUNT_PROBE_MAX_RETRIES, lastObserved[0], expectedCount);
-			throw new RecoverableMessageException(
-					"AOSS index " + indexName + " did not converge to expected count ("
-							+ lastObserved[0] + " of " + expectedCount + ") within the retry budget",
-					e.getCause());
 		} catch (RuntimeException e) {
 			throw e;
 		} catch (Exception e) {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
@@ -313,13 +313,6 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 			// failure is not in the search index's configuration.
 			throw e;
 		} catch (Throwable e) {
-			// SearchIndexRowHandler.close() tunnels RecoverableMessageException through
-			// IOException because RowHandler.close() can't declare anything else. Unwrap
-			// here so a convergence-probe timeout reaches the do-not-mark-FAILED branch
-			// above on retry instead of permanently failing the index.
-			if (e instanceof IOException && e.getCause() instanceof RecoverableMessageException) {
-				throw (RecoverableMessageException) e.getCause();
-			}
 			// Another worker is currently deleting this same AOSS index. Translate
 			// to a recoverable SQS retry: by the time the retry runs, the winning
 			// delete has finished and our deleteIndex on retry no-ops via
@@ -616,17 +609,7 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 		@Override
 		public void close() throws IOException {
 			flush();
-			// AOSS bulk writes acknowledge before the documents are visible to _search or
-			// _count. Block until the index reports the row count we streamed, so the
-			// SearchIndex isn't flipped to ACTIVE while a query would still under-return.
-			try {
-				client.waitForDocumentCount(indexName, totalRows);
-			} catch (RecoverableMessageException e) {
-				// RowHandler.close() can only declare IOException; tunnel the recoverable
-				// signal through it. The lifecycle build path unwraps before its FAILED
-				// branch so the message goes back on SQS instead of marking the index FAILED.
-				throw new IOException(e);
-			}
+			client.waitForDocumentCount(indexName, totalRows);
 		}
 	}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImpl.java
@@ -609,7 +609,6 @@ public class SearchIndexLifecycleManagerImpl implements SearchIndexLifecycleMana
 		@Override
 		public void close() throws IOException {
 			flush();
-			client.waitForDocumentCount(indexName, totalRows);
 		}
 	}
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -1236,9 +1236,10 @@ public class OpenSearchManagerImplAutoWiredTest {
 				.setSize(10L)
 				.setFrom(0L);
 
-		// call under test — post_filter narrows hits; aggregations stay at full population
-		SearchQueryResults results = openSearchManager.search(indexName, body, columns,
-				EnumSet.of(SearchQueryPart.HITS, SearchQueryPart.TOTAL_HITS));
+		// call under test — post_filter narrows hits; aggregations stay at full population.
+		// Poll until post_filter returns the expected 2 ACTIVE hits.
+		SearchQueryResults results = waitForSearchHits(body, columns,
+				EnumSet.of(SearchQueryPart.HITS, SearchQueryPart.TOTAL_HITS), 2);
 
 		assertEquals(2L, results.getTotalHits(),
 				"totalHits must reflect post_filter narrowing — only ACTIVE rows");
@@ -1285,9 +1286,10 @@ public class OpenSearchManagerImplAutoWiredTest {
 				.setSize(10L)
 				.setFrom(0L);
 
-		// call under test — highlight payload round-trips and SearchHit.highlights is populated
-		SearchQueryResults results = openSearchManager.search(indexName, body, columns,
-				EnumSet.of(SearchQueryPart.HITS, SearchQueryPart.TOTAL_HITS));
+		// call under test — highlight payload round-trips and SearchHit.highlights is populated.
+		// Poll until the match query returns all 3 hits.
+		SearchQueryResults results = waitForSearchHits(body, columns,
+				EnumSet.of(SearchQueryPart.HITS, SearchQueryPart.TOTAL_HITS), 3);
 
 		assertEquals(3L, results.getTotalHits());
 		assertNotNull(results.getHits());

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -1765,19 +1765,16 @@ public class OpenSearchManagerImplTest {
 	}
 
 	@Test
-	public void testWaitForDocumentCountExhaustsRetriesAndThrowsRecoverableMessageException() throws Exception {
+	public void testWaitForDocumentCountExhaustsRetriesAndLogsWarning() throws Exception {
 		// Persistent under-count: every attempt sees fewer documents than expected. The probe
-		// must throw RecoverableMessageException so the lifecycle worker re-queues the message
-		// without writing FAILED — convergence is transient by definition.
+		// exhausts its retry budget, logs a warning, and returns normally — the index is
+		// flipped to ACTIVE so AOSS can self-correct as writes propagate.
 		when(openSearchClient.count(any(org.opensearch.client.opensearch.core.CountRequest.class)))
 				.thenReturn(countResponse(2L));
 
-		// call under test
-		RecoverableMessageException ex = assertThrows(RecoverableMessageException.class,
-				() -> manager.waitForDocumentCount("search-index-syn1", 5L));
+		// call under test — must not throw
+		manager.waitForDocumentCount("search-index-syn1", 5L);
 
-		assertTrue(ex.getMessage().contains("did not converge"), ex.getMessage());
-		assertTrue(ex.getMessage().contains("2 of 5"), ex.getMessage());
 		verify(openSearchClient, times(OpenSearchManagerImpl.COUNT_PROBE_MAX_RETRIES))
 				.count(any(org.opensearch.client.opensearch.core.CountRequest.class));
 	}
@@ -1787,9 +1784,8 @@ public class OpenSearchManagerImplTest {
 		when(openSearchClient.count(any(org.opensearch.client.opensearch.core.CountRequest.class)))
 				.thenThrow(new IOException("connection reset"));
 
-		// call under test
-		assertThrows(RecoverableMessageException.class,
-				() -> manager.waitForDocumentCount("search-index-syn1", 5L));
+		// call under test — must not throw; probe errors are treated as transient under-counts
+		manager.waitForDocumentCount("search-index-syn1", 5L);
 
 		verify(openSearchClient, times(OpenSearchManagerImpl.COUNT_PROBE_MAX_RETRIES))
 				.count(any(org.opensearch.client.opensearch.core.CountRequest.class));
@@ -1805,9 +1801,8 @@ public class OpenSearchManagerImplTest {
 		when(openSearchClient.count(any(org.opensearch.client.opensearch.core.CountRequest.class)))
 				.thenThrow(new OpenSearchException(notFound));
 
-		// call under test
-		assertThrows(RecoverableMessageException.class,
-				() -> manager.waitForDocumentCount("search-index-syn1", 5L));
+		// call under test — must not throw; probe errors are treated as transient under-counts
+		manager.waitForDocumentCount("search-index-syn1", 5L);
 
 		verify(openSearchClient, times(OpenSearchManagerImpl.COUNT_PROBE_MAX_RETRIES))
 				.count(any(org.opensearch.client.opensearch.core.CountRequest.class));

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -136,7 +136,6 @@ public class OpenSearchManagerImplTest {
 
 	private long originalBulkInitialBackoffMs;
 	private long originalProbeInitialBackoffMs;
-	private long originalCountProbeInitialBackoffMs;
 	private long originalSentinelCleanupInitialBackoffMs;
 
 	@BeforeEach
@@ -147,8 +146,6 @@ public class OpenSearchManagerImplTest {
 		OpenSearchManagerImpl.BULK_INDEX_INITIAL_BACKOFF_MS = 1L;
 		originalProbeInitialBackoffMs = OpenSearchManagerImpl.INDEX_WRITABLE_INITIAL_BACKOFF_MS;
 		OpenSearchManagerImpl.INDEX_WRITABLE_INITIAL_BACKOFF_MS = 1L;
-		originalCountProbeInitialBackoffMs = OpenSearchManagerImpl.COUNT_PROBE_INITIAL_BACKOFF_MS;
-		OpenSearchManagerImpl.COUNT_PROBE_INITIAL_BACKOFF_MS = 1L;
 		originalSentinelCleanupInitialBackoffMs = OpenSearchManagerImpl.SENTINEL_CLEANUP_INITIAL_BACKOFF_MS;
 		OpenSearchManagerImpl.SENTINEL_CLEANUP_INITIAL_BACKOFF_MS = 1L;
 	}
@@ -157,7 +154,6 @@ public class OpenSearchManagerImplTest {
 	public void tearDown() {
 		OpenSearchManagerImpl.BULK_INDEX_INITIAL_BACKOFF_MS = originalBulkInitialBackoffMs;
 		OpenSearchManagerImpl.INDEX_WRITABLE_INITIAL_BACKOFF_MS = originalProbeInitialBackoffMs;
-		OpenSearchManagerImpl.COUNT_PROBE_INITIAL_BACKOFF_MS = originalCountProbeInitialBackoffMs;
 		OpenSearchManagerImpl.SENTINEL_CLEANUP_INITIAL_BACKOFF_MS = originalSentinelCleanupInitialBackoffMs;
 	}
 
@@ -1716,112 +1712,6 @@ public class OpenSearchManagerImplTest {
 
 		verify(openSearchClient, times(1)).index(argThat((IndexRequest<?> req) -> req != null));
 		verify(openSearchClient, times(2)).delete(argThat((DeleteRequest req) -> req != null));
-	}
-
-	// --- waitForDocumentCount ---
-
-	@Test
-	public void testWaitForDocumentCountWithImmediateMatchReturns() throws Exception {
-		// Happy path: AOSS reports the expected count on the first attempt; no retry, no log noise.
-		when(openSearchClient.count(any(org.opensearch.client.opensearch.core.CountRequest.class)))
-				.thenReturn(org.opensearch.client.opensearch.core.CountResponse.of(b -> b
-						.count(5L)
-						.shards(s -> s.total(1).successful(1).failed(0))));
-
-		// call under test
-		manager.waitForDocumentCount("search-index-syn1", 5L);
-
-		verify(openSearchClient, times(1))
-				.count(any(org.opensearch.client.opensearch.core.CountRequest.class));
-	}
-
-	@Test
-	public void testWaitForDocumentCountConvergesAfterUnderCount() throws Exception {
-		// AOSS is eventually consistent: the first probe sees fewer documents than were
-		// bulk-indexed; the second sees the full count and returns.
-		when(openSearchClient.count(any(org.opensearch.client.opensearch.core.CountRequest.class)))
-				.thenReturn(countResponse(2L))
-				.thenReturn(countResponse(5L));
-
-		// call under test
-		manager.waitForDocumentCount("search-index-syn1", 5L);
-
-		verify(openSearchClient, times(2))
-				.count(any(org.opensearch.client.opensearch.core.CountRequest.class));
-	}
-
-	@Test
-	public void testWaitForDocumentCountTreatsExcessAsConverged() throws Exception {
-		// >= rather than == so a leftover readiness-probe sentinel cannot strand convergence
-		// one short. An excess count is therefore a successful return, not a retry.
-		when(openSearchClient.count(any(org.opensearch.client.opensearch.core.CountRequest.class)))
-				.thenReturn(countResponse(6L));
-
-		// call under test
-		manager.waitForDocumentCount("search-index-syn1", 5L);
-
-		verify(openSearchClient, times(1))
-				.count(any(org.opensearch.client.opensearch.core.CountRequest.class));
-	}
-
-	@Test
-	public void testWaitForDocumentCountExhaustsRetriesAndLogsWarning() throws Exception {
-		// Persistent under-count: every attempt sees fewer documents than expected. The probe
-		// exhausts its retry budget, logs a warning, and returns normally — the index is
-		// flipped to ACTIVE so AOSS can self-correct as writes propagate.
-		when(openSearchClient.count(any(org.opensearch.client.opensearch.core.CountRequest.class)))
-				.thenReturn(countResponse(2L));
-
-		// call under test — must not throw
-		manager.waitForDocumentCount("search-index-syn1", 5L);
-
-		verify(openSearchClient, times(OpenSearchManagerImpl.COUNT_PROBE_MAX_RETRIES))
-				.count(any(org.opensearch.client.opensearch.core.CountRequest.class));
-	}
-
-	@Test
-	public void testWaitForDocumentCountWithIOExceptionExhaustsRetries() throws Exception {
-		when(openSearchClient.count(any(org.opensearch.client.opensearch.core.CountRequest.class)))
-				.thenThrow(new IOException("connection reset"));
-
-		// call under test — must not throw; probe errors are treated as transient under-counts
-		manager.waitForDocumentCount("search-index-syn1", 5L);
-
-		verify(openSearchClient, times(OpenSearchManagerImpl.COUNT_PROBE_MAX_RETRIES))
-				.count(any(org.opensearch.client.opensearch.core.CountRequest.class));
-	}
-
-	@Test
-	public void testWaitForDocumentCountWithOpenSearchExceptionExhaustsRetries() throws Exception {
-		// AOSS may briefly return index_not_found_exception (or any other transient error) from
-		// _count while shards are still propagating the freshly-written documents.
-		ErrorResponse notFound = ErrorResponse.of(er -> er
-				.error(ErrorCause.of(e -> e.type("index_not_found_exception").reason("no such index")))
-				.status(404));
-		when(openSearchClient.count(any(org.opensearch.client.opensearch.core.CountRequest.class)))
-				.thenThrow(new OpenSearchException(notFound));
-
-		// call under test — must not throw; probe errors are treated as transient under-counts
-		manager.waitForDocumentCount("search-index-syn1", 5L);
-
-		verify(openSearchClient, times(OpenSearchManagerImpl.COUNT_PROBE_MAX_RETRIES))
-				.count(any(org.opensearch.client.opensearch.core.CountRequest.class));
-	}
-
-	@Test
-	public void testWaitForDocumentCountWithZeroExpectedShortCircuits() throws Exception {
-		// An empty SearchIndex needs no probe — _count would just return 0 and we'd skip the
-		// retry path anyway. Avoid the round-trip entirely.
-		// call under test
-		manager.waitForDocumentCount("search-index-syn1", 0L);
-
-		verifyZeroInteractions(openSearchClient);
-	}
-
-	private static org.opensearch.client.opensearch.core.CountResponse countResponse(long count) {
-		return org.opensearch.client.opensearch.core.CountResponse.of(b -> b
-				.count(count)
-				.shards(s -> s.total(1).successful(1).failed(0)));
 	}
 
 	// --- per-document fallback on partial batch failure ---

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImplTest.java
@@ -7,10 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -590,37 +588,6 @@ public class SearchIndexLifecycleManagerImplTest {
 		verify(tableQueryManager, never()).runQueryAsStream(any(), any(), any(), any(), any());
 	}
 
-	@Test
-	public void testHandleCreateWithConvergenceProbeTimeoutFlipsToActive() throws Exception {
-		// waitForDocumentCount now returns normally on timeout (logs warn, flips to ACTIVE).
-		// The build path should complete successfully — no exception, no FAILED state.
-		UserInfo triggering = triggeringUser();
-		SearchIndex searchIndex = new SearchIndex();
-		searchIndex.setDefiningSQL(DEFINING_SQL);
-		searchIndex.setParentId("syn100");
-
-		stubBuildLock();
-		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
-		when(userManager.getUserInfo(USER_ID)).thenReturn(triggering);
-		when(userManager.getUserInfo(ANON_ID)).thenReturn(anonymousUser());
-		when(entityManager.getEntity(triggering, ENTITY_ID, SearchIndex.class)).thenReturn(searchIndex);
-		when(tableManagerSupport.getTableSchema(IdAndVersion.parse(ENTITY_ID)))
-				.thenReturn(Collections.singletonList(
-						new ColumnModel().setId("100").setName("name").setColumnType(ColumnType.STRING)));
-		when(searchConfigurationResolver.resolve(any(), any(), any())).thenReturn(Optional.empty());
-		when(tableQueryManager.querySinglePage(any(), any(), any(), any()))
-				.thenReturn(new QueryResultBundle().setQueryCount(0L));
-
-		// call under test
-		manager.handleCreate(progressCallback, ENTITY_ID, USER_ID);
-
-		// Index is flipped to ACTIVE despite the probe timeout.
-		ArgumentCaptor<SearchIndexStatus> captor = ArgumentCaptor.forClass(SearchIndexStatus.class);
-		verify(statusDao, atLeastOnce()).createOrUpdate(captor.capture());
-		assertTrue(captor.getAllValues().stream().anyMatch(s -> s.getState() == SearchIndexState.ACTIVE),
-				"index must be flipped to ACTIVE when convergence probe times out");
-	}
-
 	// -------- SearchIndexRowHandler tests --------
 
 	@Test
@@ -709,62 +676,6 @@ public class SearchIndexLifecycleManagerImplTest {
 		handler.close();
 
 		verify(openSearchManager, never()).bulkIndex(any(), any());
-		// The convergence probe is still called (with 0L); the short-circuit lives inside
-		// OpenSearchManagerImpl.waitForDocumentCount so it can no-op without a round-trip,
-		// but the row handler doesn't try to second-guess that decision.
-		verify(openSearchManager).waitForDocumentCount("test-index", 0L);
-	}
-
-	@Test
-	public void testRowHandlerCloseProbesDocumentCountWithStreamedRows() throws IOException {
-		// AOSS bulk writes acknowledge before documents are visible. After the final flush,
-		// close() must wait for _count to converge to the streamed row total before returning,
-		// otherwise the lifecycle manager would flip the SearchIndex to ACTIVE while a query
-		// would still under-return.
-		SelectColumn col = new SelectColumn();
-		col.setId("100");
-		col.setColumnType(ColumnType.STRING);
-		SearchIndexRowHandler handler = new SearchIndexRowHandler(
-				"test-index", Collections.singletonList(col), openSearchManager);
-
-		for (long i = 1; i <= 3; i++) {
-			Row row = new Row();
-			row.setRowId(i);
-			row.setVersionNumber(1L);
-			row.setValues(Collections.singletonList("v" + i));
-			handler.nextRow(row);
-		}
-
-		// call under test
-		handler.close();
-
-		org.mockito.InOrder order = org.mockito.Mockito.inOrder(openSearchManager);
-		order.verify(openSearchManager).bulkIndex(eq("test-index"), any());
-		order.verify(openSearchManager).waitForDocumentCount("test-index", 3L);
-	}
-
-	@Test
-	public void testRowHandlerCloseCompletesNormallyWhenProbeTimesOut() throws Exception {
-		// waitForDocumentCount returns normally on timeout (logs warn, no throw). close()
-		// must also complete normally — the index will be flipped to ACTIVE by the caller.
-		SelectColumn col = new SelectColumn();
-		col.setId("100");
-		col.setColumnType(ColumnType.STRING);
-		SearchIndexRowHandler handler = new SearchIndexRowHandler(
-				"test-index", Collections.singletonList(col), openSearchManager);
-
-		Row row = new Row();
-		row.setRowId(1L);
-		row.setVersionNumber(1L);
-		row.setValues(Collections.singletonList("v"));
-		handler.nextRow(row);
-
-		doNothing().when(openSearchManager).waitForDocumentCount("test-index", 1L);
-
-		// call under test — must not throw
-		handler.close();
-
-		verify(openSearchManager).waitForDocumentCount("test-index", 1L);
 	}
 
 	// Locks in the row handler's behavior when a SelectColumn has a null id: the

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchIndexLifecycleManagerImplTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -590,11 +591,9 @@ public class SearchIndexLifecycleManagerImplTest {
 	}
 
 	@Test
-	public void testHandleCreateUnwrapsConvergenceProbeRecoverableFromIOException() throws Exception {
-		// SearchIndexRowHandler.close() tunnels RecoverableMessageException through IOException
-		// because RowHandler.close() can't declare anything else. The build path must unwrap
-		// before the FAILED branch — convergence-timeout is transient and re-running the
-		// SQS message will rebuild from scratch.
+	public void testHandleCreateWithConvergenceProbeTimeoutFlipsToActive() throws Exception {
+		// waitForDocumentCount now returns normally on timeout (logs warn, flips to ACTIVE).
+		// The build path should complete successfully — no exception, no FAILED state.
 		UserInfo triggering = triggeringUser();
 		SearchIndex searchIndex = new SearchIndex();
 		searchIndex.setDefiningSQL(DEFINING_SQL);
@@ -611,20 +610,15 @@ public class SearchIndexLifecycleManagerImplTest {
 		when(searchConfigurationResolver.resolve(any(), any(), any())).thenReturn(Optional.empty());
 		when(tableQueryManager.querySinglePage(any(), any(), any(), any()))
 				.thenReturn(new QueryResultBundle().setQueryCount(0L));
-		RecoverableMessageException convergenceFailed = new RecoverableMessageException(
-				"AOSS index search-index-" + ENTITY_ID + " did not converge to expected count (3 of 5) within the retry budget");
-		doThrow(new IOException(convergenceFailed))
-				.when(tableQueryManager).runQueryAsStream(any(), any(), any(), any(), any());
 
 		// call under test
-		RecoverableMessageException thrown = assertThrows(RecoverableMessageException.class,
-				() -> manager.handleCreate(progressCallback, ENTITY_ID, USER_ID));
-		assertSame(convergenceFailed, thrown);
+		manager.handleCreate(progressCallback, ENTITY_ID, USER_ID);
 
-		// Only CREATING was recorded; the index is not flipped to FAILED.
+		// Index is flipped to ACTIVE despite the probe timeout.
 		ArgumentCaptor<SearchIndexStatus> captor = ArgumentCaptor.forClass(SearchIndexStatus.class);
-		verify(statusDao).createOrUpdate(captor.capture());
-		assertEquals(SearchIndexState.CREATING, captor.getValue().getState());
+		verify(statusDao, atLeastOnce()).createOrUpdate(captor.capture());
+		assertTrue(captor.getAllValues().stream().anyMatch(s -> s.getState() == SearchIndexState.ACTIVE),
+				"index must be flipped to ACTIVE when convergence probe times out");
 	}
 
 	// -------- SearchIndexRowHandler tests --------
@@ -750,10 +744,9 @@ public class SearchIndexLifecycleManagerImplTest {
 	}
 
 	@Test
-	public void testRowHandlerCloseTunnelsRecoverableThroughIOException() throws Exception {
-		// A convergence-probe timeout returns a RecoverableMessageException. RowHandler.close()
-		// can only declare IOException, so the recoverable signal is wrapped — the lifecycle
-		// build path unwraps before its FAILED branch.
+	public void testRowHandlerCloseCompletesNormallyWhenProbeTimesOut() throws Exception {
+		// waitForDocumentCount returns normally on timeout (logs warn, no throw). close()
+		// must also complete normally — the index will be flipped to ACTIVE by the caller.
 		SelectColumn col = new SelectColumn();
 		col.setId("100");
 		col.setColumnType(ColumnType.STRING);
@@ -766,13 +759,12 @@ public class SearchIndexLifecycleManagerImplTest {
 		row.setValues(Collections.singletonList("v"));
 		handler.nextRow(row);
 
-		RecoverableMessageException probeFailed = new RecoverableMessageException(
-				"AOSS index test-index did not converge to expected count (0 of 1) within the retry budget");
-		doThrow(probeFailed).when(openSearchManager).waitForDocumentCount("test-index", 1L);
+		doNothing().when(openSearchManager).waitForDocumentCount("test-index", 1L);
 
-		// call under test
-		IOException thrown = assertThrows(IOException.class, handler::close);
-		assertSame(probeFailed, thrown.getCause());
+		// call under test — must not throw
+		handler.close();
+
+		verify(openSearchManager).waitForDocumentCount("test-index", 1L);
 	}
 
 	// Locks in the row handler's behavior when a SelectColumn has a null id: the
@@ -1145,8 +1137,8 @@ public class SearchIndexLifecycleManagerImplTest {
 
 	@Test
 	public void testHandleCreateWithIOExceptionWithoutRecoverableCauseMarksFailed() throws Exception {
-		// L311: instanceof IOException but cause is NOT RecoverableMessageException — falls
-		// through to the FAILED-marking path. The IOException itself is swallowed.
+		// An IOException from the stream is a genuine build failure — falls through to
+		// the FAILED-marking path. The IOException itself is swallowed.
 		stubHappyPathThroughCreateIndex();
 		doThrow(new IOException("disk full"))
 				.when(tableQueryManager).runQueryAsStream(any(), any(), any(), any(), any());
@@ -1538,42 +1530,6 @@ public class SearchIndexLifecycleManagerImplTest {
 
 	// -------- buildIndex error-unwrap branches --------
 
-	@Test
-	public void testHandleCreateUnwrapsIOExceptionWrappingRecoverableMessageException() throws Exception {
-		// SearchIndexRowHandler tunnels RecoverableMessageException through IOException because
-		// RowHandler.close() can't declare anything else. handleCreate must unwrap to keep the
-		// retry instead of permanently FAILING the index.
-		stubBuildLock();
-		UserInfo triggering = triggeringUser();
-		SearchIndex searchIndex = new SearchIndex().setDefiningSQL(DEFINING_SQL).setParentId("syn100");
-
-		when(connectionFactory.getSearchIndexStatusDao()).thenReturn(statusDao);
-		when(userManager.getUserInfo(USER_ID)).thenReturn(triggering);
-		when(userManager.getUserInfo(ANON_ID)).thenReturn(anonymousUser());
-		when(entityManager.getEntity(triggering, ENTITY_ID, SearchIndex.class)).thenReturn(searchIndex);
-		when(tableManagerSupport.getTableSchema(IdAndVersion.parse(ENTITY_ID)))
-				.thenReturn(Collections.singletonList(
-						new ColumnModel().setId("100").setName("name").setColumnType(ColumnType.STRING)));
-		when(searchConfigurationResolver.resolve(any(), any(), any())).thenReturn(Optional.empty());
-		when(tableQueryManager.querySinglePage(any(), any(), any(), any()))
-				.thenReturn(new QueryResultBundle().setQueryCount(0L));
-		// Stream throws IOException wrapping a RecoverableMessageException — handleCreate
-		// must rethrow the inner cause.
-		IOException tunnelled = new IOException("io",
-				new RecoverableMessageException("convergence probe timed out"));
-		doThrow(tunnelled).when(tableQueryManager).runQueryAsStream(any(), any(), any(), any(), any());
-
-		assertThrows(RecoverableMessageException.class,
-				() -> manager.handleCreate(progressCallback, ENTITY_ID, USER_ID));
-
-		// Status must NOT be marked FAILED — this is transient. Only the initial CREATING
-		// status was written (no second createOrUpdate for FAILED).
-		ArgumentCaptor<SearchIndexStatus> statusCaptor = ArgumentCaptor.forClass(SearchIndexStatus.class);
-		verify(statusDao, atLeastOnce()).createOrUpdate(statusCaptor.capture());
-		assertTrue(statusCaptor.getAllValues().stream()
-				.noneMatch(s -> s.getState() == SearchIndexState.FAILED),
-				"transient errors must not mark the index FAILED");
-	}
 
 	@Test
 	public void testHandleCreateUnwrapsLockUnavailableNestedInsideAnotherException() throws Exception {


### PR DESCRIPTION
## Problem

In prod, SearchIndex entities can fail to converge and get stuck in `CREATING` indefinitely:

```
Index search-index-syn75418941 not yet converged (attempt 10/10): 1 of 52802 documents visible
Recoverable exception: AOSS index did not converge to expected count (1 of 52802) within the retry budget
```

`waitForDocumentCount` probes `_count` up to 10 times (~208s total). For large indexes, AOSS's write-to-read propagation lag exceeds that budget. On timeout it threw `RecoverableMessageException` → SQS re-delivered → after 10 redeliveries the message went to DLQ, leaving the index stuck in `CREATING` forever. Each retry also re-ran the full bulk-index operation unnecessarily.

As a result of this combined with multiple stacks using the same OCU limits, we are hitting the cap regularly:

<img width="1726" height="896" alt="image" src="https://github.com/user-attachments/assets/e8fc6d93-c0af-4c13-8245-3b68e58e049a" />


## Fix

Drop the convergence probe and expect that tests and clients handle waiting.