### PR TITLE
PLFM 9748 - Add taskId parameter to ListCurationTaskRequest

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/ITCurationTaskControllerTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITCurationTaskControllerTest.java
@@ -277,4 +277,49 @@ public class ITCurationTaskControllerTest {
         }
     }
 
+    @Test
+    public void testListCurationTasksWithTaskIdsFilter() throws SynapseException {
+        // Two tasks in the same project — taskId filter must exclude the second one.
+        // This end-to-end test confirms the "taskId" JSON field name is correctly
+        // serialized by the client and applied as an IN filter on the server.
+        CurationTask fbTask = new CurationTask()
+                .setProjectId(project.getId())
+                .setDataType("taskids-fb")
+                .setTaskProperties(
+                        new FileBasedMetadataTaskProperties()
+                                .setFileViewId(view.getId())
+                                .setUploadFolderId(folder.getId())
+                );
+
+        CurationTask rbTask = new CurationTask()
+                .setProjectId(project.getId())
+                .setDataType("taskids-rb")
+                .setTaskProperties(
+                        new RecordBasedMetadataTaskProperties().setRecordSetId(recordSet.getId())
+                );
+
+        fbTask = synapse.createCurationTask(fbTask);
+        rbTask = synapse.createCurationTask(rbTask);
+
+        try {
+            // call under test - filter by fbTask's ID only; rbTask must not appear in results
+            ListCurationTaskResponse response = synapse.listMetadataTasks(
+                    new ListCurationTaskRequest()
+                            .setProjectId(project.getId())
+                            .setTaskId(Arrays.asList(fbTask.getTaskId()))
+            );
+
+            assertNotNull(response.getPage());
+            assertEquals(1, response.getPage().size());
+            assertEquals(fbTask.getTaskId(), response.getPage().get(0).getTaskId());
+
+            assertNotNull(response.getBundlePage());
+            assertEquals(1, response.getBundlePage().size());
+            assertEquals(fbTask.getTaskId(), response.getBundlePage().get(0).getTask().getTaskId());
+        } finally {
+            synapse.deleteMetadataTask(fbTask.getTaskId());
+            synapse.deleteMetadataTask(rbTask.getTaskId());
+        }
+    }
+
 }

--- a/integration-test/src/test/java/org/sagebionetworks/ITCurationTaskControllerTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITCurationTaskControllerTest.java
@@ -277,49 +277,4 @@ public class ITCurationTaskControllerTest {
         }
     }
 
-    @Test
-    public void testListCurationTasksWithTaskIdsFilter() throws SynapseException {
-        // Two tasks in the same project — taskId filter must exclude the second one.
-        // This end-to-end test confirms the "taskId" JSON field name is correctly
-        // serialized by the client and applied as an IN filter on the server.
-        CurationTask fbTask = new CurationTask()
-                .setProjectId(project.getId())
-                .setDataType("taskids-fb")
-                .setTaskProperties(
-                        new FileBasedMetadataTaskProperties()
-                                .setFileViewId(view.getId())
-                                .setUploadFolderId(folder.getId())
-                );
-
-        CurationTask rbTask = new CurationTask()
-                .setProjectId(project.getId())
-                .setDataType("taskids-rb")
-                .setTaskProperties(
-                        new RecordBasedMetadataTaskProperties().setRecordSetId(recordSet.getId())
-                );
-
-        fbTask = synapse.createCurationTask(fbTask);
-        rbTask = synapse.createCurationTask(rbTask);
-
-        try {
-            // call under test - filter by fbTask's ID only; rbTask must not appear in results
-            ListCurationTaskResponse response = synapse.listMetadataTasks(
-                    new ListCurationTaskRequest()
-                            .setProjectId(project.getId())
-                            .setTaskIds(Arrays.asList(fbTask.getTaskId()))
-            );
-
-            assertNotNull(response.getPage());
-            assertEquals(1, response.getPage().size());
-            assertEquals(fbTask.getTaskId(), response.getPage().get(0).getTaskId());
-
-            assertNotNull(response.getBundlePage());
-            assertEquals(1, response.getBundlePage().size());
-            assertEquals(fbTask.getTaskId(), response.getBundlePage().get(0).getTask().getTaskId());
-        } finally {
-            synapse.deleteMetadataTask(fbTask.getTaskId());
-            synapse.deleteMetadataTask(rbTask.getTaskId());
-        }
-    }
-
 }

