### PR TITLE
[PLFM-9754]: SearchConfig binding authorization must resolve the benefactor ACL

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/ITSearchConfigurationTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITSearchConfigurationTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
 
@@ -17,17 +16,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sagebionetworks.client.SynapseAdminClient;
-import org.sagebionetworks.client.SynapseClient;
-import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
-import org.sagebionetworks.repo.model.ACCESS_TYPE;
-import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.Entity;
-import org.sagebionetworks.repo.model.Folder;
 import org.sagebionetworks.repo.model.Project;
-import org.sagebionetworks.repo.model.ResourceAccess;
-import org.sagebionetworks.repo.model.TeamConstants;
 import org.sagebionetworks.repo.model.search.table.BindSearchConfigToEntityRequest;
 import org.sagebionetworks.repo.model.search.table.ColumnAnalyzerOverride;
 import org.sagebionetworks.repo.model.search.table.ColumnAnalyzerOverrideEntry;
@@ -233,73 +225,6 @@ public class ITSearchConfigurationTest {
 				adminSynapse.getSearchConfigBindingForEntity(createdProject.getId()));
 		} finally {
 			adminSynapse.deleteEntity(createdProject);
-		}
-	}
-
-	@Test
-	public void testBindAndUnbindWithBenefactorInheritedAcl() throws Exception {
-		// Reproduces PLFM-9754: a non-admin Sage employee who has UPDATE on a project via that
-		// project's local ACL must be able to bind/unbind a config on a child folder that has
-		// NO local ACL (it inherits the project's ACL). The authorization check must resolve the
-		// benefactor, not read only the folder's own (absent) ACL.
-		SynapseClient userClient = new SynapseClientImpl();
-		Long userId = null;
-		Entity createdProject = null;
-		try {
-			userId = SynapseClientHelper.createUser(adminSynapse, userClient);
-			// The binding endpoint is gated to Sage Bionetworks employees.
-			adminSynapse.addTeamMember(TeamConstants.SAGE_BIONETWORKS_TEAM_ID.toString(), userId.toString(),
-					null, null);
-
-			// Project P with a local ACL granting the user UPDATE (and READ).
-			Project project = new Project();
-			project.setName("IT_BENEFACTOR_BIND_PROJECT_" + UUID.randomUUID().toString().replace("-", ""));
-			createdProject = adminSynapse.createEntity(project);
-
-			AccessControlList acl = adminSynapse.getACL(createdProject.getId());
-			ResourceAccess userAccess = new ResourceAccess();
-			userAccess.setPrincipalId(userId);
-			userAccess.setAccessType(EnumSet.of(ACCESS_TYPE.READ, ACCESS_TYPE.UPDATE));
-			acl.getResourceAccess().add(userAccess);
-			adminSynapse.updateACL(acl);
-
-			// Child Folder E under P with NO local ACL — it inherits P's ACL.
-			Folder folder = new Folder();
-			folder.setParentId(createdProject.getId());
-			Entity createdFolder = adminSynapse.createEntity(folder);
-
-			// Confirm the folder inherits (has no local ACL of its own).
-			assertThrows(SynapseNotFoundException.class, () -> adminSynapse.getACL(createdFolder.getId()));
-
-			ListTextAnalyzersResponse analyzers = adminSynapse.listTextAnalyzers(new ListTextAnalyzersRequest());
-			TextAnalyzer bootstrappedAnalyzer = analyzers.getResults().get(0);
-			String orgName = bootstrappedAnalyzer.getOrganizationName();
-			String defaultAnalyzerName = orgName + "-" + bootstrappedAnalyzer.getName();
-			SearchConfiguration createdConfig = adminSynapse.createSearchConfiguration(new SearchConfiguration()
-					.setName("IT_BENEFACTOR_BIND_CONFIG_" + UUID.randomUUID().toString().replace("-", ""))
-					.setOrganizationName(orgName)
-					.setDefaultAnalyzer(ref(defaultAnalyzerName)));
-
-			// call under test — as the non-admin user, BIND to the inheriting folder.
-			SearchConfigBinding binding = userClient.bindSearchConfigToEntity(new BindSearchConfigToEntityRequest()
-					.setEntityId(createdFolder.getId())
-					.setSearchConfigurationId(createdConfig.getId()));
-
-			assertNotNull(binding.getBindId());
-			assertEquals(createdConfig.getId(), binding.getSearchConfigurationId());
-			assertEquals(createdFolder.getId(), "syn" + binding.getObjectId());
-
-			// call under test — as the non-admin user, UNBIND.
-			userClient.clearSearchConfigBindingForEntity(createdFolder.getId());
-			assertThrows(SynapseNotFoundException.class, () ->
-				adminSynapse.getSearchConfigBindingForEntity(createdFolder.getId()));
-		} finally {
-			if (createdProject != null) {
-				adminSynapse.deleteEntity(createdProject);
-			}
-			if (userId != null) {
-				adminSynapse.deleteUser(userId);
-			}
 		}
 	}
 }

--- a/integration-test/src/test/java/org/sagebionetworks/ITSearchConfigurationTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITSearchConfigurationTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.UUID;
 
@@ -16,10 +17,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sagebionetworks.client.SynapseAdminClient;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.SynapseClientImpl;
 import org.sagebionetworks.client.exceptions.SynapseException;
 import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
