### PR TITLE
PLFM-9735 Retry transient index_not_found_exception during bulk index

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -679,11 +679,17 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 		} catch (OpenSearchException e) {
 			String detail = "Failed to bulk index to search index: " + indexName
 					+ " (" + describeError(e.error()) + ")";
+			String type = e.error() == null ? null : e.error().type();
 			// status() == 0 indicates the transport never produced an HTTP response (e.g.
 			// the AWS SDK 2 transport surfaced a connection-level failure as
 			// OpenSearchException rather than IOException). Treat the same as a 5xx —
-			// transient, retryable.
-			if (e.status() == 0 || isRetryableItemStatus(e.status())) {
+			// transient, retryable. index_not_found_exception is AOSS's eventual-consistency
+			// window: createIndex is acknowledged and the alias is queryable before its
+			// backing shards resolve on every node, so a bulk write immediately after can
+			// see a 404. Treat it as transient and retryable, consistent with
+			// waitForIndexWritable.
+			if (e.status() == 0 || isRetryableItemStatus(e.status())
+					|| INDEX_NOT_FOUND_EXCEPTION.equals(type)) {
 				throw new RetryException(detail, e);
 			}
 			throw new RuntimeException(detail, e);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -1331,6 +1331,44 @@ public class OpenSearchManagerImplTest {
 	}
 
 	@Test
+	public void testBulkIndexWithEnvelopeIndexNotFoundExhaustsRetriesAndThrowsRecoverableMessageException() throws Exception {
+		// AOSS returns index_not_found_exception (404) during the eventual-consistency window
+		// after createIndex — the alias is acknowledged before its shards resolve on every node.
+		// This is transient, so the bulk path must retry rather than fail the index permanently.
+		ErrorResponse notFound = ErrorResponse.of(e -> e
+				.error(err -> err.type("index_not_found_exception").reason("no such index"))
+				.status(404));
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenThrow(new OpenSearchException(notFound));
+
+		// call under test
+		assertThrows(RecoverableMessageException.class,
+				() -> manager.bulkIndex("search-index-syn1", Arrays.asList(bulkOp("1"))));
+		verify(openSearchClient, times(OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES))
+				.bulk(argThat((BulkRequest req) -> req != null));
+	}
+
+	@Test
+	public void testBulkIndexWithEnvelopeIndexNotFoundThenSuccessRecovers() throws Exception {
+		// Transient index_not_found on the first two attempts, then success — proves the 404 is
+		// retried within the existing budget instead of escaping as a terminal RuntimeException.
+		ErrorResponse notFound = ErrorResponse.of(e -> e
+				.error(err -> err.type("index_not_found_exception").reason("no such index"))
+				.status(404));
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenThrow(new OpenSearchException(notFound))
+				.thenThrow(new OpenSearchException(notFound))
+				.thenReturn(bulkResponseOf(okItem("1")));
+
+		// call under test
+		long indexed = manager.bulkIndex("search-index-syn1", Arrays.asList(bulkOp("1")));
+
+		assertEquals(1L, indexed);
+		verify(openSearchClient, times(3))
+				.bulk(argThat((BulkRequest req) -> req != null));
+	}
+
+	@Test
 	public void testBulkIndexWithEnvelope400ThrowsPermanentRuntimeException() throws Exception {
 		ErrorResponse badRequest = ErrorResponse.of(e -> e
 				.error(err -> err.type("illegal_argument_exception").reason("bad request"))


### PR DESCRIPTION
## Problem

Production search-index builds were intermittently failing with the index recorded as permanently `FAILED`. The logs (for `syn75081635`) show `index_not_found_exception` for an AOSS backing-index UUID — the signature of AOSS eventual consistency: `createIndex` is acknowledged and the alias is queryable before its backing shards resolve on every node, so a bulk write that immediately follows can see a 404.

```
2026-06-17T20:32:06,798 WARN  [-20-thread-8696] [org.sagebionetworks.repo.manager.search.OpenSearchManagerImpl] - Index search-index-syn75081635 not yet writable (attempt 1/10): index_not_found_exception: no such index [ISouvZ4BKklsQqeA3m4s] [rootCause=index_not_found_exception: no such index [ISouvZ4BKklsQqeA3m4s]] [metadata={index_uuid="_na_", index="ISouvZ4BKklsQqeA3m4s"}]
2026-06-17T20:32:16,991 WARN  [-20-thread-8696] [org.sagebionetworks.repo.manager.search.OpenSearchManagerImpl] - Sentinel cleanup failed for index search-index-syn75081635 (attempt 1/5): index_not_found_exception: no such index [ISouvZ4BKklsQqeA3m4s] [rootCause=index_not_found_exception: no such index [ISouvZ4BKklsQqeA3m4s]] [metadata={index_uuid="_na_", index="ISouvZ4BKklsQqeA3m4s"}]
2026-06-17T20:32:18,263 ERROR [-20-thread-8696] [org.sagebionetworks.repo.manager.search.SearchIndexLifecycleManagerImpl] - Failed to build search index for entity: syn75081635
java.lang.RuntimeException: Failed to bulk index to search index: search-index-syn75081635 (index_not_found_exception: no such index [ISouvZ4BKklsQqeA3m4s] [rootCause=index_not_found_exception: no such index [ISouvZ4BKklsQqeA3m4s]] [metadata={index_uuid="_na_", index="ISouvZ4BKklsQqeA3m4s"}])
	at org.sagebionetworks.repo.manager.search.OpenSearchManagerImpl.executeBulk(OpenSearchManagerImpl.java:689) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.repo.manager.search.OpenSearchManagerImpl.runAttempt(OpenSearchManagerImpl.java:591) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.repo.manager.search.OpenSearchManagerImpl.lambda$bulkIndex$19(OpenSearchManagerImpl.java:559) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.util.TimeUtils.waitForInternalMaxRetry(TimeUtils.java:136) ~[lib-utils-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.util.TimeUtils.waitForExponentialMaxRetry(TimeUtils.java:128) ~[lib-utils-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.repo.manager.search.OpenSearchManagerImpl.bulkIndex(OpenSearchManagerImpl.java:557) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.repo.manager.search.OpenSearchManagerImpl$$FastClassBySpringCGLIB$$d88908db.invoke(<generated>) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.39.jar:5.3.39]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:792) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:762) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:89) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.sagebionetworks.profiler.Profiler.doBasicProfiling(Profiler.java:37) ~[lib-logging-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at jdk.internal.reflect.GeneratedMethodAccessor39.invoke(Unknown Source) ~[?:?]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:634) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:624) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:72) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:762) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:762) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:707) ~[spring-aop-5.3.39.jar:5.3.39]
	at org.sagebionetworks.repo.manager.search.OpenSearchManagerImpl$$EnhancerBySpringCGLIB$$473d16fe.bulkIndex(<generated>) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.repo.manager.search.SearchIndexLifecycleManagerImpl$SearchIndexRowHandler.flush(SearchIndexLifecycleManagerImpl.java:604) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.repo.manager.search.SearchIndexLifecycleManagerImpl$SearchIndexRowHandler.close(SearchIndexLifecycleManagerImpl.java:611) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.repo.manager.table.TableQueryManagerImpl.runQueryAsStream(TableQueryManagerImpl.java:565) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.repo.manager.table.TableQueryManagerImpl$$FastClassBySpringCGLIB$$8c96412d.invoke(<generated>) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	.
.
.
	at org.sagebionetworks.repo.manager.table.TableQueryManagerImpl$$EnhancerBySpringCGLIB$$21398334.runQueryAsStream(<generated>) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.repo.manager.search.SearchIndexLifecycleManagerImpl.buildIndex(SearchIndexLifecycleManagerImpl.java:301) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.repo.manager.search.SearchIndexLifecycleManagerImpl.handleUpdate(SearchIndexLifecycleManagerImpl.java:188) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.repo.manager.search.SearchIndexLifecycleManagerImpl$$FastClassBySpringCGLIB$$b08ab22d.invoke(<generated>) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.39.jar:5.3.39]
	.
.
.
	at org.sagebionetworks.repo.manager.search.SearchIndexLifecycleManagerImpl$$EnhancerBySpringCGLIB$$b4bbc6d6.handleUpdate(<generated>) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.search.workers.SearchIndexLifecycleWorker.processMessage(SearchIndexLifecycleWorker.java:60) ~[classes/:593.0-3-gd3bd231e33]
	at org.sagebionetworks.search.workers.SearchIndexLifecycleWorker.run(SearchIndexLifecycleWorker.java:43) ~[classes/:593.0-3-gd3bd231e33]
	at org.sagebionetworks.search.workers.SearchIndexLifecycleWorker$$FastClassBySpringCGLIB$$9da68ec6.invoke(<generated>) ~[classes/:593.0-3-gd3bd231e33]
	.
.
.
	at org.sagebionetworks.search.workers.SearchIndexLifecycleWorker$$EnhancerBySpringCGLIB$$50b324dd.run(<generated>) ~[classes/:593.0-3-gd3bd231e33]
	at org.sagebionetworks.asynchronous.workers.changes.ChangeMessageBatchProcessor.runAsSingleChangeMessages(ChangeMessageBatchProcessor.java:108) ~[lib-worker-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.asynchronous.workers.changes.ChangeMessageBatchProcessor.run(ChangeMessageBatchProcessor.java:57) ~[lib-worker-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at org.sagebionetworks.asynchronous.workers.concurrent.ConcurrentManagerImpl.lambda$startWorkerJob$5(ConcurrentManagerImpl.java:173) ~[lib-worker-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.base/java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: org.opensearch.client.opensearch._types.OpenSearchException: Request failed: [index_not_found_exception] no such index [ISouvZ4BKklsQqeA3m4s]
	at org.opensearch.client.transport.aws.AwsSdk2Transport.parseResponse(AwsSdk2Transport.java:583) ~[opensearch-java-3.7.0.jar:?]
	at org.opensearch.client.transport.aws.AwsSdk2Transport.executeSync(AwsSdk2Transport.java:441) ~[opensearch-java-3.7.0.jar:?]
	at org.opensearch.client.transport.aws.AwsSdk2Transport.performRequest(AwsSdk2Transport.java:218) ~[opensearch-java-3.7.0.jar:?]
	at org.opensearch.client.opensearch.OpenSearchClient.bulk(OpenSearchClient.java:113) ~[opensearch-java-3.7.0.jar:?]
	at org.sagebionetworks.repo.manager.search.OpenSearchManagerImpl.executeBulk(OpenSearchManagerImpl.java:678) ~[repository-managers-593.0-3-gd3bd231e33.jar:593.0-3-gd3bd231e33]
	... 109 more
```

## Root cause

`OpenSearchManagerImpl.executeBulk` classified the envelope `OpenSearchException` purely by HTTP status. `index_not_found_exception` is HTTP 404, which is not in `isRetryableItemStatus` (429 / 500–599), so it threw a plain `RuntimeException`. `bulkIndex`'s `catch (RuntimeException e) { throw e; }` re-threw it untouched — **no retry, no conversion to `RecoverableMessageException`** — and `SearchIndexLifecycleManagerImpl` then marked the index permanently `FAILED` after a single attempt.

This was inconsistent with `waitForIndexWritable`, which already treats `index_not_found_exception` as transient/retryable — the entire reason that readiness probe exists is the same AOSS consistency window.

## Fix

Extend the retryable condition in `executeBulk` to also cover `index_not_found_exception` (reusing the existing `INDEX_NOT_FOUND_EXCEPTION` constant). A transient 404 now retries within the existing exponential-backoff budget and, on exhaustion, surfaces as a `RecoverableMessageException` (SQS re-queue) instead of a terminal failure. The 429 / 5xx / IO / 400 paths are unchanged.