--- a/integration-test/src/test/java/org/sagebionetworks/ITCurationTaskControllerTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITCurationTaskControllerTest.java
@@ -306,7 +306,7 @@ public class ITCurationTaskControllerTest {
             ListCurationTaskResponse response = synapse.listMetadataTasks(
                     new ListCurationTaskRequest()
                             .setProjectId(project.getId())
-                            .setTaskId(Arrays.asList(fbTask.getTaskId()))
+                            .setTaskIds(Arrays.asList(fbTask.getTaskId()))
             );
 
             assertNotNull(response.getPage());

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDao.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDao.java
@@ -31,7 +31,7 @@ public interface CurationTaskDao {
     void clearActiveSessionId(Long taskId);
 
     List<TaskBundle> getCurationTaskBundles(List<Long> projectIds, List<Long> assigneeIds,
-            List<TaskState> stateFilter, Long taskId, long limit, long offset);
+            List<TaskState> stateFilter, List<Long> taskIds, long limit, long offset);
 
     Set<Long> getDistinctProjectIds();
 

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDao.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDao.java
@@ -31,7 +31,7 @@ public interface CurationTaskDao {
     void clearActiveSessionId(Long taskId);
 
     List<TaskBundle> getCurationTaskBundles(List<Long> projectIds, List<Long> assigneeIds,
-            List<TaskState> stateFilter, long limit, long offset);
+            List<TaskState> stateFilter, Long taskId, long limit, long offset);
 
     Set<Long> getDistinctProjectIds();
 

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDao.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDao.java
@@ -31,7 +31,7 @@ public interface CurationTaskDao {
     void clearActiveSessionId(Long taskId);
 
     List<TaskBundle> getCurationTaskBundles(List<Long> projectIds, List<Long> assigneeIds,
-            List<TaskState> stateFilter, List<Long> taskId, long limit, long offset);
+            List<TaskState> stateFilter, List<Long> taskIds, long limit, long offset);
 
     Set<Long> getDistinctProjectIds();
 

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDao.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDao.java
@@ -31,7 +31,7 @@ public interface CurationTaskDao {
     void clearActiveSessionId(Long taskId);
 
     List<TaskBundle> getCurationTaskBundles(List<Long> projectIds, List<Long> assigneeIds,
-            List<TaskState> stateFilter, List<Long> taskIds, long limit, long offset);
+            List<TaskState> stateFilter, List<Long> taskId, long limit, long offset);
 
     Set<Long> getDistinctProjectIds();
 

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoImpl.java
@@ -249,7 +249,7 @@ public class CurationTaskDaoImpl implements CurationTaskDao {
 
     @Override
     public List<TaskBundle> getCurationTaskBundles(List<Long> projectIds, List<Long> assigneeIds,
-            List<TaskState> stateFilter, List<Long> taskIds, long limit, long offset) {
+            List<TaskState> stateFilter, List<Long> taskId, long limit, long offset) {
         ValidateArgument.requiredNotEmpty(projectIds, "projectIds");
 
         StringBuilder sql = new StringBuilder("SELECT * FROM CURATION_TASK WHERE PROJECT_ID IN (:projectIds)");
@@ -267,9 +267,9 @@ public class CurationTaskDaoImpl implements CurationTaskDao {
             params.addValue("stateFilter", stateNames);
         }
 
-        if (taskIds != null && !taskIds.isEmpty()) {
-            sql.append(" AND " + COL_CURATION_TASK_ID + " IN (:taskIds)");
-            params.addValue("taskIds", taskIds);
+        if (taskId != null && !taskId.isEmpty()) {
+            sql.append(" AND " + COL_CURATION_TASK_ID + " IN (:taskId)");
+            params.addValue("taskId", taskId);
         }
 
         sql.append(" ORDER BY ID LIMIT :limit OFFSET :offset");

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoImpl.java
@@ -249,7 +249,7 @@ public class CurationTaskDaoImpl implements CurationTaskDao {
 
     @Override
     public List<TaskBundle> getCurationTaskBundles(List<Long> projectIds, List<Long> assigneeIds,
-            List<TaskState> stateFilter, List<Long> taskId, long limit, long offset) {
+            List<TaskState> stateFilter, List<Long> taskIds, long limit, long offset) {
         ValidateArgument.requiredNotEmpty(projectIds, "projectIds");
 
         StringBuilder sql = new StringBuilder("SELECT * FROM CURATION_TASK WHERE PROJECT_ID IN (:projectIds)");
@@ -267,9 +267,9 @@ public class CurationTaskDaoImpl implements CurationTaskDao {
             params.addValue("stateFilter", stateNames);
         }
 
-        if (taskId != null && !taskId.isEmpty()) {
-            sql.append(" AND " + COL_CURATION_TASK_ID + " IN (:taskId)");
-            params.addValue("taskId", taskId);
+        if (taskIds != null && !taskIds.isEmpty()) {
+            sql.append(" AND " + COL_CURATION_TASK_ID + " IN (:taskIds)");
+            params.addValue("taskIds", taskIds);
         }
 
         sql.append(" ORDER BY ID LIMIT :limit OFFSET :offset");

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoImpl.java
@@ -249,7 +249,7 @@ public class CurationTaskDaoImpl implements CurationTaskDao {
 
     @Override
     public List<TaskBundle> getCurationTaskBundles(List<Long> projectIds, List<Long> assigneeIds,
-            List<TaskState> stateFilter, Long taskId, long limit, long offset) {
+            List<TaskState> stateFilter, List<Long> taskIds, long limit, long offset) {
         ValidateArgument.requiredNotEmpty(projectIds, "projectIds");
 
         StringBuilder sql = new StringBuilder("SELECT * FROM CURATION_TASK WHERE PROJECT_ID IN (:projectIds)");
@@ -267,9 +267,9 @@ public class CurationTaskDaoImpl implements CurationTaskDao {
             params.addValue("stateFilter", stateNames);
         }
 
-        if (taskId != null) {
-            sql.append(" AND " + COL_CURATION_TASK_ID + " = :taskId");
-            params.addValue("taskId", taskId);
+        if (taskIds != null && !taskIds.isEmpty()) {
+            sql.append(" AND " + COL_CURATION_TASK_ID + " IN (:taskIds)");
+            params.addValue("taskIds", taskIds);
         }
 
         sql.append(" ORDER BY ID LIMIT :limit OFFSET :offset");

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoImpl.java
@@ -249,7 +249,7 @@ public class CurationTaskDaoImpl implements CurationTaskDao {
 
     @Override
     public List<TaskBundle> getCurationTaskBundles(List<Long> projectIds, List<Long> assigneeIds,
-            List<TaskState> stateFilter, long limit, long offset) {
+            List<TaskState> stateFilter, Long taskId, long limit, long offset) {
         ValidateArgument.requiredNotEmpty(projectIds, "projectIds");
 
         StringBuilder sql = new StringBuilder("SELECT * FROM CURATION_TASK WHERE PROJECT_ID IN (:projectIds)");
@@ -265,6 +265,11 @@ public class CurationTaskDaoImpl implements CurationTaskDao {
             List<String> stateNames = stateFilter.stream().map(TaskState::name).collect(Collectors.toList());
             sql.append(" AND STATE IN (:stateFilter)");
             params.addValue("stateFilter", stateNames);
+        }
+
+        if (taskId != null) {
+            sql.append(" AND " + COL_CURATION_TASK_ID + " = :taskId");
+            params.addValue("taskId", taskId);
         }
 
         sql.append(" ORDER BY ID LIMIT :limit OFFSET :offset");

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoAutowireTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoAutowireTest.java
@@ -530,7 +530,7 @@ class CurationTaskDaoAutowireTest {
         // call under test
         List<TaskBundle> bundles = dao.getCurationTaskBundles(
                 List.of(KeyFactory.stringToKey(project1.getId())),
-                null, null, 10, 0);
+                null, null, null, 10, 0);
 
         assertEquals(2, bundles.size());
         assertEquals(created1.getTaskId(), bundles.get(0).getTask().getTaskId());
@@ -559,7 +559,7 @@ class CurationTaskDaoAutowireTest {
         // call under test - filter by userId
         List<TaskBundle> bundles = dao.getCurationTaskBundles(
                 List.of(KeyFactory.stringToKey(project1.getId())),
-                List.of(userId), null, 10, 0);
+                List.of(userId), null, null, 10, 0);
 
         assertEquals(1, bundles.size());
         assertEquals(created1.getTaskId(), bundles.get(0).getTask().getTaskId());
@@ -588,11 +588,35 @@ class CurationTaskDaoAutowireTest {
         // call under test - filter by IN_PROGRESS
         List<TaskBundle> bundles = dao.getCurationTaskBundles(
                 List.of(KeyFactory.stringToKey(project1.getId())),
-                null, List.of(TaskState.IN_PROGRESS), 10, 0);
+                null, List.of(TaskState.IN_PROGRESS), null, 10, 0);
 
         assertEquals(1, bundles.size());
         assertEquals(created1.getTaskId(), bundles.get(0).getTask().getTaskId());
         assertEquals(TaskState.IN_PROGRESS, bundles.get(0).getStatus().getState());
+
+        dao.deleteCurationTask(created1.getTaskId());
+        dao.deleteCurationTask(created2.getTaskId());
+    }
+
+    @Test
+    public void testGetCurationTaskBundlesWithTaskIdFilter() {
+        CurationTask created1 = dao.createCurationTask(userId, new CurationTask()
+                .setProjectId(project1.getId())
+                .setDataType("fastq")
+                .setTaskProperties(createTaskProperties(CurationTaskPropertiesType.FILE_BASED)));
+
+        CurationTask created2 = dao.createCurationTask(userId, new CurationTask()
+                .setProjectId(project1.getId())
+                .setDataType("rnaseq")
+                .setTaskProperties(createTaskProperties(CurationTaskPropertiesType.RECORD_BASED)));
+
+        // call under test - filter by taskId of created1; created2 is the decoy in the same project
+        List<TaskBundle> bundles = dao.getCurationTaskBundles(
+                List.of(KeyFactory.stringToKey(project1.getId())),
+                null, null, created1.getTaskId(), 10, 0);
+
+        assertEquals(1, bundles.size());
+        assertEquals(created1.getTaskId(), bundles.get(0).getTask().getTaskId());
 
         dao.deleteCurationTask(created1.getTaskId());
         dao.deleteCurationTask(created2.getTaskId());

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoAutowireTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoAutowireTest.java
@@ -599,7 +599,7 @@ class CurationTaskDaoAutowireTest {
     }
 
     @Test
-    public void testGetCurationTaskBundlesWithTaskIdFilter() {
+    public void testGetCurationTaskBundlesWithTaskIdsFilter() {
         CurationTask created1 = dao.createCurationTask(userId, new CurationTask()
                 .setProjectId(project1.getId())
                 .setDataType("fastq")
@@ -610,16 +610,31 @@ class CurationTaskDaoAutowireTest {
                 .setDataType("rnaseq")
                 .setTaskProperties(createTaskProperties(CurationTaskPropertiesType.RECORD_BASED)));
 
-        // call under test - filter by taskId of created1; created2 is the decoy in the same project
-        List<TaskBundle> bundles = dao.getCurationTaskBundles(
-                List.of(KeyFactory.stringToKey(project1.getId())),
-                null, null, created1.getTaskId(), 10, 0);
+        CurationTask created3 = dao.createCurationTask(userId, new CurationTask()
+                .setProjectId(project2.getId())
+                .setDataType("fastq")
+                .setTaskProperties(createTaskProperties(CurationTaskPropertiesType.FILE_BASED)));
 
-        assertEquals(1, bundles.size());
+        // call under test - filter by taskIds of created1 and created2; created3 in a different project is the decoy
+        List<TaskBundle> bundles = dao.getCurationTaskBundles(
+                List.of(KeyFactory.stringToKey(project1.getId()), KeyFactory.stringToKey(project2.getId())),
+                null, null, List.of(created1.getTaskId(), created2.getTaskId()), 10, 0);
+
+        assertEquals(2, bundles.size());
         assertEquals(created1.getTaskId(), bundles.get(0).getTask().getTaskId());
+        assertEquals(created2.getTaskId(), bundles.get(1).getTask().getTaskId());
+
+        // non-existent ID is silently excluded
+        List<TaskBundle> bundlesWithMissing = dao.getCurationTaskBundles(
+                List.of(KeyFactory.stringToKey(project1.getId())),
+                null, null, List.of(created1.getTaskId(), 999999999L), 10, 0);
+
+        assertEquals(1, bundlesWithMissing.size());
+        assertEquals(created1.getTaskId(), bundlesWithMissing.get(0).getTask().getTaskId());
 
         dao.deleteCurationTask(created1.getTaskId());
         dao.deleteCurationTask(created2.getTaskId());
+        dao.deleteCurationTask(created3.getTaskId());
     }
 
     @Test

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoAutowireTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoAutowireTest.java
@@ -615,7 +615,7 @@ class CurationTaskDaoAutowireTest {
                 .setDataType("fastq")
                 .setTaskProperties(createTaskProperties(CurationTaskPropertiesType.FILE_BASED)));
 
-        // call under test - filter by taskIds of created1 and created2; created3 in a different project is the decoy
+        // call under test - filter by taskId of created1 and created2; created3 in a different project is the decoy
         List<TaskBundle> bundles = dao.getCurationTaskBundles(
                 List.of(KeyFactory.stringToKey(project1.getId()), KeyFactory.stringToKey(project2.getId())),
                 null, null, List.of(created1.getTaskId(), created2.getTaskId()), 10, 0);
@@ -635,6 +635,34 @@ class CurationTaskDaoAutowireTest {
         dao.deleteCurationTask(created1.getTaskId());
         dao.deleteCurationTask(created2.getTaskId());
         dao.deleteCurationTask(created3.getTaskId());
+    }
+
+    @Test
+    public void testGetCurationTaskBundlesTaskIdsFilterExcludesOtherTasksInSameProject() {
+        // Two tasks in the same project — only the IN (:taskId) clause separates them.
+        // This is the direct analog of "passing taskId=123 returns taskId=456".
+        CurationTask task1 = dao.createCurationTask(userId, new CurationTask()
+                .setProjectId(project1.getId())
+                .setDataType("fastq")
+                .setTaskProperties(createTaskProperties(CurationTaskPropertiesType.FILE_BASED)));
+
+        CurationTask task2 = dao.createCurationTask(userId, new CurationTask()
+                .setProjectId(project1.getId())
+                .setDataType("rnaseq")
+                .setTaskProperties(createTaskProperties(CurationTaskPropertiesType.RECORD_BASED)));
+
+        try {
+            // call under test - filter by task1's ID only; task2 is in the same project and must be excluded
+            List<TaskBundle> result = dao.getCurationTaskBundles(
+                    List.of(KeyFactory.stringToKey(project1.getId())),
+                    null, null, List.of(task1.getTaskId()), 10, 0);
+
+            assertEquals(1, result.size());
+            assertEquals(task1.getTaskId(), result.get(0).getTask().getTaskId());
+        } finally {
+            dao.deleteCurationTask(task1.getTaskId());
+            dao.deleteCurationTask(task2.getTaskId());
+        }
     }
 
     @Test

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoAutowireTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoAutowireTest.java
@@ -529,7 +529,7 @@ class CurationTaskDaoAutowireTest {
 
         // call under test
         List<TaskBundle> bundles = dao.getCurationTaskBundles(
-                Collections.emptyList(),
+                List.of(KeyFactory.stringToKey(project1.getId())),
                 null, null, List.of(created1.getTaskId(), created2.getTaskId()), 10, 0);
 
         assertEquals(2, bundles.size());
@@ -669,7 +669,7 @@ class CurationTaskDaoAutowireTest {
     public void testGetCurationTaskBundlesReturnsZeroResultsForNonExistentTaskId() {
         // call under test - filter by non-existent taskId
         List<TaskBundle> bundles = dao.getCurationTaskBundles(
-                Collections.emptyList(),
+                List.of(KeyFactory.stringToKey(project1.getId())),
                 null, null, List.of(999999999L), 10, 0);
 
         assertEquals(0, bundles.size());

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoAutowireTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/curation/CurationTaskDaoAutowireTest.java
@@ -529,8 +529,8 @@ class CurationTaskDaoAutowireTest {
 
         // call under test
         List<TaskBundle> bundles = dao.getCurationTaskBundles(
-                List.of(KeyFactory.stringToKey(project1.getId())),
-                null, null, null, 10, 0);
+                Collections.emptyList(),
+                null, null, List.of(created1.getTaskId(), created2.getTaskId()), 10, 0);
 
         assertEquals(2, bundles.size());
         assertEquals(created1.getTaskId(), bundles.get(0).getTask().getTaskId());
@@ -663,6 +663,16 @@ class CurationTaskDaoAutowireTest {
             dao.deleteCurationTask(task1.getTaskId());
             dao.deleteCurationTask(task2.getTaskId());
         }
+    }
+
+    @Test
+    public void testGetCurationTaskBundlesReturnsZeroResultsForNonExistentTaskId() {
+        // call under test - filter by non-existent taskId
+        List<TaskBundle> bundles = dao.getCurationTaskBundles(
+                Collections.emptyList(),
+                null, null, List.of(999999999L), 10, 0);
+
+        assertEquals(0, bundles.size());
     }
 
     @Test

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/curation/ListCurationTaskRequest.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/curation/ListCurationTaskRequest.json
@@ -23,9 +23,12 @@
       },
       "description": "Optional. Filter tasks by their current state."
     },
-    "taskId": {
-      "type": "integer",
-      "description": "Optional. Filter by a specific task ID."
+    "taskIds": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      },
+      "description": "Optional. Filter to tasks with these IDs. Tasks that do not exist or are not accessible are silently excluded."
     },
     "nextPageToken": {
       "type": "string",

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/curation/ListCurationTaskRequest.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/curation/ListCurationTaskRequest.json
@@ -28,7 +28,7 @@
       "items": {
         "type": "integer"
       },
-      "description": "Optional. Filter to tasks with these IDs. Tasks that do not exist or are not accessible are silently excluded."
+      "description": "Optional. Filter tasks by their task ID."
     },
     "nextPageToken": {
       "type": "string",

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/curation/ListCurationTaskRequest.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/curation/ListCurationTaskRequest.json
@@ -23,7 +23,7 @@
       },
       "description": "Optional. Filter tasks by their current state."
     },
-    "taskIds": {
+    "taskId": {
       "type": "array",
       "items": {
         "type": "integer"

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/curation/ListCurationTaskRequest.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/curation/ListCurationTaskRequest.json
@@ -23,12 +23,12 @@
       },
       "description": "Optional. Filter tasks by their current state."
     },
-    "taskId": {
+    "taskIds": {
       "type": "array",
       "items": {
         "type": "integer"
       },
-      "description": "Optional. Filter tasks by their task ID."
+      "description": "Optional. Filter tasks by their task IDs."
     },
     "nextPageToken": {
       "type": "string",

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/curation/ListCurationTaskRequest.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/curation/ListCurationTaskRequest.json
@@ -23,6 +23,10 @@
       },
       "description": "Optional. Filter tasks by their current state."
     },
+    "taskId": {
+      "type": "integer",
+      "description": "Optional. Filter by a specific task ID."
+    },
     "nextPageToken": {
       "type": "string",
       "description": "Forward the returned 'nextPageToken' to get the next page of results."

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImpl.java
@@ -127,12 +127,6 @@ public class CurationTaskManagerImpl implements CurationTaskManager {
             authorizationManager.canAccess(userInfo, request.getProjectId(), ObjectType.ENTITY, ACCESS_TYPE.READ)
                     .checkAuthorizationOrElseThrow();
             accessibleProjectIds = List.of(KeyFactory.stringToKey(request.getProjectId()));
-        } else if (request.getTaskId() != null) {
-            CurationTask task = curationTaskDao.getCurationTask(request.getTaskId())
-                    .orElseThrow(() -> new NotFoundException("Task not found: " + request.getTaskId()));
-            authorizationManager.canAccess(userInfo, task.getProjectId(), ObjectType.ENTITY, ACCESS_TYPE.READ)
-                    .checkAuthorizationOrElseThrow();
-            accessibleProjectIds = List.of(KeyFactory.stringToKey(task.getProjectId()));
         } else {
             Set<Long> allTaskProjectIds = curationTaskDao.getDistinctProjectIds();
             if (allTaskProjectIds.isEmpty()) {
@@ -147,7 +141,7 @@ public class CurationTaskManagerImpl implements CurationTaskManager {
 
         List<TaskBundle> bundles = curationTaskDao.getCurationTaskBundles(
                 accessibleProjectIds, assigneeIds, request.getStateFilter(),
-                request.getTaskId(), token.getLimitForQuery(), token.getOffset());
+                request.getTaskIds(), token.getLimitForQuery(), token.getOffset());
 
         List<CurationTask> tasks = bundles.stream().map(TaskBundle::getTask).collect(Collectors.toList());
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImpl.java
@@ -141,7 +141,7 @@ public class CurationTaskManagerImpl implements CurationTaskManager {
 
         List<TaskBundle> bundles = curationTaskDao.getCurationTaskBundles(
                 accessibleProjectIds, assigneeIds, request.getStateFilter(),
-                request.getTaskIds(), token.getLimitForQuery(), token.getOffset());
+                request.getTaskId(), token.getLimitForQuery(), token.getOffset());
 
         List<CurationTask> tasks = bundles.stream().map(TaskBundle::getTask).collect(Collectors.toList());
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImpl.java
@@ -127,6 +127,12 @@ public class CurationTaskManagerImpl implements CurationTaskManager {
             authorizationManager.canAccess(userInfo, request.getProjectId(), ObjectType.ENTITY, ACCESS_TYPE.READ)
                     .checkAuthorizationOrElseThrow();
             accessibleProjectIds = List.of(KeyFactory.stringToKey(request.getProjectId()));
+        } else if (request.getTaskId() != null) {
+            CurationTask task = curationTaskDao.getCurationTask(request.getTaskId())
+                    .orElseThrow(() -> new NotFoundException("Task not found: " + request.getTaskId()));
+            authorizationManager.canAccess(userInfo, task.getProjectId(), ObjectType.ENTITY, ACCESS_TYPE.READ)
+                    .checkAuthorizationOrElseThrow();
+            accessibleProjectIds = List.of(KeyFactory.stringToKey(task.getProjectId()));
         } else {
             Set<Long> allTaskProjectIds = curationTaskDao.getDistinctProjectIds();
             if (allTaskProjectIds.isEmpty()) {
@@ -141,7 +147,7 @@ public class CurationTaskManagerImpl implements CurationTaskManager {
 
         List<TaskBundle> bundles = curationTaskDao.getCurationTaskBundles(
                 accessibleProjectIds, assigneeIds, request.getStateFilter(),
-                token.getLimitForQuery(), token.getOffset());
+                request.getTaskId(), token.getLimitForQuery(), token.getOffset());
 
         List<CurationTask> tasks = bundles.stream().map(TaskBundle::getTask).collect(Collectors.toList());
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImpl.java
@@ -141,7 +141,7 @@ public class CurationTaskManagerImpl implements CurationTaskManager {
 
         List<TaskBundle> bundles = curationTaskDao.getCurationTaskBundles(
                 accessibleProjectIds, assigneeIds, request.getStateFilter(),
-                request.getTaskId(), token.getLimitForQuery(), token.getOffset());
+                request.getTaskIds(), token.getLimitForQuery(), token.getOffset());
 
         List<CurationTask> tasks = bundles.stream().map(TaskBundle::getTask).collect(Collectors.toList());
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
@@ -341,8 +341,8 @@ public class CurationTaskManagerImplUnitTest {
 
     @Test
     public void testGetCurationTasksWithTaskIdsNoProjectId() {
-        List<Long> taskId = List.of(this.taskId);
-        ListCurationTaskRequest request = new ListCurationTaskRequest().setTaskId(taskId);
+        List<Long> taskIds = List.of(this.taskId);
+        ListCurationTaskRequest request = new ListCurationTaskRequest().setTaskIds(taskIds);
 
         Set<Long> allProjectIds = new HashSet<>(Arrays.asList(100L, 200L));
         Set<Long> accessibleIds = new HashSet<>(Arrays.asList(100L, 200L));

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
@@ -355,7 +355,7 @@ public class CurationTaskManagerImplUnitTest {
         TaskBundle bundle1 = new TaskBundle().setTask(task1);
         List<TaskBundle> bundles = List.of(bundle1);
 
-        when(mockCurationTaskDao.getCurationTaskBundles(any(), eq(null), eq(null), eq(taskId), anyLong(), anyLong()))
+        when(mockCurationTaskDao.getCurationTaskBundles(any(), eq(null), eq(null), eq(taskIds), anyLong(), anyLong()))
                 .thenReturn(bundles);
 
         // call under test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
@@ -307,7 +308,7 @@ public class CurationTaskManagerImplUnitTest {
 
         when(mockAuthorizationManager.canAccess(eq(userInfo), eq(projectId), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.READ))).thenReturn(mockAuthorizationStatus);
         when(mockCurationTaskDao.getCurationTaskBundles(eq(List.of(KeyFactory.stringToKey(projectId))),
-                eq(null), eq(null), eq((Long) null), anyLong(), anyLong())).thenReturn(bundles);
+                eq(null), eq(null), isNull(), anyLong(), anyLong())).thenReturn(bundles);
 
         // Call under test
         ListCurationTaskResponse response = curationTaskManager.getCurationTasks(userInfo, request);
@@ -317,10 +318,11 @@ public class CurationTaskManagerImplUnitTest {
     }
 
     @Test
-    public void testGetCurationTasksWithTaskIdFilter() {
+    public void testGetCurationTasksWithTaskIdsFilter() {
+        List<Long> taskIds = List.of(taskId);
         ListCurationTaskRequest request = new ListCurationTaskRequest()
                 .setProjectId(projectId)
-                .setTaskId(taskId);
+                .setTaskIds(taskIds);
         CurationTask task1 = createCurationTask(CurationTaskPropertiesType.FILE_BASED);
         TaskBundle bundle1 = new TaskBundle().setTask(task1);
         List<TaskBundle> bundles = List.of(bundle1);
@@ -328,7 +330,7 @@ public class CurationTaskManagerImplUnitTest {
         when(mockAuthorizationManager.canAccess(eq(userInfo), eq(projectId), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.READ)))
                 .thenReturn(mockAuthorizationStatus);
         when(mockCurationTaskDao.getCurationTaskBundles(eq(List.of(KeyFactory.stringToKey(projectId))),
-                eq(null), eq(null), eq(taskId), anyLong(), anyLong())).thenReturn(bundles);
+                eq(null), eq(null), eq(taskIds), anyLong(), anyLong())).thenReturn(bundles);
 
         // call under test
         ListCurationTaskResponse response = curationTaskManager.getCurationTasks(userInfo, request);
@@ -338,38 +340,30 @@ public class CurationTaskManagerImplUnitTest {
     }
 
     @Test
-    public void testGetCurationTasksWithTaskIdButNoProjectId() {
-        ListCurationTaskRequest request = new ListCurationTaskRequest().setTaskId(taskId);
-        CurationTask task = createCurationTask(CurationTaskPropertiesType.FILE_BASED).setTaskId(taskId).setProjectId(projectId);
-        TaskBundle bundle = new TaskBundle().setTask(task);
-        List<TaskBundle> bundles = List.of(bundle);
+    public void testGetCurationTasksWithTaskIdsNoProjectId() {
+        List<Long> taskIds = List.of(taskId);
+        ListCurationTaskRequest request = new ListCurationTaskRequest().setTaskIds(taskIds);
 
-        when(mockCurationTaskDao.getCurationTask(taskId)).thenReturn(Optional.of(task));
-        when(mockAuthorizationManager.canAccess(eq(userInfo), eq(projectId), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.READ)))
-                .thenReturn(mockAuthorizationStatus);
-        when(mockCurationTaskDao.getCurationTaskBundles(eq(List.of(KeyFactory.stringToKey(projectId))),
-                eq(null), eq(null), eq(taskId), anyLong(), anyLong())).thenReturn(bundles);
+        Set<Long> allProjectIds = new HashSet<>(Arrays.asList(100L, 200L));
+        Set<Long> accessibleIds = new HashSet<>(Arrays.asList(100L, 200L));
+
+        when(mockCurationTaskDao.getDistinctProjectIds()).thenReturn(allProjectIds);
+        when(mockAclManager.getAccessibleBenefactors(eq(userInfo), eq(ObjectType.ENTITY), eq(allProjectIds), eq(ACCESS_TYPE.READ)))
+                .thenReturn(accessibleIds);
+
+        CurationTask task1 = createCurationTask(CurationTaskPropertiesType.FILE_BASED);
+        TaskBundle bundle1 = new TaskBundle().setTask(task1);
+        List<TaskBundle> bundles = List.of(bundle1);
+
+        when(mockCurationTaskDao.getCurationTaskBundles(any(), eq(null), eq(null), eq(taskIds), anyLong(), anyLong()))
+                .thenReturn(bundles);
 
         // call under test
         ListCurationTaskResponse response = curationTaskManager.getCurationTasks(userInfo, request);
 
-        assertEquals(List.of(task), response.getPage());
+        assertEquals(List.of(task1), response.getPage());
         assertEquals(bundles, response.getBundlePage());
-        verify(mockCurationTaskDao, never()).getDistinctProjectIds();
-        verifyNoMoreInteractions(mockAclManager);
-    }
-
-    @Test
-    public void testGetCurationTasksWithTaskIdButNoProjectIdNotFound() {
-        ListCurationTaskRequest request = new ListCurationTaskRequest().setTaskId(taskId);
-
-        when(mockCurationTaskDao.getCurationTask(taskId)).thenReturn(Optional.empty());
-
-        // call under test
-        assertThrows(NotFoundException.class, () -> curationTaskManager.getCurationTasks(userInfo, request));
-
-        verify(mockCurationTaskDao, never()).getDistinctProjectIds();
-        verifyNoMoreInteractions(mockAclManager, mockAuthorizationManager);
+        verify(mockCurationTaskDao, never()).getCurationTask(any());
     }
 
 	@Test
@@ -385,7 +379,7 @@ public class CurationTaskManagerImplUnitTest {
 		when(mockAuthorizationManager.canAccess(eq(userInfo), eq(projectId), eq(ObjectType.ENTITY),
 				eq(ACCESS_TYPE.READ))).thenReturn(mockAuthorizationStatus);
 		when(mockCurationTaskDao.getCurationTaskBundles(eq(List.of(KeyFactory.stringToKey(projectId))), eq(List.of(111L,222L)),
-				eq(null), eq((Long) null), anyLong(), anyLong())).thenReturn(bundles);
+				eq(null), isNull(), anyLong(), anyLong())).thenReturn(bundles);
 
 		// Call under test
 		ListCurationTaskResponse response = curationTaskManager.getCurationTasks(userInfo, request);
@@ -425,7 +419,7 @@ public class CurationTaskManagerImplUnitTest {
         when(mockAuthorizationManager.canAccess(eq(userInfo), eq(projectId), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.READ)))
                 .thenReturn(mockAuthorizationStatus);
         when(mockCurationTaskDao.getCurationTaskBundles(eq(List.of(KeyFactory.stringToKey(projectId))),
-                eq(new ArrayList<>(groups)), eq(null), eq((Long) null), anyLong(), anyLong())).thenReturn(bundles);
+                eq(new ArrayList<>(groups)), eq(null), isNull(), anyLong(), anyLong())).thenReturn(bundles);
 
         // Call under test
         ListCurationTaskResponse response = curationTaskManager.getCurationTasks(userInfo, request);
@@ -465,7 +459,7 @@ public class CurationTaskManagerImplUnitTest {
         TaskBundle bundle1 = new TaskBundle().setTask(task1);
         List<TaskBundle> bundles = Arrays.asList(bundle1);
 
-        when(mockCurationTaskDao.getCurationTaskBundles(any(), eq(null), eq(null), eq((Long) null), anyLong(), anyLong()))
+        when(mockCurationTaskDao.getCurationTaskBundles(any(), eq(null), eq(null), isNull(), anyLong(), anyLong()))
                 .thenReturn(bundles);
 
         // Call under test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
@@ -322,7 +322,7 @@ public class CurationTaskManagerImplUnitTest {
         List<Long> taskId = List.of(this.taskId);
         ListCurationTaskRequest request = new ListCurationTaskRequest()
                 .setProjectId(projectId)
-                .setTaskId(taskId);
+                .setTaskIds(taskId);
         CurationTask task1 = createCurationTask(CurationTaskPropertiesType.FILE_BASED);
         TaskBundle bundle1 = new TaskBundle().setTask(task1);
         List<TaskBundle> bundles = List.of(bundle1);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
@@ -319,10 +319,10 @@ public class CurationTaskManagerImplUnitTest {
 
     @Test
     public void testGetCurationTasksWithTaskIdsFilter() {
-        List<Long> taskIds = List.of(taskId);
+        List<Long> taskId = List.of(this.taskId);
         ListCurationTaskRequest request = new ListCurationTaskRequest()
                 .setProjectId(projectId)
-                .setTaskIds(taskIds);
+                .setTaskId(taskId);
         CurationTask task1 = createCurationTask(CurationTaskPropertiesType.FILE_BASED);
         TaskBundle bundle1 = new TaskBundle().setTask(task1);
         List<TaskBundle> bundles = List.of(bundle1);
@@ -330,7 +330,7 @@ public class CurationTaskManagerImplUnitTest {
         when(mockAuthorizationManager.canAccess(eq(userInfo), eq(projectId), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.READ)))
                 .thenReturn(mockAuthorizationStatus);
         when(mockCurationTaskDao.getCurationTaskBundles(eq(List.of(KeyFactory.stringToKey(projectId))),
-                eq(null), eq(null), eq(taskIds), anyLong(), anyLong())).thenReturn(bundles);
+                eq(null), eq(null), eq(taskId), anyLong(), anyLong())).thenReturn(bundles);
 
         // call under test
         ListCurationTaskResponse response = curationTaskManager.getCurationTasks(userInfo, request);
@@ -341,8 +341,8 @@ public class CurationTaskManagerImplUnitTest {
 
     @Test
     public void testGetCurationTasksWithTaskIdsNoProjectId() {
-        List<Long> taskIds = List.of(taskId);
-        ListCurationTaskRequest request = new ListCurationTaskRequest().setTaskIds(taskIds);
+        List<Long> taskId = List.of(this.taskId);
+        ListCurationTaskRequest request = new ListCurationTaskRequest().setTaskId(taskId);
 
         Set<Long> allProjectIds = new HashSet<>(Arrays.asList(100L, 200L));
         Set<Long> accessibleIds = new HashSet<>(Arrays.asList(100L, 200L));
@@ -355,7 +355,7 @@ public class CurationTaskManagerImplUnitTest {
         TaskBundle bundle1 = new TaskBundle().setTask(task1);
         List<TaskBundle> bundles = List.of(bundle1);
 
-        when(mockCurationTaskDao.getCurationTaskBundles(any(), eq(null), eq(null), eq(taskIds), anyLong(), anyLong()))
+        when(mockCurationTaskDao.getCurationTaskBundles(any(), eq(null), eq(null), eq(taskId), anyLong(), anyLong()))
                 .thenReturn(bundles);
 
         // call under test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/curation/CurationTaskManagerImplUnitTest.java
@@ -307,7 +307,7 @@ public class CurationTaskManagerImplUnitTest {
 
         when(mockAuthorizationManager.canAccess(eq(userInfo), eq(projectId), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.READ))).thenReturn(mockAuthorizationStatus);
         when(mockCurationTaskDao.getCurationTaskBundles(eq(List.of(KeyFactory.stringToKey(projectId))),
-                eq(null), eq(null), anyLong(), anyLong())).thenReturn(bundles);
+                eq(null), eq(null), eq((Long) null), anyLong(), anyLong())).thenReturn(bundles);
 
         // Call under test
         ListCurationTaskResponse response = curationTaskManager.getCurationTasks(userInfo, request);
@@ -315,7 +315,63 @@ public class CurationTaskManagerImplUnitTest {
         assertEquals(Arrays.asList(task1, task2), response.getPage());
         assertEquals(bundles, response.getBundlePage());
     }
-    
+
+    @Test
+    public void testGetCurationTasksWithTaskIdFilter() {
+        ListCurationTaskRequest request = new ListCurationTaskRequest()
+                .setProjectId(projectId)
+                .setTaskId(taskId);
+        CurationTask task1 = createCurationTask(CurationTaskPropertiesType.FILE_BASED);
+        TaskBundle bundle1 = new TaskBundle().setTask(task1);
+        List<TaskBundle> bundles = List.of(bundle1);
+
+        when(mockAuthorizationManager.canAccess(eq(userInfo), eq(projectId), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.READ)))
+                .thenReturn(mockAuthorizationStatus);
+        when(mockCurationTaskDao.getCurationTaskBundles(eq(List.of(KeyFactory.stringToKey(projectId))),
+                eq(null), eq(null), eq(taskId), anyLong(), anyLong())).thenReturn(bundles);
+
+        // call under test
+        ListCurationTaskResponse response = curationTaskManager.getCurationTasks(userInfo, request);
+
+        assertEquals(List.of(task1), response.getPage());
+        assertEquals(bundles, response.getBundlePage());
+    }
+
+    @Test
+    public void testGetCurationTasksWithTaskIdButNoProjectId() {
+        ListCurationTaskRequest request = new ListCurationTaskRequest().setTaskId(taskId);
+        CurationTask task = createCurationTask(CurationTaskPropertiesType.FILE_BASED).setTaskId(taskId).setProjectId(projectId);
+        TaskBundle bundle = new TaskBundle().setTask(task);
+        List<TaskBundle> bundles = List.of(bundle);
+
+        when(mockCurationTaskDao.getCurationTask(taskId)).thenReturn(Optional.of(task));
+        when(mockAuthorizationManager.canAccess(eq(userInfo), eq(projectId), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.READ)))
+                .thenReturn(mockAuthorizationStatus);
+        when(mockCurationTaskDao.getCurationTaskBundles(eq(List.of(KeyFactory.stringToKey(projectId))),
+                eq(null), eq(null), eq(taskId), anyLong(), anyLong())).thenReturn(bundles);
+
+        // call under test
+        ListCurationTaskResponse response = curationTaskManager.getCurationTasks(userInfo, request);
+
+        assertEquals(List.of(task), response.getPage());
+        assertEquals(bundles, response.getBundlePage());
+        verify(mockCurationTaskDao, never()).getDistinctProjectIds();
+        verifyNoMoreInteractions(mockAclManager);
+    }
+
+    @Test
+    public void testGetCurationTasksWithTaskIdButNoProjectIdNotFound() {
+        ListCurationTaskRequest request = new ListCurationTaskRequest().setTaskId(taskId);
+
+        when(mockCurationTaskDao.getCurationTask(taskId)).thenReturn(Optional.empty());
+
+        // call under test
+        assertThrows(NotFoundException.class, () -> curationTaskManager.getCurationTasks(userInfo, request));
+
+        verify(mockCurationTaskDao, never()).getDistinctProjectIds();
+        verifyNoMoreInteractions(mockAclManager, mockAuthorizationManager);
+    }
+
 	@Test
 	public void testGetCurationTasksWithAssigneeIds() {
 		ListCurationTaskRequest request = new ListCurationTaskRequest().setProjectId(projectId)
@@ -329,7 +385,7 @@ public class CurationTaskManagerImplUnitTest {
 		when(mockAuthorizationManager.canAccess(eq(userInfo), eq(projectId), eq(ObjectType.ENTITY),
 				eq(ACCESS_TYPE.READ))).thenReturn(mockAuthorizationStatus);
 		when(mockCurationTaskDao.getCurationTaskBundles(eq(List.of(KeyFactory.stringToKey(projectId))), eq(List.of(111L,222L)),
-				eq(null), anyLong(), anyLong())).thenReturn(bundles);
+				eq(null), eq((Long) null), anyLong(), anyLong())).thenReturn(bundles);
 
 		// Call under test
 		ListCurationTaskResponse response = curationTaskManager.getCurationTasks(userInfo, request);
@@ -369,7 +425,7 @@ public class CurationTaskManagerImplUnitTest {
         when(mockAuthorizationManager.canAccess(eq(userInfo), eq(projectId), eq(ObjectType.ENTITY), eq(ACCESS_TYPE.READ)))
                 .thenReturn(mockAuthorizationStatus);
         when(mockCurationTaskDao.getCurationTaskBundles(eq(List.of(KeyFactory.stringToKey(projectId))),
-                eq(new ArrayList<>(groups)), eq(null), anyLong(), anyLong())).thenReturn(bundles);
+                eq(new ArrayList<>(groups)), eq(null), eq((Long) null), anyLong(), anyLong())).thenReturn(bundles);
 
         // Call under test
         ListCurationTaskResponse response = curationTaskManager.getCurationTasks(userInfo, request);
@@ -409,7 +465,7 @@ public class CurationTaskManagerImplUnitTest {
         TaskBundle bundle1 = new TaskBundle().setTask(task1);
         List<TaskBundle> bundles = Arrays.asList(bundle1);
 
-        when(mockCurationTaskDao.getCurationTaskBundles(any(), eq(null), eq(null), anyLong(), anyLong()))
+        when(mockCurationTaskDao.getCurationTaskBundles(any(), eq(null), eq(null), eq((Long) null), anyLong(), anyLong()))
                 .thenReturn(bundles);
 
         // Call under test


### PR DESCRIPTION
Add taskId filter parameter to ListCurationTaskRequest. This takes an array of integers and returns tasks with matching taskIds.