+import org.sagebionetworks.repo.model.ACCESS_TYPE;
+import org.sagebionetworks.repo.model.AccessControlList;
 import org.sagebionetworks.repo.model.Entity;
+import org.sagebionetworks.repo.model.Folder;
 import org.sagebionetworks.repo.model.Project;
+import org.sagebionetworks.repo.model.ResourceAccess;
+import org.sagebionetworks.repo.model.TeamConstants;
 import org.sagebionetworks.repo.model.search.table.BindSearchConfigToEntityRequest;
 import org.sagebionetworks.repo.model.search.table.ColumnAnalyzerOverride;
 import org.sagebionetworks.repo.model.search.table.ColumnAnalyzerOverrideEntry;
@@ -225,6 +233,73 @@ public class ITSearchConfigurationTest {
 				adminSynapse.getSearchConfigBindingForEntity(createdProject.getId()));
 		} finally {
 			adminSynapse.deleteEntity(createdProject);
+		}
+	}
+
+	@Test
+	public void testBindAndUnbindWithBenefactorInheritedAcl() throws Exception {
+		// Reproduces PLFM: a non-admin Sage employee who has UPDATE on a project via that
+		// project's local ACL must be able to bind/unbind a config on a child folder that has
+		// NO local ACL (it inherits the project's ACL). The authorization check must resolve the
+		// benefactor, not read only the folder's own (absent) ACL.
+		SynapseClient userClient = new SynapseClientImpl();
+		Long userId = null;
+		Entity createdProject = null;
+		try {
+			userId = SynapseClientHelper.createUser(adminSynapse, userClient);
+			// The binding endpoint is gated to Sage Bionetworks employees.
+			adminSynapse.addTeamMember(TeamConstants.SAGE_BIONETWORKS_TEAM_ID.toString(), userId.toString(),
+					null, null);
+
+			// Project P with a local ACL granting the user UPDATE (and READ).
+			Project project = new Project();
+			project.setName("IT_BENEFACTOR_BIND_PROJECT_" + UUID.randomUUID().toString().replace("-", ""));
+			createdProject = adminSynapse.createEntity(project);
+
+			AccessControlList acl = adminSynapse.getACL(createdProject.getId());
+			ResourceAccess userAccess = new ResourceAccess();
+			userAccess.setPrincipalId(userId);
+			userAccess.setAccessType(EnumSet.of(ACCESS_TYPE.READ, ACCESS_TYPE.UPDATE));
+			acl.getResourceAccess().add(userAccess);
+			adminSynapse.updateACL(acl);
+
+			// Child Folder E under P with NO local ACL — it inherits P's ACL.
+			Folder folder = new Folder();
+			folder.setParentId(createdProject.getId());
+			Entity createdFolder = adminSynapse.createEntity(folder);
+
+			// Confirm the folder inherits (has no local ACL of its own).
+			assertThrows(SynapseNotFoundException.class, () -> adminSynapse.getACL(createdFolder.getId()));
+
+			ListTextAnalyzersResponse analyzers = adminSynapse.listTextAnalyzers(new ListTextAnalyzersRequest());
+			TextAnalyzer bootstrappedAnalyzer = analyzers.getResults().get(0);
+			String orgName = bootstrappedAnalyzer.getOrganizationName();
+			String defaultAnalyzerName = orgName + "-" + bootstrappedAnalyzer.getName();
+			SearchConfiguration createdConfig = adminSynapse.createSearchConfiguration(new SearchConfiguration()
+					.setName("IT_BENEFACTOR_BIND_CONFIG_" + UUID.randomUUID().toString().replace("-", ""))
+					.setOrganizationName(orgName)
+					.setDefaultAnalyzer(ref(defaultAnalyzerName)));
+
+			// call under test — as the non-admin user, BIND to the inheriting folder.
+			SearchConfigBinding binding = userClient.bindSearchConfigToEntity(new BindSearchConfigToEntityRequest()
+					.setEntityId(createdFolder.getId())
+					.setSearchConfigurationId(createdConfig.getId()));
+
+			assertNotNull(binding.getBindId());
+			assertEquals(createdConfig.getId(), binding.getSearchConfigurationId());
+			assertEquals(createdFolder.getId(), "syn" + binding.getObjectId());
+
+			// call under test — as the non-admin user, UNBIND.
+			userClient.clearSearchConfigBindingForEntity(createdFolder.getId());
+			assertThrows(SynapseNotFoundException.class, () ->
+				adminSynapse.getSearchConfigBindingForEntity(createdFolder.getId()));
+		} finally {
+			if (createdProject != null) {
+				adminSynapse.deleteEntity(createdProject);
+			}
+			if (userId != null) {
+				adminSynapse.deleteUser(userId);
+			}
 		}
 	}
 }

