### PR TITLE
[PLFM-9750] - Retry AOSS 402 (OCU capacity) bulk-index failures

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -73,6 +73,9 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	private static final Logger LOG = LogManager.getLogger(OpenSearchManagerImpl.class);
 
 	private static final int HTTP_TOO_MANY_REQUESTS = 429;
+	// AOSS returns 402 with service_quota_exceeded_exception ("maximum OCU capacity reached")
+	// when the collection hits its OCU ceiling — a transient, auto-scaling condition, so retryable.
+	private static final int HTTP_PAYMENT_REQUIRED = 402;
 	private static final int HTTP_INTERNAL_SERVER_ERROR = 500;
 	private static final int HTTP_MAX_SERVER_ERROR = 599;
 
@@ -706,6 +709,7 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 
 	static boolean isRetryableItemStatus(int status) {
 		return status == HTTP_TOO_MANY_REQUESTS
+				|| status == HTTP_PAYMENT_REQUIRED
 				|| (status >= HTTP_INTERNAL_SERVER_ERROR && status <= HTTP_MAX_SERVER_ERROR);
 	}
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -391,6 +391,13 @@ public class OpenSearchManagerImplTest {
 	}
 
 	@Test
+	public void testIsRetryableItemStatusFor402() {
+		// AOSS returns 402 service_quota_exceeded_exception when the collection hits its OCU
+		// ceiling — a transient, auto-scaling condition, so it must be retryable.
+		assertTrue(OpenSearchManagerImpl.isRetryableItemStatus(402));
+	}
+
+	@Test
 	public void testIsRetryableItemStatusForServerErrors() {
 		assertTrue(OpenSearchManagerImpl.isRetryableItemStatus(500));
 		assertTrue(OpenSearchManagerImpl.isRetryableItemStatus(503));
@@ -1188,6 +1195,49 @@ public class OpenSearchManagerImplTest {
 		int expected = 1 + (OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES - 1) * 3;
 		verify(openSearchClient, times(expected))
 				.bulk(argThat((BulkRequest req) -> req != null));
+	}
+
+	@Test
+	public void testBulkIndexWith402ItemStatusExhaustsRetriesAndThrowsRecoverableMessageException() throws Exception {
+		// AOSS returns 402 service_quota_exceeded_exception ("maximum OCU capacity reached") when the
+		// collection hits its OCU ceiling — classified as retryable so the loop backs off and resubmits
+		// rather than failing the whole index build permanently.
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenAnswer(inv -> allFailedResponse(inv.getArgument(0), 402,
+						"service_quota_exceeded_exception", "maximum OCU capacity reached"));
+
+		// call under test
+		RecoverableMessageException ex = assertThrows(RecoverableMessageException.class,
+				() -> manager.bulkIndex("search-index-syn1",
+						Arrays.asList(bulkOp("1"), bulkOp("2"), bulkOp("3"))));
+		assertTrue(ex.getMessage().contains(
+				"failed after " + OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES + " attempts"),
+				ex.getMessage());
+		assertTrue(ex.getMessage().contains("3 document(s) still retryable out of 3"), ex.getMessage());
+		// 1 batch attempt, then MAX_RETRIES-1 per-document attempts with 3 ops each.
+		int expected = 1 + (OpenSearchManagerImpl.BULK_INDEX_MAX_RETRIES - 1) * 3;
+		verify(openSearchClient, times(expected))
+				.bulk(argThat((BulkRequest req) -> req != null));
+	}
+
+	@Test
+	public void testBulkIndexWithMixed402And400FailuresThrowsPermanentRuntimeException() throws Exception {
+		// A retryable 402 mixed with a genuine permanent 400 must still fail permanently — the 400
+		// disqualifies the batch; a 402 alone is retryable but does not rescue a real permanent failure.
+		BulkResponse response = bulkResponseOf(
+				failedItem("1", 402, "service_quota_exceeded_exception", "maximum OCU capacity reached"),
+				failedItem("2", 400, "mapper_parsing_exception", "failed to parse field [geneName]"));
+		when(openSearchClient.bulk(argThat((BulkRequest req) -> req != null)))
+				.thenReturn(response);
+
+		// call under test
+		RuntimeException ex = assertThrows(RuntimeException.class,
+				() -> manager.bulkIndex("search-index-syn1",
+						Arrays.asList(bulkOp("1"), bulkOp("2"))));
+		assertFalse(ex instanceof RecoverableMessageException,
+				ex.getClass().getName() + ": " + ex.getMessage());
+		assertTrue(ex.getMessage().contains("1 retryable"), ex.getMessage());
+		assertTrue(ex.getMessage().contains("1 permanent"), ex.getMessage());
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

AWS OpenSearch Serverless (AOSS) returns HTTP **402** with `service_quota_exceeded_exception: maximum OCU capacity reached` when a collection hits its OCU (OpenSearch Compute Unit) ceiling. This is a **transient, auto-scaling** condition — the collection scales up and the write succeeds on retry.

`OpenSearchManagerImpl.isRetryableItemStatus(int)` only classified 429 and 5xx as retryable, so a 402 was treated as **permanent**. A single permanent failure in a bulk batch throws a non-recoverable `RuntimeException`, failing the whole search-index build.

Observed in production:

```
Bulk index to search-index-syn74909093 failed: 747 document(s) rejected out of 1000 (612 retryable, 135 permanent). Sample failures:
 - doc 82518 [status=402]: service_quota_exceeded_exception: maximum OCU capacity reached
 - doc 82522 [status=402]: service_quota_exceeded_exception: maximum OCU capacity reached
 - doc 82538 [status=402]: service_quota_exceeded_exception: maximum OCU capacity reached
 - doc 82543 [status=402]: service_quota_exceeded_exception: maximum OCU capacity reached
 - doc 82550 [status=402]: service_quota_exceeded_exception: maximum OCU capacity reached
```