### PR TITLE
PLFM-7275

### DIFF
--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClient.java
@@ -2094,7 +2094,15 @@ public interface SynapseClient extends BaseClient {
 	 */
 	PrincipalAlias bindOAuthProvidersUserId(OAuthValidationRequest request)
 			throws SynapseException;
-	
+
+	/**
+	 * Bind an OIDC identity (subject) to the user's account.
+	 *
+	 * @param request
+	 * @throws SynapseException
+	 */
+	void bindOIDCIdentity(OAuthValidationRequest request) throws SynapseException;
+
 	/**
 	 * Remove an alias associated with an account via the OAuth mechanism.
 	 * 

--- a/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
+++ b/client/synapseJavaClient/src/main/java/org/sagebionetworks/client/SynapseClientImpl.java
@@ -640,7 +640,8 @@ public class SynapseClientImpl extends BaseClientImpl implements SynapseClient {
 	public static final String AUTH_OAUTH_2_SESSION_V2 = AUTH_OAUTH_2+"/session2";
 	public static final String AUTH_OAUTH_2_ACCOUNT_V2 = AUTH_OAUTH_2+"/account2";
 	public static final String AUTH_OAUTH_2_ALIAS = AUTH_OAUTH_2+"/alias";
-	
+	public static final String AUTH_OAUTH_2_IDENTITY = AUTH_OAUTH_2+"/identity";
+
 	public static final String AUTH_OPENID_CONFIG = "/.well-known/openid-configuration";
 	public static final String AUTH_OAUTH_2_JWKS = AUTH_OAUTH_2+"/jwks";
 	public static final String AUTH_OAUTH_2_CLIENT = AUTH_OAUTH_2+"/client";
@@ -4660,9 +4661,14 @@ public class SynapseClientImpl extends BaseClientImpl implements SynapseClient {
 	public PrincipalAlias bindOAuthProvidersUserId(OAuthValidationRequest request)
 			throws SynapseException {
 		return postJSONEntity(getAuthEndpoint(), AUTH_OAUTH_2_ALIAS, request, PrincipalAlias.class);
-		
+
 	}
-	
+
+	@Override
+	public void bindOIDCIdentity(OAuthValidationRequest request) throws SynapseException {
+		voidPost(getAuthEndpoint(), AUTH_OAUTH_2_IDENTITY, request, null);
+	}
+
 	@Override
 	public void unbindOAuthProvidersUserId(OAuthProvider provider, String alias) throws SynapseException {
 		ValidateArgument.required(provider, "provider");

--- a/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
+++ b/integration-test/src/test/java/org/sagebionetworks/IT990AuthenticationController.java
@@ -287,11 +287,30 @@ public class IT990AuthenticationController {
 			// OK
 		}
 	}
-	
+
+	/**
+	 * Since a browser is needed to get a real authentication code, we are just testing
+	 * that everything is wired up correctly.
+	 * @throws SynapseException
+	 */
+	@Test
+	public void testBindOIDCIdentity() throws SynapseException {
+		try {
+			OAuthValidationRequest request = new OAuthValidationRequest();
+			request.setProvider(OAuthProvider.GOOGLE_OAUTH_2_0);
+			request.setRedirectUrl("https://www.synapse.org");
+			request.setAuthenticationCode("test auth code");
+			synapseClient.bindOIDCIdentity(request);
+			fail();
+		} catch (SynapseForbiddenException e) {
+			// OK
+		}
+	}
+
 	/**
 	 * Since a browser is need to get a real authentication code, we are just testing
 	 * that everything is wires up correctly.
-	 * @throws SynapseException 
+	 * @throws SynapseException
 	 */
 	@Test
 	public void testUnbindExternalId() throws SynapseException {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationService.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationService.java
@@ -85,6 +85,8 @@ public interface AuthenticationService {
 
 	void unbindExternalID(Long userId, OAuthProvider provider, String aliasName);
 
+	void bindOIDCIdentity(Long userId, OAuthValidationRequest validationRequest);
+
 	/**
 	 * Authenticates username and password combination
 	 * User can use an authentication receipt from previous login to skip extra security checks

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImpl.java
@@ -1,5 +1,6 @@
 package org.sagebionetworks.repo.service.auth;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
@@ -51,6 +52,7 @@ import org.sagebionetworks.repo.model.oauth.OAuthUrlResponse;
 import org.sagebionetworks.repo.model.oauth.OAuthValidationRequest;
 import org.sagebionetworks.repo.model.principal.AliasType;
 import org.sagebionetworks.repo.model.principal.PrincipalAlias;
+import org.sagebionetworks.repo.model.principal.PrincipalAliasDAO;
 import org.sagebionetworks.repo.transactions.WriteTransaction;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.util.ValidateArgument;
@@ -310,6 +312,34 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 		}
 		// now bind the ID to the user account
 		return userManager.bindAlias(providersUserId.getAlias(), providersUserId.getType(), userId);
+	}
+	
+	@Override
+	public void bindOIDCIdentity(Long userId, OAuthValidationRequest validationRequest) {
+		
+		UserInfo user = userManager.getUserInfo(userId);
+		
+		if (user.isUserAnonymous()) {
+			throw new UnauthorizedException("User ID is required.");
+		}
+		
+		// only allow the binding if the given provider is in the user's realm
+		IdentityProvider identityProvider = new OAuthIdentityProvider().setProvider(validationRequest.getProvider());
+		Optional<String> optionalRealmId = realmDao.getRealmIdForIdentityProvider(identityProvider);
+		if (optionalRealmId.isEmpty()) {
+			throw new IllegalArgumentException("There is no security realm associated with "+validationRequest.getProvider().name());
+		}
+		if (!user.getRealmId().equals(optionalRealmId.get())) {
+			throw new IllegalArgumentException("Cannot bind an alias from "+validationRequest.getProvider().name()+" for this user.");
+		}
+
+		ProvidedUserInfo providedUserInfo = oauthManager.validateUserWithProvider(
+			validationRequest.getProvider(), 
+			validationRequest.getAuthenticationCode(),
+			validationRequest.getRedirectUrl());
+		
+		PrincipalAlias principalAlias = new PrincipalAlias().setPrincipalId(user.getId());
+		userManager.bindUserToOidcSubject(principalAlias, validationRequest.getProvider(), providedUserInfo.getSubject());
 	}
 	
 	@Override

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/service/auth/AuthenticationServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -745,6 +746,78 @@ public class AuthenticationServiceImplTest {
 		});
 	}
 	
+
+	@Test
+	public void testBindOIDCIdentity() {
+		String realmId = "3";
+		userInfo = new UserInfo(false, userId, realmId);
+		OAuthValidationRequest request = new OAuthValidationRequest();
+		request.setAuthenticationCode("some code");
+		request.setProvider(OAuthProvider.GOOGLE_OAUTH_2_0);
+		request.setRedirectUrl("https://domain.com");
+		String subject = "subject-123";
+
+		when(mockUserManager.getUserInfo(userId)).thenReturn(userInfo);
+		when(mockRealmDao.getRealmIdForIdentityProvider(any())).thenReturn(Optional.of(realmId));
+		ProvidedUserInfo providedUserInfo = new ProvidedUserInfo();
+		providedUserInfo.setSubject(subject);
+		when(mockOAuthManager.validateUserWithProvider(
+				request.getProvider(), request.getAuthenticationCode(), request.getRedirectUrl())).thenReturn(providedUserInfo);
+
+		// call under test
+		service.bindOIDCIdentity(userId, request);
+
+		PrincipalAlias expectedAlias = new PrincipalAlias().setPrincipalId(userId);
+		verify(mockUserManager).bindUserToOidcSubject(eq(expectedAlias), eq(OAuthProvider.GOOGLE_OAUTH_2_0), eq(subject));
+	}
+
+	@Test
+	public void testBindOIDCIdentityWithAnonymous() {
+		Long anonId = AuthorizationConstants.BOOTSTRAP_PRINCIPAL.ANONYMOUS_USER.getPrincipalId();
+		UserInfo anonUserInfo = new UserInfo(false, anonId, "0");
+		anonUserInfo.setRealmAnonymousUserId(anonId);
+		when(mockUserManager.getUserInfo(anonId)).thenReturn(anonUserInfo);
+		assertThrows(UnauthorizedException.class, () -> service.bindOIDCIdentity(anonId, null));
+	}
+
+	@Test
+	public void testBindOIDCIdentityWithWrongRealm() {
+		String userRealmId = "3";
+		String requestRealmId = "4";
+		userInfo = new UserInfo(false, userId, userRealmId);
+		OAuthValidationRequest request = new OAuthValidationRequest();
+		request.setAuthenticationCode("some code");
+		request.setProvider(OAuthProvider.GOOGLE_OAUTH_2_0);
+		request.setRedirectUrl("https://domain.com");
+
+		when(mockUserManager.getUserInfo(userId)).thenReturn(userInfo);
+		when(mockRealmDao.getRealmIdForIdentityProvider(any())).thenReturn(Optional.of(requestRealmId));
+
+		// call under test
+		assertThrows(IllegalArgumentException.class, () -> {
+			service.bindOIDCIdentity(userId, request);
+		});
+		verify(mockOAuthManager, never()).validateUserWithProvider(any(), any(), any());
+	}
+
+	@Test
+	public void testBindOIDCIdentityWithNoRealm() {
+		String userRealmId = "3";
+		userInfo = new UserInfo(false, userId, userRealmId);
+		OAuthValidationRequest request = new OAuthValidationRequest();
+		request.setAuthenticationCode("some code");
+		request.setProvider(OAuthProvider.GOOGLE_OAUTH_2_0);
+		request.setRedirectUrl("https://domain.com");
+
+		when(mockUserManager.getUserInfo(userId)).thenReturn(userInfo);
+		when(mockRealmDao.getRealmIdForIdentityProvider(any())).thenReturn(Optional.empty());
+
+		// call under test
+		assertThrows(IllegalArgumentException.class, () -> {
+			service.bindOIDCIdentity(userId, request);
+		});
+		verify(mockOAuthManager, never()).validateUserWithProvider(any(), any(), any());
+	}
 
 	@Test
 	public void testUnbindExternalID() throws NotFoundException{

--- a/services/repository/src/main/java/org/sagebionetworks/auth/controller/AuthenticationController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/auth/controller/AuthenticationController.java
@@ -342,6 +342,28 @@ public class AuthenticationController {
 	}
 	
 	/**
+	 * After a user has been authenticated at an OAuth provider's web page, the
+	 * provider will redirect the browser to the provided redirectUrl. The
+	 * provider will add a query parameter to the redirectUrl called "code" that
+	 * represents the authorization code for the user. This method will use the
+	 * authorization code to fetch the provider's ID for the user.  The provider's
+	 * ID will then be bound to the user's account.
+	 * 
+	 * @param request
+	 * @param userId
+	 * @return
+	 * @throws Exception
+	 */
+	@RequiredScope({})
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@RequestMapping(value = UrlHelpers.AUTH_OAUTH_2_IDENTITY, method = RequestMethod.POST)
+	public void bindOIDCIdentityToAccount(@RequestBody OAuthValidationRequest request,
+			@RequestParam(value = AuthorizationConstants.USER_ID_PARAM) Long userId)
+			throws Exception {
+		authenticationService.bindOIDCIdentity(userId, request);
+	}
+	
+	/**
 	 * After a user has been authenticated at an OAuthProvider's web page, the
 	 * provider will redirect the browser to the provided redirectUrl. The
 	 * provider will add a query parameter to the redirectUrl called "code" that

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/UrlHelpers.java
@@ -1240,6 +1240,7 @@ public class UrlHelpers {
 	public static final String AUTH_OAUTH_2_SESSION = AUTH_OAUTH_2+"/session";
 	public static final String AUTH_OAUTH_2_SESSION_V2 = AUTH_OAUTH_2+"/session2";
 	public static final String AUTH_OAUTH_2_ALIAS = AUTH_OAUTH_2+"/alias";
+	public static final String AUTH_OAUTH_2_IDENTITY = AUTH_OAUTH_2+"/identity";
 	public static final String AUTH_OAUTH_2_ACCOUNT = AUTH_OAUTH_2+"/account";
 	public static final String AUTH_OAUTH_2_ACCOUNT_V2 = AUTH_OAUTH_2+"/account2";
 	public static final String WELL_KNOWN = "/.well-known";

--- a/services/repository/src/main/webapp/WEB-INF/web.xml
+++ b/services/repository/src/main/webapp/WEB-INF/web.xml
@@ -134,6 +134,7 @@
 		<url-pattern>/auth/v1/sessionAccessToken</url-pattern>
 		<url-pattern>/auth/v1/user/*</url-pattern>
 		<url-pattern>/auth/v1/oauth2/alias</url-pattern>
+		<url-pattern>/auth/v1/oauth2/identity</url-pattern>
 		<url-pattern>/auth/v1/oauth2/client/*</url-pattern>
 		<url-pattern>/auth/v1/authenticatedOn</url-pattern>
 		<url-pattern>/auth/v1/oauth2/consent</url-pattern>


### PR DESCRIPTION
For RAS integration we need a way to bind an OIDC-based identity to an existing Synapse account.  It's suprising that we don't have a way to do this today, since we can already bind a Google or and ORCID identity to an existing Synapse account.  That's because, in each of those cases we bind an 'alias' to the account using some unique attribute:  In the case of Google we use the unique email address, understanding it will never change; in the case of ORCID we use the ORCID which, again, is immutable.  But we don't directly bind the OIDC 'subject', which is the immutable OIDC identifier.  When we create a new Synapse account based on an OIDC provider we DO do this.  We just need a service that does this for an arbitrary OIDC provider, like RAS.