--- a/integration-test/src/test/java/org/sagebionetworks/ITSearchConfigurationTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITSearchConfigurationTest.java
@@ -238,7 +238,7 @@ public class ITSearchConfigurationTest {
 
 	@Test
 	public void testBindAndUnbindWithBenefactorInheritedAcl() throws Exception {
-		// Reproduces PLFM: a non-admin Sage employee who has UPDATE on a project via that
+		// Reproduces PLFM-9754: a non-admin Sage employee who has UPDATE on a project via that
 		// project's local ACL must be able to bind/unbind a config on a child folder that has
 		// NO local ACL (it inherits the project's ACL). The authorization check must resolve the
 		// benefactor, not read only the folder's own (absent) ACL.

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDaoImpl.java
@@ -509,6 +509,10 @@ public class DBOAccessControlListDaoImpl implements AccessControlListDAO {
 	public boolean canAccess(Set<Long> groups, String resourceId,
 			ObjectType resourceType, ACCESS_TYPE accessType)
 			throws DatastoreException {
+		if (ObjectType.ENTITY.equals(resourceType)) {
+			throw new IllegalArgumentException(
+					"This method cannot be used for entities; entity access checks must resolve the benefactor via EntityAuthorizationManager.");
+		}
 		Long idLong = KeyFactory.stringToKey(resourceId);
 		HashSet<Long> benefactors = Sets.newHashSet(idLong);
 		Set<Long> results = getAccessibleBenefactors(groups, benefactors,

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOImplTest.java
@@ -38,7 +38,6 @@ import org.sagebionetworks.repo.model.ResourceAccess;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserGroupDAO;
 import org.sagebionetworks.repo.model.UserInfo;
-import org.sagebionetworks.repo.model.auth.AuthorizationStatus;
 import org.sagebionetworks.repo.model.jdo.KeyFactory;
 import org.sagebionetworks.repo.model.jdo.NodeTestUtils;
 import org.sagebionetworks.repo.model.util.AccessControlListUtil;
@@ -179,6 +178,22 @@ public class DBOAccessControlListDAOImplTest {
 		return acl;
 	}
 
+	/**
+	 * Whether any of the given groups has the given access type to the given entity. The DAO's
+	 * {@link AccessControlListDAO#canAccess} now rejects {@link ObjectType#ENTITY} (entity access must
+	 * resolve the benefactor via the EntityAuthorizationManager), so these tests reach the same
+	 * benefactor-resolving logic through {@link AccessControlListDAO#getAccessibleBenefactors}.
+	 */
+	private boolean canAccessEntity(Set<Long> groups, String entityId, ACCESS_TYPE accessType) {
+		Long entityIdLong = KeyFactory.stringToKey(entityId);
+		return aclDAO.getAccessibleBenefactors(groups, Set.of(entityIdLong), ObjectType.ENTITY, accessType)
+				.contains(entityIdLong);
+	}
+
+	private boolean canAccessEntity(UserInfo user, String entityId, ACCESS_TYPE accessType) {
+		return canAccessEntity(user.getGroups(), entityId, accessType);
+	}
+
 	@AfterEach
 	public void tearDown() throws Exception {
 		for (AccessControlList acl : aclList){
@@ -225,28 +240,36 @@ public class DBOAccessControlListDAOImplTest {
 		gs.add(Long.parseLong(group.getId()));
 		
 		// as expressed in 'setUp', 'group' has 'READ' access to 'node'
-		assertTrue(aclDAO.canAccess(gs, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.READ));
-		
+		assertTrue(canAccessEntity(gs, node.getId(), ACCESS_TYPE.READ));
+
 		// but it doesn't have 'UPDATE' access
-		assertFalse(aclDAO.canAccess(gs, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.UPDATE));
-		
+		assertFalse(canAccessEntity(gs, node.getId(), ACCESS_TYPE.UPDATE));
+
 		// and no other group has been given access
 		UserGroup sham = new UserGroup();
 		sham.setId("-34876387468764"); // dummy
 		gs.clear();
 		gs.add(Long.parseLong(sham.getId()));
-		assertFalse(aclDAO.canAccess(gs, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.READ));
+		assertFalse(canAccessEntity(gs, node.getId(), ACCESS_TYPE.READ));
 	}
 	
 	@Test
 	public void testCanAccessStatus() throws Exception {
-		// call under test
-		AuthorizationStatus status = aclDAO.canAccess(userInfo, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.READ);
-		assertTrue(status.isAuthorized());
-		// call under test
-		status = aclDAO.canAccess(userInfo, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.UPDATE);
-		assertFalse(status.isAuthorized());
-		assertEquals("You do not have UPDATE permission for ENTITY : "+node.getId(), status.getMessage());
+		// the user's groups include 'group', which has READ (but not UPDATE) on 'node'
+		assertTrue(canAccessEntity(userInfo, node.getId(), ACCESS_TYPE.READ));
+		assertFalse(canAccessEntity(userInfo, node.getId(), ACCESS_TYPE.UPDATE));
+	}
+
+	@Test
+	public void testCanAccessWithEntityTypeThrows() {
+		Set<Long> gs = Set.of(Long.parseLong(group.getId()));
+
+		// canAccess cannot be used for entities; entity access must resolve the benefactor via the
+		// EntityAuthorizationManager (the benefactor-resolving entry point is getAccessibleBenefactors).
+		assertThrows(IllegalArgumentException.class,
+				() -> aclDAO.canAccess(gs, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.READ));
+		assertThrows(IllegalArgumentException.class,
+				() -> aclDAO.canAccess(userInfo, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.READ));
 	}
 	
 	@Test
@@ -531,9 +554,9 @@ public class DBOAccessControlListDAOImplTest {
 		
 		Set<Long> gs = new HashSet<Long>();
 		gs.add(Long.parseLong(group.getId()));
-		assertFalse(aclDAO.canAccess(gs, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.READ));
-		assertTrue(aclDAO.canAccess(gs, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.UPDATE));
-		assertTrue(aclDAO.canAccess(gs, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.CREATE));
+		assertFalse(canAccessEntity(gs, node.getId(), ACCESS_TYPE.READ));
+		assertTrue(canAccessEntity(gs, node.getId(), ACCESS_TYPE.UPDATE));
+		assertTrue(canAccessEntity(gs, node.getId(), ACCESS_TYPE.CREATE));
 
 		AccessControlList acl2 = aclDAO.get(rid, ObjectType.ENTITY);
 		assertFalse(etagBeforeUpdate.equals(acl2.getEtag()));
@@ -593,15 +616,15 @@ public class DBOAccessControlListDAOImplTest {
 		gs.add(Long.parseLong(group.getId()));
 		Set<Long> gs2 = new HashSet<Long>();
 		gs2.add(Long.parseLong(group2.getId()));
-		assertFalse(aclDAO.canAccess(gs, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.READ));
-		assertTrue(aclDAO.canAccess(gs2, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.READ));
-		
+		assertFalse(canAccessEntity(gs, node.getId(), ACCESS_TYPE.READ));
+		assertTrue(canAccessEntity(gs2, node.getId(), ACCESS_TYPE.READ));
+
 		// Group one can do this but 2 cannot.
-		assertTrue(aclDAO.canAccess(gs, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.UPDATE));
-		assertTrue(aclDAO.canAccess(gs, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.CREATE));
+		assertTrue(canAccessEntity(gs, node.getId(), ACCESS_TYPE.UPDATE));
+		assertTrue(canAccessEntity(gs, node.getId(), ACCESS_TYPE.CREATE));
 		// Now try 2
-		assertFalse(aclDAO.canAccess(gs2, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.UPDATE));
-		assertFalse(aclDAO.canAccess(gs2, node.getId(), ObjectType.ENTITY, ACCESS_TYPE.CREATE));
+		assertFalse(canAccessEntity(gs2, node.getId(), ACCESS_TYPE.UPDATE));
+		assertFalse(canAccessEntity(gs2, node.getId(), ACCESS_TYPE.CREATE));
 		
 	}
 	

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOScaleTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/DBOAccessControlListDAOScaleTest.java
@@ -28,6 +28,7 @@ import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.ResourceAccess;
 import org.sagebionetworks.repo.model.UserGroup;
 import org.sagebionetworks.repo.model.UserGroupDAO;
+import org.sagebionetworks.repo.model.jdo.KeyFactory;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
@@ -132,13 +133,16 @@ public class DBOAccessControlListDAOScaleTest {
 		// Time the can access methods
 		Set<Long> groups = new HashSet<Long>();
 		groups.add(Long.parseLong(userGroup.getId()));
+		Long benefactorId = KeyFactory.stringToKey(toDelete.get(0));
 		for(ACCESS_TYPE type: ALLOWED_ACCESS_TYPES.get(ObjectType.ENTITY)){
 			long start = System.nanoTime();
-			boolean canAccess = aclDAO.canAccess(groups, toDelete.get(0), ObjectType.ENTITY, type);
+			// Entity access resolves the benefactor; getAccessibleBenefactors is the entry point used everywhere.
+			boolean canAccess = aclDAO.getAccessibleBenefactors(groups, Set.of(benefactorId), ObjectType.ENTITY, type)
+					.contains(benefactorId);
 			long end = System.nanoTime();
 			long elpaseMs = (end-start)/1000000;
 			assertTrue(canAccess);
-			assertTrue("Since accessControlListDAO.canAccess() is called everywhere, it cannot take more than 100 ms to run!",elpaseMs < 100);
+			assertTrue("Since accessControlListDAO.getAccessibleBenefactors() is called everywhere, it cannot take more than 100 ms to run!",elpaseMs < 100);
 		}
 	}
 }

--- a/lib/models/src/main/java/org/sagebionetworks/repo/model/AccessControlListDAO.java
+++ b/lib/models/src/main/java/org/sagebionetworks/repo/model/AccessControlListDAO.java
@@ -12,18 +12,22 @@ public interface AccessControlListDAO  {
 
 	/**
 	 * @return true iff some group in 'groups' has explicit permission to access 'resourceId' using access type 'accessType'
-	 * @throws DatastoreException 
+	 * @throws DatastoreException
+	 * @throws IllegalArgumentException if resourceType is {@link ObjectType#ENTITY}. Entity access checks must resolve
+	 *                                  the benefactor and therefore go through the EntityAuthorizationManager.
 	 */
 	boolean canAccess(Set<Long> groups, String resourceId, ObjectType resourceType, ACCESS_TYPE accessType) throws DatastoreException;
-	
+
 	/**
 	 * Does the user have the permission to access the given resource.
-	 * 
+	 *
 	 * @param user         User attempting access.
 	 * @param resourceId   Identifier of the resource to access.
 	 * @param resourceType Type of resource to access.
 	 * @param permission   The permission required for access.
-	 * @return 
+	 * @return
+	 * @throws IllegalArgumentException if resourceType is {@link ObjectType#ENTITY}. Entity access checks must resolve
+	 *                                  the benefactor and therefore go through the EntityAuthorizationManager.
 	 */
 	AuthorizationStatus canAccess(UserInfo user, String resourceId, ObjectType resourceType,
 			ACCESS_TYPE permission);

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchConfigurationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchConfigurationManagerImpl.java
@@ -13,6 +13,7 @@ import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.NodeDAO;
 import org.sagebionetworks.repo.manager.entity.EntityAuthorizationManager;
+import org.sagebionetworks.repo.model.dbo.dao.NodeUtils;
 import org.sagebionetworks.repo.model.dbo.schema.OrganizationDao;
 import org.sagebionetworks.repo.model.dbo.search.ColumnAnalyzerOverrideDao;
 import org.sagebionetworks.repo.model.dbo.search.SearchConfigurationDao;
@@ -144,7 +145,7 @@ public class SearchConfigurationManagerImpl implements SearchConfigurationManage
 		// A search configuration can only be bound to a Project or Folder so that entities within
 		// that container inherit the binding.
 		EntityType entityType = nodeDAO.getNodeTypeById(request.getEntityId());
-		if (!EntityType.project.equals(entityType) && !EntityType.folder.equals(entityType)) {
+		if (!NodeUtils.isProjectOrFolder(entityType)) {
 			throw new IllegalArgumentException("A search configuration can only be bound to a Project or Folder.");
 		}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchConfigurationManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/SearchConfigurationManagerImpl.java
@@ -6,11 +6,13 @@ import java.util.List;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.AccessControlListDAO;
 import org.sagebionetworks.repo.model.AuthorizationUtils;
+import org.sagebionetworks.repo.model.EntityType;
 import org.sagebionetworks.repo.model.NextPageToken;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.UnauthorizedException;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.NodeDAO;
+import org.sagebionetworks.repo.manager.entity.EntityAuthorizationManager;
 import org.sagebionetworks.repo.model.dbo.schema.OrganizationDao;
 import org.sagebionetworks.repo.model.dbo.search.ColumnAnalyzerOverrideDao;
 import org.sagebionetworks.repo.model.dbo.search.SearchConfigurationDao;
@@ -39,16 +41,19 @@ public class SearchConfigurationManagerImpl implements SearchConfigurationManage
 	private final ColumnAnalyzerOverrideDao columnAnalyzerOverrideDao;
 	private final TextAnalyzerDao textAnalyzerDao;
 	private final NodeDAO nodeDAO;
+	private final EntityAuthorizationManager entityAuthorizationManager;
 
 	public SearchConfigurationManagerImpl(SearchConfigurationDao searchConfigurationDao, AccessControlListDAO aclDao,
 			OrganizationDao organizationDao,
-			ColumnAnalyzerOverrideDao columnAnalyzerOverrideDao, TextAnalyzerDao textAnalyzerDao, NodeDAO nodeDAO) {
+			ColumnAnalyzerOverrideDao columnAnalyzerOverrideDao, TextAnalyzerDao textAnalyzerDao, NodeDAO nodeDAO,
+			EntityAuthorizationManager entityAuthorizationManager) {
 		this.searchConfigurationDao = searchConfigurationDao;
 		this.aclDao = aclDao;
 		this.organizationDao = organizationDao;
 		this.columnAnalyzerOverrideDao = columnAnalyzerOverrideDao;
 		this.textAnalyzerDao = textAnalyzerDao;
 		this.nodeDAO = nodeDAO;
+		this.entityAuthorizationManager = entityAuthorizationManager;
 	}
 
 	@Override
@@ -132,10 +137,15 @@ public class SearchConfigurationManagerImpl implements SearchConfigurationManage
 		Long entityId = KeyFactory.stringToKey(request.getEntityId());
 		Long searchConfigId = Long.parseLong(request.getSearchConfigurationId());
 
-		// Verify entity exists and user has EDIT permission
-		if (!user.isAdmin()) {
-			aclDao.canAccess(user, String.valueOf(entityId), ObjectType.ENTITY, ACCESS_TYPE.UPDATE)
-				.checkAuthorizationOrElseThrow();
+		// Verify the user has UPDATE permission on the entity, resolving the benefactor ACL.
+		entityAuthorizationManager.hasAccess(user, request.getEntityId(), ACCESS_TYPE.UPDATE)
+			.checkAuthorizationOrElseThrow();
+
+		// A search configuration can only be bound to a Project or Folder so that entities within
+		// that container inherit the binding.
+		EntityType entityType = nodeDAO.getNodeTypeById(request.getEntityId());
+		if (!EntityType.project.equals(entityType) && !EntityType.folder.equals(entityType)) {
+			throw new IllegalArgumentException("A search configuration can only be bound to a Project or Folder.");
 		}
 
 		// Verify search config exists
@@ -174,10 +184,9 @@ public class SearchConfigurationManagerImpl implements SearchConfigurationManage
 
 		Long nodeId = KeyFactory.stringToKey(entityId);
 
-		if (!user.isAdmin()) {
-			aclDao.canAccess(user, String.valueOf(nodeId), ObjectType.ENTITY, ACCESS_TYPE.UPDATE)
-				.checkAuthorizationOrElseThrow();
-		}
+		// Verify the user has UPDATE permission on the entity, resolving the benefactor ACL.
+		entityAuthorizationManager.hasAccess(user, entityId, ACCESS_TYPE.UPDATE)
+			.checkAuthorizationOrElseThrow();
 
 		searchConfigurationDao.clearSearchConfigBinding(nodeId, ENTITY_OBJECT_TYPE);
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/AccessControlListManagerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/AccessControlListManagerTest.java
@@ -216,10 +216,10 @@ public class AccessControlListManagerTest {
 	@Test
 	public void testCanAccess(){
 		String objectId = "123";
-		when(aclDao.canAccess(userInfo, objectId, ObjectType.ENTITY, ACCESS_TYPE.READ)).thenReturn(AuthorizationStatus.authorized());
-		AuthorizationStatus canAccess = aclManager.canAccess(userInfo, objectId, ObjectType.ENTITY, ACCESS_TYPE.READ);
+		when(aclDao.canAccess(userInfo, objectId, ObjectType.EVALUATION, ACCESS_TYPE.READ)).thenReturn(AuthorizationStatus.authorized());
+		AuthorizationStatus canAccess = aclManager.canAccess(userInfo, objectId, ObjectType.EVALUATION, ACCESS_TYPE.READ);
 		assertNotNull(canAccess);
-		verify(aclDao, times(1)).canAccess(userInfo, objectId, ObjectType.ENTITY, ACCESS_TYPE.READ);
+		verify(aclDao, times(1)).canAccess(userInfo, objectId, ObjectType.EVALUATION, ACCESS_TYPE.READ);
 	}
 
 	@Test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchConfigurationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchConfigurationManagerImplTest.java
@@ -27,10 +27,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.sagebionetworks.repo.manager.entity.EntityAuthorizationManager;
 import org.sagebionetworks.repo.model.ACCESS_TYPE;
 import org.sagebionetworks.repo.model.AccessControlListDAO;
 import org.sagebionetworks.repo.model.AuthorizationConstants;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
+import org.sagebionetworks.repo.model.EntityType;
 import org.sagebionetworks.repo.model.NodeDAO;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.UnauthorizedException;
@@ -63,13 +65,15 @@ public class SearchConfigurationManagerImplTest {
 	private TextAnalyzerDao textAnalyzerDao;
 	@Mock
 	private NodeDAO nodeDAO;
+	@Mock
+	private EntityAuthorizationManager entityAuthorizationManager;
 
 	private SearchConfigurationManagerImpl manager;
 
 	@BeforeEach
 	void setUp() {
 		manager = new SearchConfigurationManagerImpl(searchConfigurationDao, aclDao, organizationDao,
-				columnAnalyzerOverrideDao, textAnalyzerDao, nodeDAO);
+				columnAnalyzerOverrideDao, textAnalyzerDao, nodeDAO, entityAuthorizationManager);
 	}
 
 	// --- Sage employee / admin authorization ---
@@ -339,8 +343,9 @@ public class SearchConfigurationManagerImplTest {
 		request.setEntityId("syn123");
 		request.setSearchConfigurationId("456");
 
-		when(aclDao.canAccess(any(UserInfo.class), eq("123"), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.UPDATE)))
+		when(entityAuthorizationManager.hasAccess(user, "syn123", ACCESS_TYPE.UPDATE))
 			.thenReturn(AuthorizationStatus.authorized());
+		when(nodeDAO.getNodeTypeById("syn123")).thenReturn(EntityType.project);
 		when(searchConfigurationDao.get("456")).thenReturn(Optional.of(new SearchConfiguration()));
 		SearchConfigBinding expectedBinding = new SearchConfigBinding();
 		expectedBinding.setBindId("1");
@@ -410,8 +415,9 @@ public class SearchConfigurationManagerImplTest {
 		request.setEntityId("syn123");
 		request.setSearchConfigurationId("999");
 
-		when(aclDao.canAccess(any(UserInfo.class), eq("123"), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.UPDATE)))
+		when(entityAuthorizationManager.hasAccess(user, "syn123", ACCESS_TYPE.UPDATE))
 			.thenReturn(AuthorizationStatus.authorized());
+		when(nodeDAO.getNodeTypeById("syn123")).thenReturn(EntityType.folder);
 		when(searchConfigurationDao.get("999")).thenReturn(Optional.empty());
 
 		// call under test
@@ -421,12 +427,33 @@ public class SearchConfigurationManagerImplTest {
 	}
 
 	@Test
+	public void testBindSearchConfigToEntityWithNonProjectOrFolderEntity() {
+		// A search configuration can only be bound to a Project or Folder.
+		UserInfo user = new UserInfo(false);
+		user.setId(1L);
+		user.setGroups(Set.of(1L, BOOTSTRAP_PRINCIPAL.SAGE_BIONETWORKS.getPrincipalId()));
+
+		BindSearchConfigToEntityRequest request = new BindSearchConfigToEntityRequest();
+		request.setEntityId("syn123");
+		request.setSearchConfigurationId("456");
+
+		when(entityAuthorizationManager.hasAccess(user, "syn123", ACCESS_TYPE.UPDATE))
+			.thenReturn(AuthorizationStatus.authorized());
+		when(nodeDAO.getNodeTypeById("syn123")).thenReturn(EntityType.searchindex);
+
+		// call under test
+		String message = assertThrows(IllegalArgumentException.class, () -> manager.bindSearchConfigToEntity(user, request)).getMessage();
+		assertEquals("A search configuration can only be bound to a Project or Folder.", message);
+		verify(searchConfigurationDao, never()).bindSearchConfigToObject(anyLong(), anyLong(), anyString(), anyLong());
+	}
+
+	@Test
 	public void testClearSearchConfigBindingWithValidEntity() {
 		UserInfo user = new UserInfo(false);
 		user.setId(1L);
 		user.setGroups(Set.of(1L, BOOTSTRAP_PRINCIPAL.SAGE_BIONETWORKS.getPrincipalId()));
 
-		when(aclDao.canAccess(any(UserInfo.class), eq("123"), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.UPDATE)))
+		when(entityAuthorizationManager.hasAccess(user, "syn123", ACCESS_TYPE.UPDATE))
 			.thenReturn(AuthorizationStatus.authorized());
 
 		// call under test
@@ -658,15 +685,16 @@ public class SearchConfigurationManagerImplTest {
 	}
 
 	@Test
-	public void testBindSearchConfigToEntityWithSageNonAdminChecksAcl() {
-		// Sage employee but not admin: ACL check must run against ENTITY/UPDATE.
+	public void testBindSearchConfigToEntityWithSageNonAdminChecksEntityAuthorization() {
+		// Sage employee but not admin: UPDATE check must resolve the benefactor via EntityAuthorizationManager.
 		UserInfo user = new UserInfo(false);
 		user.setId(1L);
 		user.setGroups(Set.of(1L, BOOTSTRAP_PRINCIPAL.SAGE_BIONETWORKS.getPrincipalId()));
 		BindSearchConfigToEntityRequest req = new BindSearchConfigToEntityRequest()
 				.setEntityId("syn123").setSearchConfigurationId("42");
-		when(aclDao.canAccess(any(UserInfo.class), anyString(), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.UPDATE)))
+		when(entityAuthorizationManager.hasAccess(user, "syn123", ACCESS_TYPE.UPDATE))
 				.thenReturn(AuthorizationStatus.authorized());
+		when(nodeDAO.getNodeTypeById("syn123")).thenReturn(EntityType.project);
 		when(searchConfigurationDao.get("42")).thenReturn(Optional.of(new SearchConfiguration().setId("42")));
 		when(searchConfigurationDao.getSearchConfigBindingForObject(123L, "entity"))
 				.thenReturn(Optional.of(new SearchConfigBinding()));
@@ -674,8 +702,25 @@ public class SearchConfigurationManagerImplTest {
 		// call under test
 		manager.bindSearchConfigToEntity(user, req);
 
-		verify(aclDao).canAccess(any(UserInfo.class), anyString(), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.UPDATE));
+		verify(entityAuthorizationManager).hasAccess(user, "syn123", ACCESS_TYPE.UPDATE);
 		verify(searchConfigurationDao).bindSearchConfigToObject(42L, 123L, "entity", 1L);
+	}
+
+	@Test
+	public void testBindSearchConfigToEntityWithUnauthorized() {
+		// Sage employee but lacks UPDATE on the entity (or its benefactor) → denied, no write.
+		UserInfo user = new UserInfo(false);
+		user.setId(1L);
+		user.setGroups(Set.of(1L, BOOTSTRAP_PRINCIPAL.SAGE_BIONETWORKS.getPrincipalId()));
+		BindSearchConfigToEntityRequest req = new BindSearchConfigToEntityRequest()
+				.setEntityId("syn123").setSearchConfigurationId("42");
+		when(entityAuthorizationManager.hasAccess(user, "syn123", ACCESS_TYPE.UPDATE))
+				.thenReturn(AuthorizationStatus.accessDenied("no"));
+
+		// call under test
+		assertThrows(UnauthorizedException.class, () -> manager.bindSearchConfigToEntity(user, req));
+
+		verify(searchConfigurationDao, never()).bindSearchConfigToObject(anyLong(), anyLong(), anyString(), anyLong());
 	}
 
 	@Test
@@ -691,27 +736,44 @@ public class SearchConfigurationManagerImplTest {
 	}
 
 	@Test
-	public void testClearSearchConfigBindingWithSageNonAdminChecksAcl() {
+	public void testClearSearchConfigBindingWithSageNonAdminChecksEntityAuthorization() {
 		UserInfo user = new UserInfo(false);
 		user.setId(1L);
 		user.setGroups(Set.of(1L, BOOTSTRAP_PRINCIPAL.SAGE_BIONETWORKS.getPrincipalId()));
-		when(aclDao.canAccess(any(UserInfo.class), anyString(), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.UPDATE)))
+		when(entityAuthorizationManager.hasAccess(user, "syn123", ACCESS_TYPE.UPDATE))
 				.thenReturn(AuthorizationStatus.authorized());
 
 		// call under test
 		manager.clearSearchConfigBinding(user, "syn123");
 
-		verify(aclDao).canAccess(any(UserInfo.class), anyString(), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.UPDATE));
+		verify(entityAuthorizationManager).hasAccess(user, "syn123", ACCESS_TYPE.UPDATE);
 		verify(searchConfigurationDao).clearSearchConfigBinding(123L, "entity");
 	}
 
 	@Test
-	public void testBindSearchConfigToEntityAsAdminSkipsAcl() {
-		// admin → !user.isAdmin() == false → ACL check skipped (covers L137 admin half).
+	public void testClearSearchConfigBindingWithUnauthorized() {
+		UserInfo user = new UserInfo(false);
+		user.setId(1L);
+		user.setGroups(Set.of(1L, BOOTSTRAP_PRINCIPAL.SAGE_BIONETWORKS.getPrincipalId()));
+		when(entityAuthorizationManager.hasAccess(user, "syn123", ACCESS_TYPE.UPDATE))
+				.thenReturn(AuthorizationStatus.accessDenied("no"));
+
+		// call under test
+		assertThrows(UnauthorizedException.class, () -> manager.clearSearchConfigBinding(user, "syn123"));
+
+		verify(searchConfigurationDao, never()).clearSearchConfigBinding(anyLong(), anyString());
+	}
+
+	@Test
+	public void testBindSearchConfigToEntityAsAdmin() {
+		// admin → EntityAuthorizationManager grants UPDATE; ORGANIZATION aclDao is untouched here.
 		UserInfo admin = new UserInfo(true);
 		admin.setId(2L);
 		BindSearchConfigToEntityRequest req = new BindSearchConfigToEntityRequest()
 				.setEntityId("syn123").setSearchConfigurationId("42");
+		when(entityAuthorizationManager.hasAccess(admin, "syn123", ACCESS_TYPE.UPDATE))
+				.thenReturn(AuthorizationStatus.authorized());
+		when(nodeDAO.getNodeTypeById("syn123")).thenReturn(EntityType.project);
 		when(searchConfigurationDao.get("42")).thenReturn(Optional.of(new SearchConfiguration().setId("42")));
 		when(searchConfigurationDao.getSearchConfigBindingForObject(123L, "entity"))
 				.thenReturn(Optional.of(new SearchConfigBinding()));
@@ -724,10 +786,12 @@ public class SearchConfigurationManagerImplTest {
 	}
 
 	@Test
-	public void testClearSearchConfigBindingAsAdminSkipsAcl() {
-		// admin → !user.isAdmin() == false → ACL check skipped (covers L178 admin half).
+	public void testClearSearchConfigBindingAsAdmin() {
+		// admin → EntityAuthorizationManager grants UPDATE; ORGANIZATION aclDao is untouched here.
 		UserInfo admin = new UserInfo(true);
 		admin.setId(2L);
+		when(entityAuthorizationManager.hasAccess(admin, "syn123", ACCESS_TYPE.UPDATE))
+				.thenReturn(AuthorizationStatus.authorized());
 
 		// call under test
 		manager.clearSearchConfigBinding(admin, "syn123");

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchConfigurationManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/SearchConfigurationManagerImplTest.java
@@ -707,6 +707,31 @@ public class SearchConfigurationManagerImplTest {
 	}
 
 	@Test
+	public void testBindSearchConfigToEntityWithBenefactorInheritedAccess() {
+		// PLFM-9754: a caller authorized only via the benefactor (no local ACL on the entity) must be able
+		// to bind. The UPDATE check must go through EntityAuthorizationManager (which resolves the benefactor)
+		// and never read the entity's own ACL via aclDao.
+		UserInfo user = new UserInfo(false);
+		user.setId(1L);
+		user.setGroups(Set.of(1L, BOOTSTRAP_PRINCIPAL.SAGE_BIONETWORKS.getPrincipalId()));
+		BindSearchConfigToEntityRequest req = new BindSearchConfigToEntityRequest()
+				.setEntityId("syn123").setSearchConfigurationId("42");
+		when(entityAuthorizationManager.hasAccess(user, "syn123", ACCESS_TYPE.UPDATE))
+				.thenReturn(AuthorizationStatus.authorized());
+		when(nodeDAO.getNodeTypeById("syn123")).thenReturn(EntityType.folder);
+		when(searchConfigurationDao.get("42")).thenReturn(Optional.of(new SearchConfiguration().setId("42")));
+		when(searchConfigurationDao.getSearchConfigBindingForObject(123L, "entity"))
+				.thenReturn(Optional.of(new SearchConfigBinding()));
+
+		// call under test
+		manager.bindSearchConfigToEntity(user, req);
+
+		verify(searchConfigurationDao).bindSearchConfigToObject(42L, 123L, "entity", 1L);
+		// The entity's own ACL must not be consulted directly.
+		verify(aclDao, never()).canAccess(any(UserInfo.class), anyString(), eq(ObjectType.ENTITY), any(ACCESS_TYPE.class));
+	}
+
+	@Test
 	public void testBindSearchConfigToEntityWithUnauthorized() {
 		// Sage employee but lacks UPDATE on the entity (or its benefactor) → denied, no write.
 		UserInfo user = new UserInfo(false);


### PR DESCRIPTION
## Problem

- Binding/unbinding a `SearchConfiguration` to an entity checked `ACCESS_TYPE.UPDATE` against the entity's **own** ACL via `aclDao.canAccess(..., ObjectType.ENTITY, ...)`, which does **not** resolve the benefactor. An entity that inherits its ACL from a parent was denied with a 403 even when the caller legitimately had UPDATE via the inherited (benefactor) ACL — inconsistent with every other entity-update path in Synapse.

Observed in prod (see [PLFM-9754](https://sagebionetworks.jira.com/browse/PLFM-9754)): `syn75081636` inherits its ACL from project `syn74909065`; `nf-osi-service` had `canEdit == true` and the standard `PUT /entity/{id}` path authorized the caller, but `PUT /entity/{id}/searchconfig/binding` returned 403.


- Binding could be done to any Entity but it was intended that only Project/Folders could have the configuration bound to it.


[PLFM-9754]: https://sagebionetworks.jira.com/browse/PLFM-9754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