### PR TITLE
PLFM-9732

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/SnapshotRowHandler.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/SnapshotRowHandler.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.repo.manager.grid;
 
-import static org.sagebionetworks.repo.manager.grid.internal.replica.validation.GridReplicaValidationManagerImpl.cleanupValidationResults;
 import static org.sagebionetworks.repo.manager.grid.internal.replica.view.GridReplicaViewManagerImpl.gridRowToJsonObject;
 
 import java.io.File;
@@ -20,10 +19,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.sagebionetworks.repo.manager.grid.internal.replica.validation.GridRowValidator;
 import org.sagebionetworks.repo.manager.grid.internal.replica.validation.JsonObjectSubject;
 import org.sagebionetworks.repo.manager.grid.row.translator.ColumnTypeToConType;
 import org.sagebionetworks.repo.manager.grid.row.translator.Translator;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaValidationManager;
 import org.sagebionetworks.repo.manager.schema.JsonSubject;
 import org.sagebionetworks.repo.model.dao.table.RowHandler;
 import org.sagebionetworks.repo.model.grid.encoding.IndexedModelEncoder;
@@ -68,7 +67,7 @@ public class SnapshotRowHandler implements RowHandler {
 
     // Optional validation fields
     private final JsonSchema validationSchema;
-    private final JsonSchemaValidationManager jsonSchemaValidationManager;
+    private final GridRowValidator gridRowValidator;
     private final List<String> columnNames;
 
     private long nextNodeSequenceNumber = 1;
@@ -112,7 +111,7 @@ public class SnapshotRowHandler implements RowHandler {
 
     public SnapshotRowHandler(SnapshotStore snapshotStore, String sessionId, Long replicaId, List<ColumnModel> schema,
                               List<Integer> requiredColumnIndices, FileProvider fileProvider, IndexedModelEncoderProvider encoderProvider,
-                              Long createdByUserId, JsonSchemaValidationManager jsonSchemaValidationManager, JsonSchema validationSchema) {
+                              Long createdByUserId, GridRowValidator gridRowValidator, String schemaId) {
         super();
         ValidateArgument.required(snapshotStore, "snapshotStore");
 
@@ -126,8 +125,8 @@ public class SnapshotRowHandler implements RowHandler {
         this.encoderProvider = encoderProvider;
 
         // Validation fields
-        this.validationSchema = validationSchema;
-        this.jsonSchemaValidationManager = jsonSchemaValidationManager;
+        this.gridRowValidator = gridRowValidator;
+        this.validationSchema = schemaId != null ? gridRowValidator.getValidationSchema(schemaId) : null;
         this.columnNames = schema.stream().map(ColumnModel::getName).collect(Collectors.toList());
 
         // Create temporary file
@@ -302,7 +301,7 @@ public class SnapshotRowHandler implements RowHandler {
      */
     Optional<ObjectNode> getRowMetadata(Row row, VectorNode rowDataNode, Consumer<Node> nodeConsumer) {
         boolean hasSynapseRow = row.getRowId() != null || row.getVersionNumber() != null || row.getEtag() != null;
-        boolean hasValidation = validationSchema != null && jsonSchemaValidationManager != null;
+        boolean hasValidation = validationSchema != null;
 
         if (!hasSynapseRow && !hasValidation) {
             return Optional.empty();
@@ -358,9 +357,7 @@ public class SnapshotRowHandler implements RowHandler {
         JsonSubject subject = new JsonObjectSubject(rowJson);
 
         // Validate
-        ValidationResults results = jsonSchemaValidationManager.validate(validationSchema, subject);
-
-        cleanupValidationResults(results);
+        ValidationResults results = gridRowValidator.validateBatch(validationSchema, List.of(subject)).get(0);
 
         // Serialize and create constant - timestamp will be > all data constants
         try {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/create/QueryCreateGridHandler.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/create/QueryCreateGridHandler.java
@@ -15,8 +15,7 @@ import org.sagebionetworks.repo.manager.grid.GridAuthorizationManager;
 import org.sagebionetworks.repo.manager.grid.IndexedModelEncoderProvider;
 import org.sagebionetworks.repo.manager.grid.SnapshotRowHandler;
 import org.sagebionetworks.repo.manager.grid.SnapshotStore;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaManager;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaValidationManager;
+import org.sagebionetworks.repo.manager.grid.internal.replica.validation.GridRowValidator;
 import org.sagebionetworks.repo.manager.table.TableQueryManager;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.EntityType;
@@ -51,22 +50,20 @@ public class QueryCreateGridHandler implements CreateGridHandler {
 	private final GridDao gridDao;
 	private final TableQueryManager tableQueryManager;
 	private final EntityManager entityManager;
-	private final JsonSchemaManager schemaManager;
-	private final JsonSchemaValidationManager jsonSchemaValidationManager;
+	private final GridRowValidator gridRowValidator;
 	private final GridAuthorizationManager gridAuthorizationManager;
 	private final FileProvider fileProvider;
 	private final IndexedModelEncoderProvider encoderProvider;
 
 	public QueryCreateGridHandler(GridDao gridDao, EntityManager entityManager, TableQueryManager tableQueryManager,
-								  JsonSchemaManager schemaManager, JsonSchemaValidationManager jsonSchemaValidationManager,
+								  GridRowValidator gridRowValidator,
 								  GridAuthorizationManager gridAuthorizationManager, FileProvider fileProvider,
 								  IndexedModelEncoderProvider encoderProvider) {
 		super();
 		this.gridDao = gridDao;
 		this.entityManager = entityManager;
 		this.tableQueryManager = tableQueryManager;
-		this.schemaManager = schemaManager;
-		this.jsonSchemaValidationManager = jsonSchemaValidationManager;
+		this.gridRowValidator = gridRowValidator;
 		this.gridAuthorizationManager = gridAuthorizationManager;
 		this.fileProvider = fileProvider;
 		this.encoderProvider = encoderProvider;
@@ -106,7 +103,7 @@ public class QueryCreateGridHandler implements CreateGridHandler {
 			// grid data back into a Synapse Table or View
 			initialQuery.setIncludeEntityEtag(true);
 
-			final Optional<JsonSchema> validationSchema = schemaIdOp.map(schemaManager::getValidationSchema);
+			final Optional<JsonSchema> validationSchema = schemaIdOp.map(gridRowValidator::getValidationSchema);
 
 			final List<String> columnsRequiredBySchema = validationSchema
 					.map(JsonSchema::getRequired)
@@ -131,7 +128,7 @@ public class QueryCreateGridHandler implements CreateGridHandler {
 			tableQueryManager.runQueryAsStream(callback, filterUser, initialQuery, t -> {
 				List<ColumnModel> schema = t.getMainQuery().getTranslator().getSchemaOfSelect();
 				return getBenefactorCollectingRowHandler(snapshotStore, session, replica, schema,
-						columnsRequiredBySchemaIndices, user.getId(), validationSchema, collectedBenefactorIds);
+						columnsRequiredBySchemaIndices, user.getId(), schemaIdOp, collectedBenefactorIds);
 			}, ACCESS_TYPE.READ, ACCESS_TYPE.UPDATE);
 
 			EntityType sourceType = entityManager.getEntityType(tableId);
@@ -159,10 +156,10 @@ public class QueryCreateGridHandler implements CreateGridHandler {
 	BenefactorCollectingRowHandler getBenefactorCollectingRowHandler(SnapshotStore snapshotStore,
 			GridSession session, GridReplica replica, List<ColumnModel> schema,
 			List<Integer> columnsRequiredBySchemaIndices, Long userId,
-			Optional<JsonSchema> validationSchema, Set<Long> collectedBenefactorIds) {
+			Optional<String> schemaId, Set<Long> collectedBenefactorIds) {
 		SnapshotRowHandler snapshotHandler = new SnapshotRowHandler(snapshotStore, session.getSessionId(),
 				replica.getReplicaId(), schema, columnsRequiredBySchemaIndices, fileProvider, encoderProvider,
-				userId, jsonSchemaValidationManager, validationSchema.orElse(null));
+				userId, gridRowValidator, schemaId.orElse(null));
 		return new BenefactorCollectingRowHandler(snapshotHandler, collectedBenefactorIds);
 	}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/create/RecordSetCreateGridHandler.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/create/RecordSetCreateGridHandler.java
@@ -13,8 +13,7 @@ import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.manager.grid.IndexedModelEncoderProvider;
 import org.sagebionetworks.repo.manager.grid.SnapshotRowHandler;
 import org.sagebionetworks.repo.manager.grid.SnapshotStore;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaManager;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaValidationManager;
+import org.sagebionetworks.repo.manager.grid.internal.replica.validation.GridRowValidator;
 import org.sagebionetworks.repo.manager.table.RecordSetSchemaResolver;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.RecordSet;
@@ -27,7 +26,6 @@ import org.sagebionetworks.repo.model.grid.CreateGridRequest;
 import org.sagebionetworks.repo.model.grid.EventSource;
 import org.sagebionetworks.repo.model.grid.GridReplica;
 import org.sagebionetworks.repo.model.grid.GridSession;
-import org.sagebionetworks.repo.model.schema.JsonSchema;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
 import org.sagebionetworks.repo.model.table.Row;
@@ -44,8 +42,7 @@ public class RecordSetCreateGridHandler implements CreateGridHandler {
 	private final FileHandleManager fileHandleManager;
 	private final EntityAuthorizationManager authorizationManager;
 	private final CsvFileHandleProvider csvProvider;
-	private final JsonSchemaManager jsonSchemaManager;
-	private final JsonSchemaValidationManager jsonSchemaValidationManager;
+	private final GridRowValidator gridRowValidator;
 	private final FileProvider fileProvider;
 	private final IndexedModelEncoderProvider encoderProvider;
 	private final RecordSetSchemaResolver schemaResolver;
@@ -54,7 +51,7 @@ public class RecordSetCreateGridHandler implements CreateGridHandler {
 
 	public RecordSetCreateGridHandler(GridDao gridDao, EntityManager entityManager, FileHandleManager fileHandleManager,
 									  EntityAuthorizationManager authorizationManager, CsvFileHandleProvider csvProvider,
-									  JsonSchemaManager jsonSchemaManager, JsonSchemaValidationManager jsonSchemaValidationManager,
+									  GridRowValidator gridRowValidator,
 									  FileProvider fileProvider, IndexedModelEncoderProvider encoderProvider,
 									  RecordSetSchemaResolver schemaResolver) {
 		super();
@@ -63,8 +60,7 @@ public class RecordSetCreateGridHandler implements CreateGridHandler {
 		this.fileHandleManager = fileHandleManager;
 		this.authorizationManager = authorizationManager;
 		this.csvProvider = csvProvider;
-		this.jsonSchemaManager = jsonSchemaManager;
-		this.jsonSchemaValidationManager = jsonSchemaValidationManager;
+		this.gridRowValidator = gridRowValidator;
 		this.fileProvider = fileProvider;
 		this.encoderProvider = encoderProvider;
 		this.schemaResolver = schemaResolver;
@@ -85,7 +81,7 @@ public class RecordSetCreateGridHandler implements CreateGridHandler {
 		// Makes sure the user has download access
 		authorizationManager.hasAccess(user, recordSet.getId(), ACCESS_TYPE.DOWNLOAD).checkAuthorizationOrElseThrow();
 		
-		Optional<String> validationSchemaId = entityManager.findBoundSchema(recordSetId)
+		final Optional<String> validationSchemaId = entityManager.findBoundSchema(recordSetId)
 				.map(binding -> binding.getJsonSchemaVersionInfo().get$id());
 
 		GridSession session = gridDao.createGridSession(new CreateGridSession().setUserId(user.getId())
@@ -122,12 +118,10 @@ public class RecordSetCreateGridHandler implements CreateGridHandler {
 			throw new IllegalArgumentException("Cannot determine the schema from the CSV file, at least one column header must be present.");
 		}
 
-		final Optional<JsonSchema> validationSchema = validationSchemaId.map(jsonSchemaManager::getValidationSchema);
-
 		// We can now read the CSV file again and reuse the PatchRowHandler.
 		CSVReader csvReader = csvProvider.getCsvReader(fileHandle, csvDescriptor);
 		SnapshotRowHandler rowHandler = getSnapshotRowHandler(snapshotStore, session, replica, schema, columnsRequiredByJsonSchemaIndices,
-				fileProvider, user.getId(), validationSchema.orElse(null));
+				fileProvider, user.getId(), validationSchemaId.orElse(null));
 		
 		try (csvReader; rowHandler) {
 
@@ -152,9 +146,9 @@ public class RecordSetCreateGridHandler implements CreateGridHandler {
 
 	SnapshotRowHandler getSnapshotRowHandler(SnapshotStore snapshotStore, GridSession session, GridReplica replica,
 											 List<ColumnModel> schema, List<Integer> requiredColumnIndices, FileProvider fileProvider,
-											 Long createdByUserId, JsonSchema validationSchema) {
+											 Long createdByUserId, String schemaId) {
 		return new SnapshotRowHandler(snapshotStore, session.getSessionId(), replica.getReplicaId(), schema, requiredColumnIndices,
-				fileProvider, encoderProvider, createdByUserId, jsonSchemaValidationManager, validationSchema);
+				fileProvider, encoderProvider, createdByUserId, gridRowValidator, schemaId);
 	}
 
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporter.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporter.java
@@ -5,24 +5,8 @@ import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.dao.asynch.AsyncJobProgressCallback;
 import org.sagebionetworks.repo.model.grid.GridRecordSetExportRequest;
 import org.sagebionetworks.repo.model.grid.GridRecordSetExportResponse;
-import org.sagebionetworks.repo.model.schema.ValidationSummaryStatistics;
 
 public interface GridRecordSetExporter {
 
 	GridRecordSetExportResponse exportGrid(UserInfo user, GridRecordSetExportRequest request, AsyncJobProgressCallback jobCallback);
-
-	/**
-	 * Create a new RecordSet version pointing at the provided data file handle and
-	 * validation-details file handle, and persist the validation summary.
-	 *
-	 * @param user                       the calling user
-	 * @param recordSet                  the source RecordSet
-	 * @param csvFileHandleId            the new data CSV file handle id
-	 * @param validationSummary          the validation summary to persist
-	 * @param validationDetailsFileHandleId the validation-details file handle id
-	 * @return the updated RecordSet
-	 */
-	RecordSet createRecordSetVersionFromArtifacts(UserInfo user, RecordSet recordSet, String csvFileHandleId,
-			ValidationSummaryStatistics validationSummary, String validationDetailsFileHandleId);
-
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporter.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporter.java
@@ -1,12 +1,28 @@
 package org.sagebionetworks.repo.manager.grid.internal.replica.export;
 
+import org.sagebionetworks.repo.model.RecordSet;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.dao.asynch.AsyncJobProgressCallback;
 import org.sagebionetworks.repo.model.grid.GridRecordSetExportRequest;
 import org.sagebionetworks.repo.model.grid.GridRecordSetExportResponse;
+import org.sagebionetworks.repo.model.schema.ValidationSummaryStatistics;
 
 public interface GridRecordSetExporter {
 
 	GridRecordSetExportResponse exportGrid(UserInfo user, GridRecordSetExportRequest request, AsyncJobProgressCallback jobCallback);
-	
+
+	/**
+	 * Create a new RecordSet version pointing at the provided data file handle and
+	 * validation-details file handle, and persist the validation summary.
+	 *
+	 * @param user                       the calling user
+	 * @param recordSet                  the source RecordSet
+	 * @param csvFileHandleId            the new data CSV file handle id
+	 * @param validationSummary          the validation summary to persist
+	 * @param validationDetailsFileHandleId the validation-details file handle id
+	 * @return the updated RecordSet
+	 */
+	RecordSet createRecordSetVersionFromArtifacts(UserInfo user, RecordSet recordSet, String csvFileHandleId,
+			ValidationSummaryStatistics validationSummary, String validationDetailsFileHandleId);
+
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporterImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporterImpl.java
@@ -4,13 +4,15 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Date;
+import java.util.List;
 
 import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.manager.file.LocalFileUploadRequest;
 import org.sagebionetworks.repo.manager.grid.GridManager;
 import org.sagebionetworks.repo.manager.grid.internal.replica.GridReplicaSupport;
 import org.sagebionetworks.repo.manager.grid.internal.replica.model.RowView;
+import org.sagebionetworks.repo.manager.grid.internal.replica.validation.GridRowValidator;
+import org.sagebionetworks.repo.manager.grid.internal.replica.validation.ValidationSummaryAccumulator;
 import org.sagebionetworks.repo.model.RecordSet;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.dao.asynch.AsyncJobProgressCallback;
@@ -20,9 +22,8 @@ import org.sagebionetworks.repo.model.grid.DownloadFromGridResult;
 import org.sagebionetworks.repo.model.grid.GridRecordSetExportRequest;
 import org.sagebionetworks.repo.model.grid.GridRecordSetExportResponse;
 import org.sagebionetworks.repo.model.grid.GridSession;
-import org.sagebionetworks.repo.model.jdo.JDOSecondaryPropertyUtils;
 import org.sagebionetworks.repo.model.jdo.KeyFactory;
-import org.sagebionetworks.repo.model.schema.ValidationResults;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
 import org.sagebionetworks.repo.model.schema.ValidationSummaryStatistics;
 import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
 import org.sagebionetworks.repo.service.EntityService;
@@ -35,10 +36,8 @@ import au.com.bytecode.opencsv.CSVWriter;
 
 @Service
 public class GridRecordSetExporterImpl implements GridRecordSetExporter {
-	
-	private static final String[] VALIDATION_CSV_HEADERS = new String[] {
-		"row_index", "is_valid", "validation_error_message", "all_validation_messages"
-	};
+
+	private static final int VALIDATION_BATCH_SIZE = 1000;
 
 	private final GridManager gridManager;
 	private final GridReplicaSupport gridReplicaSupport;
@@ -46,9 +45,10 @@ public class GridRecordSetExporterImpl implements GridRecordSetExporter {
 	private final GridReplicaCsvExporter csvExporter;
 	private final EntitySchemaValidationResultDao validationResultDao;
 	private final CSVWriterProvider csvWriterProvider;
-    private final FileHandleManager fileHandleManager;
+	private final FileHandleManager fileHandleManager;
+	private final GridRowValidator gridRowValidator;
 
-	public GridRecordSetExporterImpl(GridManager gridManager, GridReplicaSupport gridReplicaSupport, EntityService entityService, GridReplicaCsvExporter csvExporter, EntitySchemaValidationResultDao validationResultDao, CSVWriterProvider csvWriterProvider, FileHandleManager fileHandleManager) {
+	public GridRecordSetExporterImpl(GridManager gridManager, GridReplicaSupport gridReplicaSupport, EntityService entityService, GridReplicaCsvExporter csvExporter, EntitySchemaValidationResultDao validationResultDao, CSVWriterProvider csvWriterProvider, FileHandleManager fileHandleManager, GridRowValidator gridRowValidator) {
 		this.gridManager = gridManager;
 		this.gridReplicaSupport = gridReplicaSupport;
 		this.entityService = entityService;
@@ -56,6 +56,7 @@ public class GridRecordSetExporterImpl implements GridRecordSetExporter {
 		this.validationResultDao = validationResultDao;
 		this.csvWriterProvider = csvWriterProvider;
 		this.fileHandleManager = fileHandleManager;
+		this.gridRowValidator = gridRowValidator;
 	}
 	
 	@Override
@@ -104,7 +105,7 @@ public class GridRecordSetExporterImpl implements GridRecordSetExporter {
 		}
 		
 		// Creates a new version of the record set that points to the new file and persist the validation summary
-		recordSet = createNewVersion(user, recordSet, exportedFileId, validationSummary, validationFileId);
+		recordSet = createRecordSetVersionFromArtifacts(user, recordSet, exportedFileId, validationSummary, validationFileId);
 
 		// Update the GridSession to denote that it is in sync with the record set
 		gridManager.updateSourceEntityVersion(request.getSessionId(), recordSet.getVersionNumber());
@@ -136,8 +137,10 @@ public class GridRecordSetExporterImpl implements GridRecordSetExporter {
 		
 		return result.getResultsFileHandleId();
 	}
-	
-	RecordSet createNewVersion(UserInfo user, RecordSet recordSet, String newFileHandleId, ValidationSummaryStatistics validationSummary, String validationFileHandleId) {
+
+
+	@Override
+	public RecordSet createRecordSetVersionFromArtifacts(UserInfo user, RecordSet recordSet, String newFileHandleId, ValidationSummaryStatistics validationSummary, String validationFileHandleId) {
 		recordSet.setDataFileHandleId(newFileHandleId);
 		// The file handle with the validation details is stored in the revision table
 		recordSet.setValidationFileHandleId(validationFileHandleId);
@@ -165,55 +168,21 @@ public class GridRecordSetExporterImpl implements GridRecordSetExporter {
 	
 	final class ValidationSummaryBuilder implements RowViewCallbackHandler {
 
-		private String recordSetId;
-		private int totalCount = 0;
-		private int validCount = 0;
-		private int invalidCount = 0;
-		private int unknownCount = 0;
-		private CSVWriter validationCsvWriter;
-		
+		private final String recordSetId;
+		private final ValidationSummaryAccumulator accumulator;
+
 		ValidationSummaryBuilder(String recordSetId, CSVWriter validationCsvWriter) throws IOException {
 			this.recordSetId = recordSetId;
-			this.validationCsvWriter = validationCsvWriter;
-			this.validationCsvWriter.writeNext(VALIDATION_CSV_HEADERS);
+			this.accumulator = new ValidationSummaryAccumulator(validationCsvWriter);
 		}
 		
 		@Override
 		public void next(RowView rowView) {
-			// row_index, is_valid, validation_error_message, all_validation_messages
-			String[] rowValidationDetails = new String[] { String.valueOf(totalCount), null, null, null };
-			
-			totalCount++;
-			
-			ValidationResults validationResult = rowView.getRowValidationResults();
-			
-			if (validationResult == null) {
-				unknownCount++;
-			} else if (Boolean.TRUE.equals(validationResult.getIsValid())) {
-				validCount++;
-				rowValidationDetails[1] = "true";
-			} else {
-				invalidCount++;
-				rowValidationDetails[1] = "false";
-				rowValidationDetails[2] = validationResult.getValidationErrorMessage();
-				rowValidationDetails[3] = JDOSecondaryPropertyUtils.writeStringListToJson(validationResult.getAllValidationMessages());
-			}
-			
-			try {
-				validationCsvWriter.writeNext(rowValidationDetails);
-			} catch (IOException e) {
-				throw new IllegalStateException("Could not write validation details to CSV file.", e);
-			}
+			accumulator.record(rowView.getRowValidationResults());
 		}
 		
 		ValidationSummaryStatistics getValidationSummary() {
-			return new ValidationSummaryStatistics()
-				.setContainerId(recordSetId)
-				.setTotalNumberOfChildren(Long.valueOf(totalCount))
-				.setNumberOfValidChildren(Long.valueOf(validCount))
-				.setNumberOfInvalidChildren(Long.valueOf(invalidCount))
-				.setNumberOfUnknownChildren(Long.valueOf(unknownCount))
-				.setGeneratedOn(new Date());
+			return accumulator.getValidationSummary(recordSetId);
 		}
 		
 	}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporterImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporterImpl.java
@@ -139,8 +139,20 @@ public class GridRecordSetExporterImpl implements GridRecordSetExporter {
 	}
 
 
-	@Override
-	public RecordSet createRecordSetVersionFromArtifacts(UserInfo user, RecordSet recordSet, String newFileHandleId, ValidationSummaryStatistics validationSummary, String validationFileHandleId) {
+	/**
+	 * Create a new RecordSet version pointing at the provided data file handle and
+	 * validation-details file handle, and persist the validation summary. This is
+	 * the shared "create version" tail used by both {@link #exportGrid} and
+	 * {@link #pushFromArtifactBuilder}.
+	 *
+	 * @param user                       the calling user
+	 * @param recordSet                  the source RecordSet
+	 * @param newFileHandleId            the new data CSV file handle id
+	 * @param validationSummary          the validation summary to persist
+	 * @param validationFileHandleId	 the validation-details file handle id
+	 * @return the updated RecordSet
+	 */
+	RecordSet createRecordSetVersionFromArtifacts(UserInfo user, RecordSet recordSet, String newFileHandleId, ValidationSummaryStatistics validationSummary, String validationFileHandleId) {
 		recordSet.setDataFileHandleId(newFileHandleId);
 		// The file handle with the validation details is stored in the revision table
 		recordSet.setValidationFileHandleId(validationFileHandleId);

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporterImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/export/GridRecordSetExporterImpl.java
@@ -37,8 +37,6 @@ import au.com.bytecode.opencsv.CSVWriter;
 @Service
 public class GridRecordSetExporterImpl implements GridRecordSetExporter {
 
-	private static final int VALIDATION_BATCH_SIZE = 1000;
-
 	private final GridManager gridManager;
 	private final GridReplicaSupport gridReplicaSupport;
 	private final EntityService entityService;

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImpl.java
@@ -22,8 +22,6 @@ import org.sagebionetworks.repo.manager.grid.internal.replica.model.RowObject;
 import org.sagebionetworks.repo.manager.grid.internal.replica.model.RowView;
 import org.sagebionetworks.repo.manager.grid.internal.replica.view.GridReplicaViewManager;
 import org.sagebionetworks.repo.manager.grid.internal.replica.view.query.filter.VectorIdFilterElement;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaManager;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaValidationManager;
 import org.sagebionetworks.repo.manager.schema.JsonSubject;
 import org.sagebionetworks.repo.model.dbo.grid.GridDao;
 import org.sagebionetworks.repo.model.grid.EventSource;
@@ -46,18 +44,15 @@ public class GridReplicaValidationManagerImpl implements GridReplicaValidationMa
 	private static final Logger log = LogManager.getLogger(GridReplicaValidationManagerImpl.class);
 
 	private final GridReplicaViewManager gridReplicaViewManager;
-	private final JsonSchemaManager jsonSchemaManager;
 	private final GridDao gridDao;
-	private final JsonSchemaValidationManager jsonSchemaValidationManager;
+	private final GridRowValidator gridRowValidator;
 	private final PatchBuilderPublisher patchBuilderPublisher;
 
-	public GridReplicaValidationManagerImpl(GridReplicaViewManager gridReplicaViewManager,
-			JsonSchemaManager jsonSchemaManager, GridDao gridDao,
-			JsonSchemaValidationManager jsonSchemaValidationManager, PatchBuilderPublisher patchBuilderPublisher) {
+	public GridReplicaValidationManagerImpl(GridReplicaViewManager gridReplicaViewManager, GridDao gridDao,
+			GridRowValidator gridRowValidator, PatchBuilderPublisher patchBuilderPublisher) {
 		this.gridReplicaViewManager = gridReplicaViewManager;
-		this.jsonSchemaManager = jsonSchemaManager;
 		this.gridDao = gridDao;
-		this.jsonSchemaValidationManager = jsonSchemaValidationManager;
+		this.gridRowValidator = gridRowValidator;
 		this.patchBuilderPublisher = patchBuilderPublisher;
 	}
 
@@ -240,12 +235,12 @@ public class GridReplicaValidationManagerImpl implements GridReplicaValidationMa
 	 * @return
 	 */
 	List<IntendedChange> validateRows(GridHeader header, String schemaId, List<RowView> rowsToValidate) {
-		JsonSchema schema = jsonSchemaManager.getValidationSchema(schemaId);
+		JsonSchema schema = gridRowValidator.getValidationSchema(schemaId);
 
 		List<JsonSubject> subjects = rowsToValidate.stream()
 				.map(row -> new JsonObjectSubject(row.getRowObject().getData().getRowJsonDocument())).collect(Collectors.toList());
 
-		List<ValidationResults> results = jsonSchemaValidationManager.validateBatch(schema, subjects);
+		List<ValidationResults> results = gridRowValidator.validateBatch(schema, subjects);
 
 		List<IntendedChange> changes = new ArrayList<>();
 
@@ -253,25 +248,12 @@ public class GridReplicaValidationManagerImpl implements GridReplicaValidationMa
 			ValidationResults validationResults = results.get(i);
 			RowView row = rowsToValidate.get(i);
 
-			cleanupValidationResults(validationResults);
-
 			// Always apply the new validation results, even if the value did not change.
 			// The client uses the timestamp to determine if results are up-to-date with its local changes.
 			changes.add(createChange(row, validationResults));
 		}
 
 		return changes;
-	}
-
-	/**
-	 * Remove 'extra' data from a row's validation results to reduce its size.
-	 * 
-	 * @param validationResults
-	 */
-	public static void cleanupValidationResults(ValidationResults validationResults) {
-		validationResults.setValidatedOn(null);
-		validationResults.setSchema$id(null);
-		validationResults.setValidationException(null);
 	}
 
 	/**

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridRowValidator.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridRowValidator.java
@@ -10,12 +10,8 @@ import org.sagebionetworks.repo.model.schema.ValidationResults;
 import org.springframework.stereotype.Service;
 
 /**
- * Shared, schema-driven row validator used by both the asynchronous grid
- * validation worker ({@link GridReplicaValidationManagerImpl}) and the
- * synchronous RecordSet push build (the push CSV/validation sink). Centralizing
- * the {@code resolve schema -> validateBatch -> cleanup} pipeline guarantees the
- * pushed RecordSet version's validation summary is computed with exactly the
- * same logic the worker uses to write the live grid's validation state.
+ * Shared, schema-driven row validator used in all places a JSON Schema is used to validate
+ * one or more grid rows.
  */
 @Service
 public class GridRowValidator {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridRowValidator.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridRowValidator.java
@@ -1,0 +1,68 @@
+package org.sagebionetworks.repo.manager.grid.internal.replica.validation;
+
+import java.util.List;
+
+import org.sagebionetworks.repo.manager.schema.JsonSchemaManager;
+import org.sagebionetworks.repo.manager.schema.JsonSchemaValidationManager;
+import org.sagebionetworks.repo.manager.schema.JsonSubject;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.repo.model.schema.ValidationResults;
+import org.springframework.stereotype.Service;
+
+/**
+ * Shared, schema-driven row validator used by both the asynchronous grid
+ * validation worker ({@link GridReplicaValidationManagerImpl}) and the
+ * synchronous RecordSet push build (the push CSV/validation sink). Centralizing
+ * the {@code resolve schema -> validateBatch -> cleanup} pipeline guarantees the
+ * pushed RecordSet version's validation summary is computed with exactly the
+ * same logic the worker uses to write the live grid's validation state.
+ */
+@Service
+public class GridRowValidator {
+
+	private final JsonSchemaManager jsonSchemaManager;
+	private final JsonSchemaValidationManager jsonSchemaValidationManager;
+
+	public GridRowValidator(JsonSchemaManager jsonSchemaManager,
+			JsonSchemaValidationManager jsonSchemaValidationManager) {
+		this.jsonSchemaManager = jsonSchemaManager;
+		this.jsonSchemaValidationManager = jsonSchemaValidationManager;
+	}
+
+	/**
+	 * Resolve the de-referenced validation schema for the given schema $id.
+	 *
+	 * @param schemaId the bound JSON Schema $id
+	 * @return the validation schema
+	 */
+	public JsonSchema getValidationSchema(String schemaId) {
+		return jsonSchemaManager.getValidationSchema(schemaId);
+	}
+
+	/**
+	 * Validate a batch of subjects against the provided schema. Each returned
+	 * {@link ValidationResults} has its transient fields cleared via
+	 * {@link #cleanupValidationResults(ValidationResults)} so the payload is
+	 * minimal and identical whether produced by the worker or the push build.
+	 *
+	 * @param schema   the validation schema
+	 * @param subjects the subjects to validate, in order
+	 * @return one {@link ValidationResults} per subject, in the same order
+	 */
+	public List<ValidationResults> validateBatch(JsonSchema schema, List<JsonSubject> subjects) {
+		List<ValidationResults> results = jsonSchemaValidationManager.validateBatch(schema, subjects);
+		results.forEach(GridRowValidator::cleanupValidationResults);
+		return results;
+	}
+
+	/**
+	 * Remove 'extra' data from a row's validation results to reduce its size.
+	 *
+	 * @param validationResults the results to clean up (mutated in place)
+	 */
+	public static void cleanupValidationResults(ValidationResults validationResults) {
+		validationResults.setValidatedOn(null);
+		validationResults.setSchema$id(null);
+		validationResults.setValidationException(null);
+	}
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/ValidationSummaryAccumulator.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/ValidationSummaryAccumulator.java
@@ -13,15 +13,6 @@ import au.com.bytecode.opencsv.CSVWriter;
  * Accumulates the per-row validation outcome of a grid export/push into both the
  * user-visible validation-details CSV and the aggregate
  * {@link ValidationSummaryStatistics}.
- *
- * <p>
- * This is the single source of truth for the validation-summary accounting shared
- * by the two grid→RecordSet write paths: the asynchronous export
- * ({@code GridRecordSetExporterImpl.ValidationSummaryBuilder}) and the synchronous
- * push ({@code PushRowSink}). Both feed each surviving row's
- * {@link ValidationResults} (or {@code null} when there is no bound schema) to
- * {@link #record(ValidationResults)} so the details CSV layout and the summary
- * counters cannot drift between the two paths.
  */
 public class ValidationSummaryAccumulator {
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/ValidationSummaryAccumulator.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/ValidationSummaryAccumulator.java
@@ -1,0 +1,90 @@
+package org.sagebionetworks.repo.manager.grid.internal.replica.validation;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.sagebionetworks.repo.model.jdo.JDOSecondaryPropertyUtils;
+import org.sagebionetworks.repo.model.schema.ValidationResults;
+import org.sagebionetworks.repo.model.schema.ValidationSummaryStatistics;
+
+import au.com.bytecode.opencsv.CSVWriter;
+
+/**
+ * Accumulates the per-row validation outcome of a grid export/push into both the
+ * user-visible validation-details CSV and the aggregate
+ * {@link ValidationSummaryStatistics}.
+ *
+ * <p>
+ * This is the single source of truth for the validation-summary accounting shared
+ * by the two grid→RecordSet write paths: the asynchronous export
+ * ({@code GridRecordSetExporterImpl.ValidationSummaryBuilder}) and the synchronous
+ * push ({@code PushRowSink}). Both feed each surviving row's
+ * {@link ValidationResults} (or {@code null} when there is no bound schema) to
+ * {@link #record(ValidationResults)} so the details CSV layout and the summary
+ * counters cannot drift between the two paths.
+ */
+public class ValidationSummaryAccumulator {
+
+	public static final String[] VALIDATION_CSV_HEADERS = new String[] {
+		"row_index", "is_valid", "validation_error_message", "all_validation_messages"
+	};
+
+	private final CSVWriter validationCsvWriter;
+
+	private int totalCount = 0;
+	private int validCount = 0;
+	private int invalidCount = 0;
+	private int unknownCount = 0;
+
+	/**
+	 * @param validationCsvWriter writer for the validation-details CSV; the header
+	 *                            row is written here on construction
+	 */
+	public ValidationSummaryAccumulator(CSVWriter validationCsvWriter) throws IOException {
+		this.validationCsvWriter = validationCsvWriter;
+		this.validationCsvWriter.writeNext(VALIDATION_CSV_HEADERS);
+	}
+
+	/**
+	 * Record one row's validation outcome: increment the appropriate counter and
+	 * write the row's details. A {@code null} result counts as "unknown" (no bound
+	 * schema, so the row could not be validated).
+	 *
+	 * @param result the row's validation result, or null if unknown
+	 */
+	public void record(ValidationResults result) {
+		// row_index, is_valid, validation_error_message, all_validation_messages
+		String[] details = new String[] { String.valueOf(totalCount), null, null, null };
+		totalCount++;
+		if (result == null) {
+			unknownCount++;
+		} else if (Boolean.TRUE.equals(result.getIsValid())) {
+			validCount++;
+			details[1] = "true";
+		} else {
+			invalidCount++;
+			details[1] = "false";
+			details[2] = result.getValidationErrorMessage();
+			details[3] = JDOSecondaryPropertyUtils.writeStringListToJson(result.getAllValidationMessages());
+		}
+		try {
+			validationCsvWriter.writeNext(details);
+		} catch (IOException e) {
+			throw new IllegalStateException("Could not write validation details to CSV file.", e);
+		}
+	}
+
+	/**
+	 * @param containerId the id to set as the summary's container (the RecordSet id)
+	 * @return the accumulated validation summary
+	 */
+	public ValidationSummaryStatistics getValidationSummary(String containerId) {
+		return new ValidationSummaryStatistics()
+			.setContainerId(containerId)
+			.setTotalNumberOfChildren(Long.valueOf(totalCount))
+			.setNumberOfValidChildren(Long.valueOf(validCount))
+			.setNumberOfInvalidChildren(Long.valueOf(invalidCount))
+			.setNumberOfUnknownChildren(Long.valueOf(unknownCount))
+			.setGeneratedOn(new Date());
+	}
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/table/RecordSetSchemaResolver.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/table/RecordSetSchemaResolver.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.sagebionetworks.repo.manager.EntityManager;
@@ -16,7 +17,10 @@ import org.sagebionetworks.repo.manager.grid.CsvSchemaReconciler;
 import org.sagebionetworks.repo.manager.schema.JsonSchemaManager;
 import org.sagebionetworks.repo.model.file.FileHandle;
 import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.repo.model.schema.Type;
+import org.sagebionetworks.repo.model.table.ColumnConstants;
 import org.sagebionetworks.repo.model.table.ColumnModel;
+import org.sagebionetworks.repo.model.table.ColumnType;
 import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
 import org.sagebionetworks.repo.model.table.UploadToTablePreviewRequest;
 import org.springframework.stereotype.Service;
@@ -90,9 +94,10 @@ public class RecordSetSchemaResolver {
 	 */
 	public ReconciledSchema getReconciledSchema(String entityId, FileHandle fileHandle,
 			CsvTableDescriptor csvDescriptor, boolean fullScan) {
-		List<ColumnModel> schema = inferSchemaFromCsv(fileHandle, csvDescriptor, fullScan);
+		List<ColumnModel> schema = new ArrayList<>(inferSchemaFromCsv(fileHandle, csvDescriptor, fullScan));
 		Optional<JsonSchema> validationSchema = getBoundValidationSchema(entityId);
 		validationSchema.ifPresent(vs -> CsvSchemaReconciler.reconcile(schema, vs));
+		validationSchema.ifPresent(vs -> addJsonSchemaOnlyColumns(schema, vs));
 
 		List<String> required = validationSchema.map(JsonSchema::getRequired).orElse(new ArrayList<>());
 		Map<String, Integer> columnNameToIndex = new HashMap<>();
@@ -105,6 +110,53 @@ public class RecordSetSchemaResolver {
 				.collect(Collectors.toList());
 
 		return new ReconciledSchema(schema, requiredColumnIndices);
+	}
+
+	/**
+	 * Append a column for each top-level JSON Schema property that is not already
+	 * present in the CSV-inferred schema. This ensures that columns declared only
+	 * in the bound JSON Schema (not yet present in the CSV data) are surfaced. The
+	 * column type is derived from the property's declared {@link Type}; properties
+	 * are appended in a deterministic (name-sorted) order.
+	 *
+	 * @param schema           the schema to append to (CSV-inferred, already reconciled)
+	 * @param validationSchema the bound JSON Schema
+	 */
+	static void addJsonSchemaOnlyColumns(List<ColumnModel> schema, JsonSchema validationSchema) {
+		Map<String, JsonSchema> properties = validationSchema.getProperties();
+		if (properties == null) {
+			return;
+		}
+		Set<String> existingNames = schema.stream().map(ColumnModel::getName).collect(Collectors.toSet());
+		properties.entrySet().stream()
+				.filter(e -> !existingNames.contains(e.getKey()))
+				.sorted(Map.Entry.comparingByKey())
+				.forEach(e -> schema.add(toColumnModel(e.getKey(), e.getValue())));
+	}
+
+	/**
+	 * Map a single JSON Schema property to a {@link ColumnModel}. Scalar types map
+	 * to their column equivalents; arrays map to a string list; objects, nulls, and
+	 * untyped properties default to a string.
+	 *
+	 * @param name     the property (column) name
+	 * @param property the property's JSON Schema
+	 * @return a ColumnModel for the property
+	 */
+	static ColumnModel toColumnModel(String name, JsonSchema property) {
+		ColumnModel column = new ColumnModel().setName(name);
+		Type type = property == null ? null : property.getType();
+		if (type == null) {
+			return column.setColumnType(ColumnType.STRING).setMaximumSize(ColumnConstants.DEFAULT_STRING_SIZE);
+		}
+        return switch (type) {
+            case integer -> column.setColumnType(ColumnType.INTEGER);
+            case number -> column.setColumnType(ColumnType.DOUBLE);
+            case _boolean -> column.setColumnType(ColumnType.BOOLEAN);
+            case array ->
+                    column.setColumnType(ColumnType.STRING_LIST).setMaximumSize(ColumnConstants.DEFAULT_STRING_SIZE);
+            default -> column.setColumnType(ColumnType.STRING).setMaximumSize(ColumnConstants.DEFAULT_STRING_SIZE);
+        };
 	}
 
 	List<ColumnModel> inferSchemaFromCsv(FileHandle fileHandle, CsvTableDescriptor csvDescriptor, boolean fullScan) {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/SnapshotRowHandlerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/SnapshotRowHandlerTest.java
@@ -32,8 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaValidationManager;
-import org.sagebionetworks.repo.manager.schema.JsonSubject;
+import org.sagebionetworks.repo.manager.grid.internal.replica.validation.GridRowValidator;
 import org.sagebionetworks.repo.model.dbo.dao.table.TableModelTestUtils;
 import org.sagebionetworks.repo.model.grid.ClockTable;
 import org.sagebionetworks.repo.model.grid.encoding.IndexedModelEncoder;
@@ -47,7 +46,6 @@ import org.sagebionetworks.repo.model.grid.patch.ConType;
 import org.sagebionetworks.repo.model.grid.patch.ConValue;
 import org.sagebionetworks.repo.model.grid.patch.LogicalTimestamp;
 import org.sagebionetworks.repo.model.schema.JsonSchema;
-import org.sagebionetworks.repo.model.schema.ValidationException;
 import org.sagebionetworks.repo.model.schema.ValidationResults;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
@@ -64,7 +62,7 @@ public class SnapshotRowHandlerTest {
 	private FileProvider mockFileProvider;
 
 	@Mock
-	private JsonSchemaValidationManager mockValidationManager;
+	private GridRowValidator mockGridRowValidator;
 
 	@Mock
 	private IndexedModelEncoderProvider mockEncoderProvider;
@@ -100,10 +98,26 @@ public class SnapshotRowHandlerTest {
 		lenient().when(mockEncoder.getClockTable()).thenReturn(new ClockTable(Collections.emptyList()));
 	}
 
+	/**
+	 * Convenience factory using all @BeforeEach defaults and no validation schema.
+	 */
+	private SnapshotRowHandler buildHandler() throws IOException {
+		return buildHandler(null);
+	}
+
+	/**
+	 * Convenience factory using all @BeforeEach defaults with a specific schema ID.
+	 * Use {@code null} for no validation.
+	 */
+	private SnapshotRowHandler buildHandler(String schemaId) throws IOException {
+		return new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
+				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId,
+				mockGridRowValidator, schemaId);
+	}
+
 	@Test
 	public void testBuildDocumentStructure() throws IOException {
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 
 		// call under test
 		SnapshotRowHandler.DocumentStructure result = handler.buildDocumentStructure();
@@ -145,7 +159,7 @@ public class SnapshotRowHandlerTest {
 	public void testBuildColumnSchemaWithEmptySchema() throws IOException {
 		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId,
 				Collections.emptyList(), requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId,
-				mockValidationManager, null);
+				mockGridRowValidator, null);
 
 		VectorNode columnNamesNode = new VectorNode().setId(new LogicalTimestamp().setReplicaId(replicaId)
 				.setSequenceNumber(1L));
@@ -171,7 +185,7 @@ public class SnapshotRowHandlerTest {
 				new ColumnModel().setColumnType(ColumnType.BOOLEAN).setName("active"));
 
 		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, testSchema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockGridRowValidator, null);
 
 		VectorNode columnNamesNode = new VectorNode().setId(new LogicalTimestamp().setReplicaId(replicaId)
 				.setSequenceNumber(1L)).setValues(new LinkedHashMap<>());
@@ -218,7 +232,7 @@ public class SnapshotRowHandlerTest {
 				new ColumnModel().setColumnType(ColumnType.STRING).setName("col2"));
 
 		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, testSchema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockGridRowValidator, null);
 
 		VectorNode columnNamesNode = new VectorNode().setId(new LogicalTimestamp().setReplicaId(replicaId)
 				.setSequenceNumber(100L)).setValues(new LinkedHashMap<>());
@@ -240,8 +254,7 @@ public class SnapshotRowHandlerTest {
 
 	@Test
 	public void testNextTimestampIncrementsSequence() throws IOException {
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 
 		// call under test
 		LogicalTimestamp ts1 = handler.nextTimestamp();
@@ -261,8 +274,7 @@ public class SnapshotRowHandlerTest {
 
 	@Test
 	public void testGetRowData() throws IOException {
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 
 		Row row = new Row().setValues(Arrays.asList("test", "123"));
 		List<Node> capturedNodes = new ArrayList<>();
@@ -291,8 +303,7 @@ public class SnapshotRowHandlerTest {
 
 	@Test
 	public void testGetRowDataWithNullValues() throws IOException {
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 
 		Row row = new Row().setValues(Arrays.asList(null, null));
 		List<Node> capturedNodes = new ArrayList<>();
@@ -314,7 +325,7 @@ public class SnapshotRowHandlerTest {
 	public void testGetRowDataWithEmptyValues() throws IOException {
 		List<ColumnModel> emptySchema = Collections.emptyList();
 		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, emptySchema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockGridRowValidator, null);
 
 		Row row = new Row().setValues(Collections.emptyList());
 		List<Node> capturedNodes = new ArrayList<>();
@@ -332,8 +343,7 @@ public class SnapshotRowHandlerTest {
 
 	@Test
 	public void testGetRowMetadataWithNoMetadata() throws IOException {
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 
 		Row row = new Row().setValues(Arrays.asList("test", "123"));
 		VectorNode rowDataNode = new VectorNode().setId(new LogicalTimestamp().setReplicaId(replicaId)
@@ -351,8 +361,7 @@ public class SnapshotRowHandlerTest {
 
 	@Test
 	public void testGetRowMetadataWithSynapseRowOnly() throws IOException {
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 
 		Row row = new Row().setValues(Arrays.asList("test", "123")).setRowId(1L).setVersionNumber(2L)
 				.setEtag("etag-123");
@@ -379,16 +388,15 @@ public class SnapshotRowHandlerTest {
 
 	@Test
 	public void testGetRowMetadataWithValidationOnly() throws IOException {
+		String schemaId = "test-schema-id";
 		JsonSchema validationSchema = new JsonSchema();
 		ValidationResults validResults = new ValidationResults();
 		validResults.setIsValid(true);
 
-		when(mockValidationManager.validate(eq(validationSchema), any(JsonSubject.class)))
-				.thenReturn(validResults);
+		when(mockGridRowValidator.getValidationSchema(schemaId)).thenReturn(validationSchema);
+		when(mockGridRowValidator.validateBatch(eq(validationSchema), any())).thenReturn(List.of(validResults));
 
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager,
-				validationSchema);
+		SnapshotRowHandler handler = buildHandler(schemaId);
 
 		Row row = new Row().setValues(Arrays.asList("test", "123"));
 
@@ -418,23 +426,22 @@ public class SnapshotRowHandlerTest {
 		assertEquals(1, metadataMap.size());
 		assertTrue(metadataMap.containsKey(DocumentConstants.ROW_VALIDATION));
 
-		verify(mockValidationManager, times(1)).validate(eq(validationSchema), any(JsonSubject.class));
+		verify(mockGridRowValidator, times(1)).validateBatch(eq(validationSchema), any());
 
 		handler.close();
 	}
 
 	@Test
 	public void testGetRowMetadataWithBothSynapseRowAndValidation() throws IOException {
+		String schemaId = "test-schema-id";
 		JsonSchema validationSchema = new JsonSchema();
 		ValidationResults validResults = new ValidationResults();
 		validResults.setIsValid(true);
 
-		when(mockValidationManager.validate(eq(validationSchema), any(JsonSubject.class)))
-				.thenReturn(validResults);
+		when(mockGridRowValidator.getValidationSchema(schemaId)).thenReturn(validationSchema);
+		when(mockGridRowValidator.validateBatch(eq(validationSchema), any())).thenReturn(List.of(validResults));
 
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager,
-				validationSchema);
+		SnapshotRowHandler handler = buildHandler(schemaId);
 
 		Row row = new Row().setValues(Arrays.asList("test", "123")).setRowId(1L).setVersionNumber(2L)
 				.setEtag("etag-123");
@@ -471,18 +478,17 @@ public class SnapshotRowHandlerTest {
 
 	@Test
 	public void testCreateValidationConstant() throws IOException {
+		String schemaId = "test-schema-id";
 		JsonSchema validationSchema = new JsonSchema();
 		ValidationResults validResults = new ValidationResults();
 		validResults.setIsValid(true);
 		validResults.setObjectId("test-id");
 		validResults.setObjectEtag("test-etag");
 
-		when(mockValidationManager.validate(eq(validationSchema), any(JsonSubject.class)))
-				.thenReturn(validResults);
+		when(mockGridRowValidator.getValidationSchema(schemaId)).thenReturn(validationSchema);
+		when(mockGridRowValidator.validateBatch(eq(validationSchema), any())).thenReturn(List.of(validResults));
 
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager,
-				validationSchema);
+		SnapshotRowHandler handler = buildHandler(schemaId);
 
 		Map<Integer, ConstantNode> cellValues = new LinkedHashMap<>();
 		cellValues.put(0, new ConstantNode().setId(new LogicalTimestamp().setReplicaId(replicaId)
@@ -500,8 +506,8 @@ public class SnapshotRowHandlerTest {
 		// Timestamp should be > 11 (highest cell value timestamp)
 		assertTrue(result.getId().getSequenceNumber() > 11L);
 
-		// Verify validation was called
-		verify(mockValidationManager, times(1)).validate(eq(validationSchema), any(JsonSubject.class));
+		// Verify validateBatch was called
+		verify(mockGridRowValidator, times(1)).validateBatch(eq(validationSchema), any());
 
 		// Verify validation results are in the constant
 		JSONObject validationJson = (JSONObject) result.getConValue().getValue();
@@ -512,42 +518,37 @@ public class SnapshotRowHandlerTest {
 	}
 
 	@Test
-	public void testCreateValidationConstantCleansUpResults() throws IOException {
+	public void testCreateValidationConstantReturnsValidateBatchResult() throws IOException {
+		String schemaId = "test-schema-id";
 		JsonSchema validationSchema = new JsonSchema();
 		ValidationResults validResults = new ValidationResults();
 		validResults.setIsValid(false);
 		validResults.setObjectId("test-id");
-		validResults.setObjectEtag("test-etag");
-		validResults.setValidatedOn(new java.util.Date());
-		validResults.setSchema$id("schema-id");
-		validResults.setValidationException(new ValidationException().setMessage("Some error"));
 
-		when(mockValidationManager.validate(eq(validationSchema), any(JsonSubject.class)))
-				.thenReturn(validResults);
+		when(mockGridRowValidator.getValidationSchema(schemaId)).thenReturn(validationSchema);
+		when(mockGridRowValidator.validateBatch(eq(validationSchema), any())).thenReturn(List.of(validResults));
 
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager,
-				validationSchema);
+		SnapshotRowHandler handler = buildHandler(schemaId);
 
 		Map<Integer, ConstantNode> cellValues = new LinkedHashMap<>();
 		cellValues.put(0, new ConstantNode().setId(new LogicalTimestamp().setReplicaId(replicaId)
 				.setSequenceNumber(10L)).setValue(new ConValue(ConType.STRING, "test")));
 
+		// call under test
 		ConstantNode result = handler.createValidationConstant(cellValues);
 
-		// Verify cleanup happened
+		// Verify the result from validateBatch is serialized into the constant
 		JSONObject validationJson = (JSONObject) result.getConValue().getValue();
-		assertFalse(validationJson.has("validatedOn"));
-		assertFalse(validationJson.has("schema$id"));
-		assertFalse(validationJson.has("validationException"));
+		assertFalse(validationJson.getBoolean("isValid"));
+
+		verify(mockGridRowValidator, times(1)).validateBatch(eq(validationSchema), any());
 
 		handler.close();
 	}
 
 	@Test
 	public void testFinalizeEncodingWithNoRows() throws IOException {
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 
 		// call under test - should not throw
 		handler.finalizeEncoding();
@@ -561,8 +562,7 @@ public class SnapshotRowHandlerTest {
 
 	@Test
 	public void testFinalizeEncodingWithRows() throws IOException {
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 
 		handler.nextRow(new Row().setValues(Arrays.asList("one", "1")));
 		handler.nextRow(new Row().setValues(Arrays.asList("two", "2")));
@@ -582,8 +582,7 @@ public class SnapshotRowHandlerTest {
 	public void testNoColumnsNoRows() throws IOException {
 		schema = Collections.emptyList();
 
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 		SnapshotRowHandler spyHandler = spy(handler);
 
 		// call under test
@@ -603,8 +602,7 @@ public class SnapshotRowHandlerTest {
 
 	@Test
 	public void testWithColumnNoRows() throws IOException {
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 		SnapshotRowHandler spyHandler = spy(handler);
 
 		// call under test
@@ -624,8 +622,7 @@ public class SnapshotRowHandlerTest {
 
 	@Test
 	public void testWithRows() throws IOException {
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 		SnapshotRowHandler spyHandler = spy(handler);
 
 		Row row1 = new Row().setValues(Arrays.asList("one", "101")).setRowId(1L).setVersionNumber(4L)
@@ -658,8 +655,7 @@ public class SnapshotRowHandlerTest {
 		List<Row> rows = TableModelTestUtils.createRows(schema, 3,
 				new TableModelTestUtils.ValueOptions().includeSpace(false));
 
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 		SnapshotRowHandler spyHandler = spy(handler);
 
 		// call under test
@@ -679,8 +675,7 @@ public class SnapshotRowHandlerTest {
 	public void testWriteNullOrUndefinedUsingRequiredColumnIndices() throws Exception {
 		requiredColumnIndices = List.of(1); // only the second column is required
 
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 		SnapshotRowHandler spyHandler = spy(handler);
 
 		Row row = new Row().setValues(Arrays.asList(null, null)).setRowId(1L).setVersionNumber(4L)
@@ -704,7 +699,7 @@ public class SnapshotRowHandlerTest {
 		// call under test
 		assertThrows(IllegalArgumentException.class, () -> {
 			new SnapshotRowHandler(null, sessionId, replicaId, schema, requiredColumnIndices, mockFileProvider,
-					mockEncoderProvider, createdByUserId, mockValidationManager, null);
+					mockEncoderProvider, createdByUserId, mockGridRowValidator, null);
 		});
 	}
 
@@ -714,17 +709,14 @@ public class SnapshotRowHandlerTest {
 				.thenThrow(new IOException("Failed to create temp file"));
 
 		// call under test
-		RuntimeException ex = assertThrows(RuntimeException.class, () -> {
-			new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema, requiredColumnIndices,
-					mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
-		});
+		RuntimeException ex = assertThrows(RuntimeException.class, this::buildHandler);
 
 		assertEquals("Failed to create temporary file for snapshot", ex.getMessage());
 	}
 
 	@Test
 	public void testWithValidationSchema() throws IOException {
-		// Setup validation schema and manager
+		String schemaId = "test-schema-id";
 		JsonSchema validationSchema = new JsonSchema();
 		ValidationResults validResults = new ValidationResults();
 		validResults.setIsValid(true);
@@ -732,12 +724,10 @@ public class SnapshotRowHandlerTest {
 		validResults.setObjectType(null);
 		validResults.setObjectEtag("test-etag");
 
-		when(mockValidationManager.validate(eq(validationSchema), any(JsonSubject.class)))
-				.thenReturn(validResults);
+		when(mockGridRowValidator.getValidationSchema(schemaId)).thenReturn(validationSchema);
+		when(mockGridRowValidator.validateBatch(eq(validationSchema), any())).thenReturn(List.of(validResults));
 
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager,
-				validationSchema);
+		SnapshotRowHandler handler = buildHandler(schemaId);
 		SnapshotRowHandler spyHandler = spy(handler);
 
 		Row row = new Row().setValues(Arrays.asList("one", "101")).setRowId(1L).setVersionNumber(4L)
@@ -755,20 +745,19 @@ public class SnapshotRowHandlerTest {
 		verifyFileCreatedUploadedAndDeleted();
 		verifySnapshotSaved();
 
-		// Verify validation was called once
-		verify(mockValidationManager, times(1)).validate(eq(validationSchema), any(JsonSubject.class));
+		// Verify validateBatch was called once
+		verify(mockGridRowValidator, times(1)).validateBatch(eq(validationSchema), any());
 	}
 
 	@Test
 	public void testWithNullValidationSchema() throws IOException {
-		SnapshotRowHandler handler = new SnapshotRowHandler(mockSnapshotStore, sessionId, replicaId, schema,
-				requiredColumnIndices, mockFileProvider, mockEncoderProvider, createdByUserId, mockValidationManager, null);
+		SnapshotRowHandler handler = buildHandler();
 		SnapshotRowHandler spyHandler = spy(handler);
 
 		Row row = new Row().setValues(Arrays.asList("one", "101")).setRowId(1L).setVersionNumber(4L)
 				.setEtag("fake-etag-1");
 
-		// call under test - null validation schema should skip validation
+		// call under test - null schema ID should skip validation
 		try (SnapshotRowHandler h = spyHandler) {
 			h.nextRow(row);
 		}
@@ -780,8 +769,8 @@ public class SnapshotRowHandlerTest {
 		verifyFileCreatedUploadedAndDeleted();
 		verifySnapshotSaved();
 
-		// Verify validation was NOT called
-		verify(mockValidationManager, never()).validate(any(), any());
+		// Verify validateBatch was NOT called
+		verify(mockGridRowValidator, never()).validateBatch(any(), any());
 	}
 
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/create/QueryCreateGridHandlerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/create/QueryCreateGridHandlerTest.java
@@ -36,7 +36,7 @@ import org.sagebionetworks.repo.manager.EntityManager;
 import org.sagebionetworks.repo.manager.grid.GridAuthorizationManager;
 import org.sagebionetworks.repo.manager.grid.IndexedModelEncoderProvider;
 import org.sagebionetworks.repo.manager.grid.SnapshotStore;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaManager;
+import org.sagebionetworks.repo.manager.grid.internal.replica.validation.GridRowValidator;
 import org.sagebionetworks.repo.manager.table.RowHandlerProvider;
 import org.sagebionetworks.repo.manager.table.TableQueryManager;
 import org.sagebionetworks.repo.manager.table.query.MainQuery;
@@ -104,7 +104,7 @@ public class QueryCreateGridHandlerTest {
 	@Mock
 	private EntityManager mockEntityManager;
 	@Mock
-	private JsonSchemaManager mockSchemaManager;
+	private GridRowValidator mockGridRowValidator;
 	@Mock
 	private GridAuthorizationManager mockGridAuthorizationManager;
 	
@@ -191,7 +191,7 @@ public class QueryCreateGridHandlerTest {
 		when(mockQueryManager.runQueryAsStream(eq(mockCallback), eq(mockSessionOwnerUser), eq(query),
 				rowHandlerProviderCaptor.capture(), eq(ACCESS_TYPE.READ), eq(ACCESS_TYPE.UPDATE))).thenReturn(new QueryResultBundle());
 		doReturn(Optional.of(schema$id)).when(handler).getSchemaId(mockUser, tableId, rows);
-		when(mockSchemaManager.getValidationSchema(schema$id)).thenReturn(new JsonSchema().setRequired(List.of("foo")));
+		when(mockGridRowValidator.getValidationSchema(schema$id)).thenReturn(new JsonSchema().setRequired(List.of("foo")));
 		when(mockEntityManager.getEntityType(tableId)).thenReturn(EntityType.entityview);
 
 		GridSession expected = new GridSession().setSessionId(gridSessionId);
@@ -470,7 +470,7 @@ public class QueryCreateGridHandlerTest {
 		GridReplica handlerReplica = new GridReplica().setReplicaId(replicaId);
 		List<ColumnModel> schema = List.of(new ColumnModel().setColumnType(ColumnType.INTEGER).setName("foo"));
 		Set<Long> collectedIds = new HashSet<>();
-		Optional<JsonSchema> validationSchema = Optional.empty();
+		Optional<String> schemaId = Optional.empty();
 		Long benefactorId = 555L;
 
 		when(mockFileProvider.createTempFile("snapshot", ".cbor")).thenReturn(mockFile);
@@ -479,7 +479,7 @@ public class QueryCreateGridHandlerTest {
 
 		// call under test
 		BenefactorCollectingRowHandler result = handler.getBenefactorCollectingRowHandler(
-				mockSnapshotStore, session, handlerReplica, schema, List.of(), userId, validationSchema, collectedIds);
+				mockSnapshotStore, session, handlerReplica, schema, List.of(), userId, schemaId, collectedIds);
 
 		assertNotNull(result);
 		// row with benefactorId — should be collected

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/create/RecordSetCreateGridHandlerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/create/RecordSetCreateGridHandlerTest.java
@@ -36,7 +36,7 @@ import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.manager.grid.IndexedModelEncoderProvider;
 import org.sagebionetworks.repo.manager.grid.SnapshotRowHandler;
 import org.sagebionetworks.repo.manager.grid.SnapshotStore;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaManager;
+import org.sagebionetworks.repo.manager.grid.internal.replica.validation.GridRowValidator;
 import org.sagebionetworks.repo.manager.table.RecordSetSchemaResolver;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.RecordSet;
@@ -55,7 +55,6 @@ import org.sagebionetworks.repo.model.grid.GridSession;
 import org.sagebionetworks.repo.model.grid.GridUtils;
 import org.sagebionetworks.repo.model.grid.encoding.IndexedModelEncoder;
 import org.sagebionetworks.repo.model.grid.patch.LogicalTimestamp;
-import org.sagebionetworks.repo.model.schema.JsonSchema;
 import org.sagebionetworks.repo.model.schema.JsonSchemaObjectBinding;
 import org.sagebionetworks.repo.model.schema.JsonSchemaVersionInfo;
 import org.sagebionetworks.repo.model.table.ColumnModel;
@@ -95,7 +94,7 @@ public class RecordSetCreateGridHandlerTest {
 	private CsvFileHandleProvider mockCsvProvider;
 
 	@Mock
-	private JsonSchemaManager mockJsonSchemaManager;
+	private GridRowValidator mockGridRowValidator;
 
 	@Mock
 	private FileProvider mockFileProvider;
@@ -129,7 +128,6 @@ public class RecordSetCreateGridHandlerTest {
 	private CsvTableDescriptor csvDescriptor;
 	private List<ColumnModel> csvSchema;
 	private RecordSet recordSet;
-	private JsonSchema jsonSchema;
 	private ClockTable clockTable;
 	@Mock
 	private CSVReader mockCsvReader;
@@ -149,7 +147,6 @@ public class RecordSetCreateGridHandlerTest {
 		replicaId = 88L;
 		replica = new GridReplica().setReplicaId(replicaId);
 		schema$id = "someorg-somename";
-		jsonSchema = new JsonSchema().setRequired(List.of("bar"));
 
 		gridSession = new GridSession();
 
@@ -181,7 +178,6 @@ public class RecordSetCreateGridHandlerTest {
 		when(mockAuthorizationManager.hasAccess(mockUser, recordSet.getId(), ACCESS_TYPE.DOWNLOAD)).thenReturn(AuthorizationStatus.authorized());
 		when(mockEntityManager.findBoundSchema(recordSet.getId())).thenReturn(Optional.of(
 				new JsonSchemaObjectBinding().setJsonSchemaVersionInfo(new JsonSchemaVersionInfo().set$id(schema$id))));
-		when(mockJsonSchemaManager.getValidationSchema(schema$id)).thenReturn(jsonSchema);
 
 		gridSession = new GridSession().setSessionId(gridSessionId);
 
@@ -197,7 +193,7 @@ public class RecordSetCreateGridHandlerTest {
 				.thenReturn(new RecordSetSchemaResolver.ReconciledSchema(csvSchema, List.of(1)));
 		doReturn(mockCsvReader).when(mockCsvProvider).getCsvReader(csvFile, csvDescriptor);
 		doReturn(mockRowHandler).when(handler).getSnapshotRowHandler(mockSnapshotStore, gridSession, replica, csvSchema,
-				 List.of(1), mockFileProvider, userId, jsonSchema);
+				 List.of(1), mockFileProvider, userId, schema$id);
 
 		when(mockCsvReader.readNext()).thenReturn(new String[] { "foo", "bar" }, new String[] { "1", "one" },
 				new String[] { "2", "two" }, new String[] { null, "three" }, null);
@@ -266,8 +262,6 @@ public class RecordSetCreateGridHandlerTest {
 		when(mockUser.getId()).thenReturn(userId);
 		when(mockEntityManager.getEntity(mockUser, recordSet.getId(), RecordSet.class)).thenReturn(recordSet);
 		when(mockAuthorizationManager.hasAccess(mockUser, recordSet.getId(), ACCESS_TYPE.DOWNLOAD)).thenReturn(AuthorizationStatus.authorized());
-		when(mockEntityManager.findBoundSchema(recordSet.getId())).thenReturn(Optional.empty());
-		when(mockJsonSchemaManager.getValidationSchema(schema$id)).thenReturn(jsonSchema);
 		when(mockEntityManager.findBoundSchema(recordSet.getId())).thenReturn(Optional.of(
 				new JsonSchemaObjectBinding().setJsonSchemaVersionInfo(new JsonSchemaVersionInfo().set$id(schema$id))));
 
@@ -286,7 +280,7 @@ public class RecordSetCreateGridHandlerTest {
 				.thenReturn(new RecordSetSchemaResolver.ReconciledSchema(csvSchema, List.of(1)));
 		doReturn(mockCsvReader).when(mockCsvProvider).getCsvReader(csvFile, csvDescriptor);
 		doReturn(mockRowHandler).when(handler).getSnapshotRowHandler(mockSnapshotStore, gridSession, replica, csvSchema,
-				List.of(1), mockFileProvider, userId, jsonSchema);
+				List.of(1), mockFileProvider, userId, schema$id);
 
 		when(mockCsvReader.readNext()).thenReturn(new String[] { "foo", "bar" }, new String[] { "1", "one" },
 				new String[] { "2", "two" }, new String[] { null, "three" }, null);
@@ -311,8 +305,6 @@ public class RecordSetCreateGridHandlerTest {
 		when(mockUser.getId()).thenReturn(userId);
 		when(mockEntityManager.getEntity(mockUser, recordSet.getId(), RecordSet.class)).thenReturn(recordSet);
 		when(mockAuthorizationManager.hasAccess(mockUser, recordSet.getId(), ACCESS_TYPE.DOWNLOAD)).thenReturn(AuthorizationStatus.authorized());
-		when(mockEntityManager.findBoundSchema(recordSet.getId())).thenReturn(Optional.empty());
-		when(mockJsonSchemaManager.getValidationSchema(schema$id)).thenReturn(jsonSchema);
 		when(mockEntityManager.findBoundSchema(recordSet.getId())).thenReturn(Optional.of(
 				new JsonSchemaObjectBinding().setJsonSchemaVersionInfo(new JsonSchemaVersionInfo().set$id(schema$id))));
 
@@ -331,7 +323,7 @@ public class RecordSetCreateGridHandlerTest {
 				.thenReturn(new RecordSetSchemaResolver.ReconciledSchema(csvSchema, List.of(1)));
 		doReturn(mockCsvReader).when(mockCsvProvider).getCsvReader(csvFile, csvDescriptor);
 		doReturn(mockRowHandler).when(handler).getSnapshotRowHandler(mockSnapshotStore, gridSession, replica, csvSchema,
-				List.of(1), mockFileProvider, userId, jsonSchema);
+				List.of(1), mockFileProvider, userId, schema$id);
 
 		when(mockCsvReader.readNext()).thenThrow(ioe);
 
@@ -391,7 +383,7 @@ public class RecordSetCreateGridHandlerTest {
 
 		// Call under test
 		SnapshotRowHandler snapshotHandler = handler.getSnapshotRowHandler(mockSnapshotStore, gridSession, replica, csvSchema,
-				List.of(), mockFileProvider, userId, jsonSchema);
+				List.of(), mockFileProvider, userId, null);
 
 
 		assertNotNull(snapshotHandler);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridReplicaValidationManagerImplTest.java
@@ -38,8 +38,6 @@ import org.sagebionetworks.repo.manager.grid.internal.replica.model.RowView;
 import org.sagebionetworks.repo.manager.grid.internal.replica.view.GridReplicaViewManager;
 import org.sagebionetworks.repo.manager.grid.internal.replica.view.query.filter.FilterElement;
 import org.sagebionetworks.repo.manager.grid.internal.replica.view.query.filter.VectorIdFilterElement;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaManager;
-import org.sagebionetworks.repo.manager.schema.JsonSchemaValidationManager;
 import org.sagebionetworks.repo.model.dbo.grid.GridDao;
 import org.sagebionetworks.repo.model.grid.EventSource;
 import org.sagebionetworks.repo.model.grid.GridConnectionInfo;
@@ -56,11 +54,9 @@ public class GridReplicaValidationManagerImplTest {
 	@Mock
 	private GridReplicaViewManager mockGridReplicaViewManager;
 	@Mock
-	private JsonSchemaManager mockJsonSchemaManager;
+	private GridRowValidator mockGridRowValidator;
 	@Mock
 	private GridDao mockGridDao;
-	@Mock
-	private JsonSchemaValidationManager mockJsonSchemaValidationManager;
 	@Mock
 	private PatchBuilderPublisher mockPatchBuilderPublisher;
 
@@ -340,7 +336,7 @@ public class GridReplicaValidationManagerImplTest {
 		// call under test
 		manager.validateAllRows(sessionId, replicaId);
 
-		verifyNoMoreInteractions(mockPatchBuilderPublisher, mockJsonSchemaManager, mockJsonSchemaValidationManager);
+		verifyNoMoreInteractions(mockPatchBuilderPublisher, mockGridRowValidator);
 	}
 
 	@Test
@@ -353,7 +349,7 @@ public class GridReplicaValidationManagerImplTest {
 
 	@Test
 	public void testValidateRows() {
-		when(mockJsonSchemaManager.getValidationSchema(schemaId)).thenReturn(jsonSchema);
+		when(mockGridRowValidator.getValidationSchema(schemaId)).thenReturn(jsonSchema);
 		rows.get(0).setRowObject(new RowObject()
 				.setData(new RowData().setRowJsonDocument(new JSONObject("{\"key\":\"value1\"}"))));
 		// Sets an existing and equal validation result for the second row
@@ -363,7 +359,7 @@ public class GridReplicaValidationManagerImplTest {
 				new RowMetadata().setRowValidation(new RowValidation().setValidationResults(validationResult))));
 		IntendedChange intendedChange2 = new UpdateMetadataChange().setRowMetadataId(rows.get(1).getArrNodeId());
 
-		when(mockJsonSchemaValidationManager.validateBatch(jsonSchema,
+		when(mockGridRowValidator.validateBatch(jsonSchema,
 				List.of(new JsonObjectSubject(rows.get(0).getRowObject().getData().getRowJsonDocument()),
 						new JsonObjectSubject(rows.get(1).getRowObject().getData().getRowJsonDocument())
 				)))
@@ -382,8 +378,8 @@ public class GridReplicaValidationManagerImplTest {
 	public void testCleanupValidation() {
 		validationResult.setSchema$id(schemaId);
 		validationResult.setValidatedOn(new Date());
-		// call under test
-		manager.cleanupValidationResults(validationResult);
+		// call under test — cleanup lives on GridRowValidator
+		GridRowValidator.cleanupValidationResults(validationResult);
 		assertNull(validationResult.getSchema$id());
 		assertNull(validationResult.getValidatedOn());
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridRowValidatorTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/GridRowValidatorTest.java
@@ -1,0 +1,76 @@
+package org.sagebionetworks.repo.manager.grid.internal.replica.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sagebionetworks.repo.manager.schema.JsonSchemaManager;
+import org.sagebionetworks.repo.manager.schema.JsonSchemaValidationManager;
+import org.sagebionetworks.repo.manager.schema.JsonSubject;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.repo.model.schema.ValidationResults;
+
+@ExtendWith(MockitoExtension.class)
+public class GridRowValidatorTest {
+
+	@Mock
+	private JsonSchemaManager mockJsonSchemaManager;
+	@Mock
+	private JsonSchemaValidationManager mockJsonSchemaValidationManager;
+	@Mock
+	private JsonSubject mockSubject;
+
+	@InjectMocks
+	private GridRowValidator validator;
+
+	@Test
+	public void testGetValidationSchema() {
+		JsonSchema schema = new JsonSchema().set$id("my.org-Schema-1.0.0");
+		when(mockJsonSchemaManager.getValidationSchema("my.org-Schema-1.0.0")).thenReturn(schema);
+
+		// call under test
+		JsonSchema result = validator.getValidationSchema("my.org-Schema-1.0.0");
+
+		assertSame(schema, result);
+		verify(mockJsonSchemaManager).getValidationSchema("my.org-Schema-1.0.0");
+	}
+
+	@Test
+	public void testValidateBatchAppliesCleanup() {
+		JsonSchema schema = new JsonSchema();
+		ValidationResults dirty = new ValidationResults().setIsValid(true).setSchema$id("schema").setValidatedOn(new Date());
+		when(mockJsonSchemaValidationManager.validateBatch(schema, List.of(mockSubject)))
+				.thenReturn(List.of(dirty));
+
+		// call under test
+		List<ValidationResults> results = validator.validateBatch(schema, List.of(mockSubject));
+
+		assertEquals(1, results.size());
+		// transient fields are cleared by the shared cleanup
+		assertNull(results.get(0).getSchema$id());
+		assertNull(results.get(0).getValidatedOn());
+		assertEquals(Boolean.TRUE, results.get(0).getIsValid());
+	}
+
+	@Test
+	public void testCleanupValidationResults() {
+		ValidationResults results = new ValidationResults().setSchema$id("schema").setValidatedOn(new Date());
+
+		// call under test
+		GridRowValidator.cleanupValidationResults(results);
+
+		assertNull(results.getSchema$id());
+		assertNull(results.getValidatedOn());
+		assertNull(results.getValidationException());
+	}
+}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/ValidationSummaryAccumulatorTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/validation/ValidationSummaryAccumulatorTest.java
@@ -1,0 +1,222 @@
+package org.sagebionetworks.repo.manager.grid.internal.replica.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sagebionetworks.repo.model.jdo.JDOSecondaryPropertyUtils;
+import org.sagebionetworks.repo.model.schema.ValidationResults;
+import org.sagebionetworks.repo.model.schema.ValidationSummaryStatistics;
+
+import au.com.bytecode.opencsv.CSVWriter;
+
+@ExtendWith(MockitoExtension.class)
+public class ValidationSummaryAccumulatorTest {
+
+	@Mock
+	private CSVWriter mockCsvWriter;
+
+	private ValidationSummaryAccumulator accumulator;
+
+	@BeforeEach
+	public void before() throws IOException {
+		accumulator = new ValidationSummaryAccumulator(mockCsvWriter);
+	}
+
+	@Test
+	public void testConstructorWritesHeader() throws IOException {
+		// call under test — header is written during construction in @BeforeEach
+		verify(mockCsvWriter).writeNext(ValidationSummaryAccumulator.VALIDATION_CSV_HEADERS);
+	}
+
+	@Test
+	public void testRecordWithNullResult() throws IOException {
+		ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+
+		// call under test
+		accumulator.record(null);
+
+		verify(mockCsvWriter, times(2)).writeNext(captor.capture());
+		String[] dataRow = captor.getAllValues().get(1);
+		assertEquals("0", dataRow[0]);   // row_index
+		assertNull(dataRow[1]);           // is_valid
+		assertNull(dataRow[2]);           // validation_error_message
+		assertNull(dataRow[3]);           // all_validation_messages
+	}
+
+	@Test
+	public void testRecordWithValidResult() throws IOException {
+		ValidationResults result = new ValidationResults().setIsValid(true);
+		ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+
+		// call under test
+		accumulator.record(result);
+
+		verify(mockCsvWriter, times(2)).writeNext(captor.capture());
+		String[] dataRow = captor.getAllValues().get(1);
+		assertEquals("0", dataRow[0]);
+		assertEquals("true", dataRow[1]);
+		assertNull(dataRow[2]);
+		assertNull(dataRow[3]);
+	}
+
+	@Test
+	public void testRecordWithInvalidResult() throws IOException {
+		List<String> allMessages = List.of("Property 'name' is required", "Value exceeds max length");
+		ValidationResults result = new ValidationResults()
+				.setIsValid(false)
+				.setValidationErrorMessage("Property 'name' is required")
+				.setAllValidationMessages(allMessages);
+		String expectedAllMessages = JDOSecondaryPropertyUtils.writeStringListToJson(allMessages);
+
+		ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+
+		// call under test
+		accumulator.record(result);
+
+		verify(mockCsvWriter, times(2)).writeNext(captor.capture());
+		String[] dataRow = captor.getAllValues().get(1);
+		assertEquals("0", dataRow[0]);
+		assertEquals("false", dataRow[1]);
+		assertEquals("Property 'name' is required", dataRow[2]);
+		assertEquals(expectedAllMessages, dataRow[3]);
+	}
+
+	@Test
+	public void testRecordWithInvalidResultAndNullMessages() throws IOException {
+		ValidationResults result = new ValidationResults()
+				.setIsValid(false)
+				.setValidationErrorMessage(null)
+				.setAllValidationMessages(null);
+
+		ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+
+		// call under test — must not throw even when messages are null
+		accumulator.record(result);
+
+		verify(mockCsvWriter, times(2)).writeNext(captor.capture());
+		String[] dataRow = captor.getAllValues().get(1);
+		assertEquals("false", dataRow[1]);
+		assertNull(dataRow[2]);
+		assertNull(dataRow[3]);
+	}
+
+	@Test
+	public void testRecordWithNullIsValidCountsAsInvalid() throws IOException {
+		// A non-null result with a null isValid field falls through to the invalid branch
+		ValidationResults result = new ValidationResults().setIsValid(null);
+
+		ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+
+		// call under test
+		accumulator.record(result);
+
+		verify(mockCsvWriter, times(2)).writeNext(captor.capture());
+		String[] dataRow = captor.getAllValues().get(1);
+		assertEquals("false", dataRow[1]);
+
+		ValidationSummaryStatistics summary = accumulator.getValidationSummary("syn1");
+		assertEquals(1L, summary.getNumberOfInvalidChildren());
+		assertEquals(0L, summary.getNumberOfValidChildren());
+		assertEquals(0L, summary.getNumberOfUnknownChildren());
+	}
+
+	@Test
+	public void testRecordRowIndexIncrements() throws IOException {
+		ValidationResults valid = new ValidationResults().setIsValid(true);
+
+		// call under test — three consecutive records
+		accumulator.record(valid);
+		accumulator.record(valid);
+		accumulator.record(valid);
+
+		ArgumentCaptor<String[]> captor = ArgumentCaptor.forClass(String[].class);
+		verify(mockCsvWriter, times(4)).writeNext(captor.capture());
+
+		List<String[]> rows = captor.getAllValues();
+		assertEquals("0", rows.get(1)[0]);  // first data row
+		assertEquals("1", rows.get(2)[0]);  // second data row
+		assertEquals("2", rows.get(3)[0]);  // third data row
+	}
+
+	@Test
+	public void testGetValidationSummaryWithNoRows() {
+		// call under test
+		ValidationSummaryStatistics summary = accumulator.getValidationSummary("syn123");
+
+		assertEquals("syn123", summary.getContainerId());
+		assertEquals(0L, summary.getTotalNumberOfChildren());
+		assertEquals(0L, summary.getNumberOfValidChildren());
+		assertEquals(0L, summary.getNumberOfInvalidChildren());
+		assertEquals(0L, summary.getNumberOfUnknownChildren());
+	}
+
+	@Test
+	public void testGetValidationSummaryWithMixedRows() {
+		ValidationResults valid = new ValidationResults().setIsValid(true);
+		ValidationResults invalid = new ValidationResults().setIsValid(false);
+
+		// 2 valid, 2 invalid, 1 unknown (null) in mixed order
+		accumulator.record(valid);
+		accumulator.record(null);
+		accumulator.record(invalid);
+		accumulator.record(valid);
+		accumulator.record(invalid);
+
+		// call under test
+		ValidationSummaryStatistics summary = accumulator.getValidationSummary("syn456");
+
+		assertEquals("syn456", summary.getContainerId());
+		assertEquals(5L, summary.getTotalNumberOfChildren());
+		assertEquals(2L, summary.getNumberOfValidChildren());
+		assertEquals(2L, summary.getNumberOfInvalidChildren());
+		assertEquals(1L, summary.getNumberOfUnknownChildren());
+	}
+
+	@Test
+	public void testGetValidationSummaryContainerId() {
+		// call under test
+		ValidationSummaryStatistics summary = accumulator.getValidationSummary("syn999");
+
+		assertEquals("syn999", summary.getContainerId());
+	}
+
+	@Test
+	public void testGetValidationSummaryGeneratedOnIsNotNull() {
+		// call under test
+		ValidationSummaryStatistics summary = accumulator.getValidationSummary("syn1");
+
+		assertNotNull(summary.getGeneratedOn());
+	}
+
+	@Test
+	public void testRecordIOExceptionWrappedAsIllegalState() throws IOException {
+		IOException cause = new IOException("disk full");
+		doThrow(cause).when(mockCsvWriter).writeNext(any(String[].class));
+
+		ValidationResults result = new ValidationResults().setIsValid(true);
+
+		// call under test
+		IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
+			accumulator.record(result);
+		});
+
+		assertEquals("Could not write validation details to CSV file.", ex.getMessage());
+		assertEquals(cause, ex.getCause());
+	}
+
+}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/table/RecordSetSchemaResolverTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/table/RecordSetSchemaResolverTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -126,7 +127,7 @@ public class RecordSetSchemaResolverTest {
 				csvDescriptor, false);
 
 		assertEquals(List.of("a", "b", "c"),
-				result.getSchema().stream().map(ColumnModel::getName).collect(java.util.stream.Collectors.toList()));
+				result.getSchema().stream().map(ColumnModel::getName).collect(Collectors.toList()));
 		// "a" is index 0, "c" is index 2 in the inferred schema.
 		assertEquals(List.of(0, 2), result.getRequiredColumnIndices());
 	}
@@ -166,5 +167,32 @@ public class RecordSetSchemaResolverTest {
 		resolver.getReconciledSchema(entityId, fileHandle, csvDescriptor, true);
 
 		verify(resolver).inferSchemaFromCsv(fileHandle, csvDescriptor, true);
+	}
+
+	@Test
+	public void testGetReconciledSchemaAddsSchemaOnlyColumn() {
+		// The CSV has only "a"; the bound schema declares an additional property "c"
+		// that is not in the CSV. "c" must be appended as a new column.
+		stubInferSchema(List.of(new ColumnModel().setName("a").setColumnType(ColumnType.INTEGER)));
+		JsonSchema validationSchema = new JsonSchema()
+				.setProperties(Map.of("c", new JsonSchema().setType(Type.integer)));
+		stubBoundSchema(validationSchema);
+
+		// call under test
+		List<ColumnModel> schema = resolver.getReconciledSchema(entityId, fileHandle, csvDescriptor, false).getSchema();
+
+		assertEquals(List.of("a", "c"),
+				schema.stream().map(ColumnModel::getName).collect(Collectors.toList()));
+		assertEquals(ColumnType.INTEGER, schema.get(1).getColumnType());
+	}
+
+	@Test
+	public void testToColumnModel() {
+		assertEquals(ColumnType.INTEGER, RecordSetSchemaResolver.toColumnModel("i", new JsonSchema().setType(Type.integer)).getColumnType());
+		assertEquals(ColumnType.DOUBLE, RecordSetSchemaResolver.toColumnModel("n", new JsonSchema().setType(Type.number)).getColumnType());
+		assertEquals(ColumnType.BOOLEAN, RecordSetSchemaResolver.toColumnModel("b", new JsonSchema().setType(Type._boolean)).getColumnType());
+		assertEquals(ColumnType.STRING, RecordSetSchemaResolver.toColumnModel("s", new JsonSchema().setType(Type.string)).getColumnType());
+		assertEquals(ColumnType.STRING_LIST, RecordSetSchemaResolver.toColumnModel("arr", new JsonSchema().setType(Type.array)).getColumnType());
+		assertEquals(ColumnType.STRING, RecordSetSchemaResolver.toColumnModel("untyped", new JsonSchema()).getColumnType());
 	}
 }


### PR DESCRIPTION
- Expand RecordSetSchemaResolver to include columns defined by the JSON Schema even if they are absent from the CSV
- Refactor grid validation logic into a new GridRowValidator class
- Lightly refactor RecordSetSchemaExporter to simplify later reuse