### PR TITLE
[release-595] PLFM-9575 - Update RecordSet indexing logic

### DIFF
--- a/integration-test/src/test/java/org/sagebionetworks/ITRecordSetTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITRecordSetTest.java
@@ -1,13 +1,16 @@
 package org.sagebionetworks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
@@ -16,14 +19,23 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.sagebionetworks.client.AsynchJobType;
 import org.sagebionetworks.client.SynapseAdminClient;
 import org.sagebionetworks.client.SynapseClient;
 import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.client.exceptions.SynapseNotFoundException;
 import org.sagebionetworks.repo.model.Project;
 import org.sagebionetworks.repo.model.RecordSet;
+import org.sagebionetworks.repo.model.entity.BindSchemaToEntityRequest;
 import org.sagebionetworks.repo.model.file.FileHandle;
 import org.sagebionetworks.repo.model.file.FileHandleAssociateType;
 import org.sagebionetworks.repo.model.file.FileHandleAssociation;
+import org.sagebionetworks.repo.model.schema.CreateOrganizationRequest;
+import org.sagebionetworks.repo.model.schema.CreateSchemaRequest;
+import org.sagebionetworks.repo.model.schema.CreateSchemaResponse;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.repo.model.schema.Organization;
+import org.sagebionetworks.repo.model.schema.Type;
 import org.sagebionetworks.repo.model.table.Query;
 import org.sagebionetworks.repo.model.table.QueryOptions;
 import org.sagebionetworks.repo.model.table.Row;
@@ -33,12 +45,15 @@ public class ITRecordSetTest {
 
 	private static final long INDEX_TIMEOUT_MS = 1000L * 60 * 2;
 
+	private static final long SCHEMA_TIMEOUT_MS = 1000L * 30;
+
 	private SynapseAdminClient adminSynapse;
 	private SynapseClient synapse;
 	private Project project;
 	private File csvFile;
 	private FileHandle csvFileHandle;
 	private RecordSet recordSet;
+	private String organizationName;
 
 	public ITRecordSetTest(SynapseAdminClient adminSynapse, SynapseClient synapse) {
 		this.adminSynapse = adminSynapse;
@@ -55,6 +70,11 @@ public class ITRecordSetTest {
 		csvFile = new File(ITRecordSetTest.class.getClassLoader().getResource("docs/test.csv").getFile().replaceAll("%20", " "));
 
 		csvFileHandle = synapse.multipartUpload(csvFile, null, false, true);
+
+		// A unique organization name per run so the test user always owns it (and thus has CREATE
+		// permission to register schemas under it), independent of prior runs. Each dot-separated
+		// segment must start with a letter, so the random suffix is prefixed with one.
+		organizationName = "it.recordset.s" + UUID.randomUUID().toString().replace("-", "");
 	}
 	
 	@AfterEach
@@ -107,7 +127,49 @@ public class ITRecordSetTest {
 		rs.setName(UUID.randomUUID().toString());
 		rs.setUpsertKey(List.of("a"));
 		rs.setDataFileHandleId(dataFileHandleId);
-		return synapse.createEntity(rs);
+		rs = synapse.createEntity(rs);
+
+		// A RecordSet is only indexed when it has a bound JSON Schema, and the column schema bound
+		// to the index is derived from that JSON Schema. The metadata provider fires on create
+		// before a schema can be bound to the new entity, so bind the schema and then update the
+		// entity to re-fire the provider with the schema present, which builds the index.
+		bindSchema(rs.getId(), integerProperties("a", "b", "c"));
+		return synapse.putEntity(rs);
+	}
+
+	/**
+	 * Registers a new JSON Schema with the given properties and binds it to the entity. A unique
+	 * organization (created by the test user, who therefore has CREATE permission) and a unique
+	 * schema name are used so repeated test runs don't collide.
+	 */
+	private void bindSchema(String entityId, Map<String, JsonSchema> properties) throws SynapseException {
+		Organization organization;
+		try {
+			organization = synapse.getOrganizationByName(organizationName);
+		} catch (SynapseNotFoundException e) {
+			organization = synapse.createOrganization(new CreateOrganizationRequest().setOrganizationName(organizationName));
+		}
+		String schemaName = "it.recordset.s" + UUID.randomUUID().toString().replace("-", "");
+		JsonSchema schema = new JsonSchema()
+				.set$id(organization.getName() + "-" + schemaName)
+				.setProperties(properties);
+		CreateSchemaResponse response = AsyncJobHelper.assertAysncJobResult(synapse, AsynchJobType.CreateJsonSchema,
+				new CreateSchemaRequest().setSchema(schema),
+				(CreateSchemaResponse r) -> assertNotNull(r.getNewVersionInfo()), SCHEMA_TIMEOUT_MS).getResponse();
+		String schema$id = response.getNewVersionInfo().get$id();
+		synapse.bindJsonSchemaToEntity(new BindSchemaToEntityRequest().setEntityId(entityId).setSchema$id(schema$id));
+	}
+
+	/**
+	 * Builds an ordered properties map (column order is preserved by the index) where every named
+	 * property is declared as an INTEGER.
+	 */
+	private static Map<String, JsonSchema> integerProperties(String... names) {
+		Map<String, JsonSchema> properties = new LinkedHashMap<>();
+		for (String name : names) {
+			properties.put(name, new JsonSchema().setType(Type.integer));
+		}
+		return properties;
 	}
 
 	/**

--- a/integration-test/src/test/java/org/sagebionetworks/ITRecordSetTest.java
+++ b/integration-test/src/test/java/org/sagebionetworks/ITRecordSetTest.java
@@ -71,9 +71,6 @@ public class ITRecordSetTest {
 
 		csvFileHandle = synapse.multipartUpload(csvFile, null, false, true);
 
-		// A unique organization name per run so the test user always owns it (and thus has CREATE
-		// permission to register schemas under it), independent of prior runs. Each dot-separated
-		// segment must start with a letter, so the random suffix is prefixed with one.
 		organizationName = "it.recordset.s" + UUID.randomUUID().toString().replace("-", "");
 	}
 	

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/entity/RecordSetManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/entity/RecordSetManager.java
@@ -17,10 +17,12 @@ public interface RecordSetManager {
     public void validateRecordSet(RecordSet entity, EntityEvent event);
 
     /**
-     * Infers the column schema from the RecordSet's CSV (reconciled with any bound
-     * JSON Schema) and binds it both to this revision's immutable snapshot
-     * (T{id}_{v}) and to the entity-level default that unversioned queries read
-     * (T{id}). Finally, a message is sent to trigger rebuilding the index.
+     * Infers the column schema from the RecordSet's bound JSON Schema and
+     * binds it both to this revision's immutable snapshot (T{id}_{v}) and
+     * to the entity-level default that unversioned queries read (T{id}).
+     * Finally, a message is sent to trigger rebuilding the index.
+     * <p>
+     * If no bound JSON Schema is present, then the RecordSet will not be indexed.
      */
     public void inferSchemaAndBindToIndex(UserInfo userInfo, RecordSet entity);
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/entity/RecordSetManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/entity/RecordSetManagerImpl.java
@@ -6,8 +6,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import org.sagebionetworks.repo.manager.file.FileHandleManager;
-import org.sagebionetworks.repo.manager.grid.create.RecordSetCreateGridHandler;
 import org.sagebionetworks.repo.manager.table.ColumnModelManager;
 import org.sagebionetworks.repo.manager.table.RecordSetSchemaResolver;
 import org.sagebionetworks.repo.manager.table.TableManagerSupport;
@@ -16,10 +14,9 @@ import org.sagebionetworks.repo.model.RecordSet;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.dbo.schema.EntitySchemaValidationResultDao;
 import org.sagebionetworks.repo.model.entity.IdAndVersion;
-import org.sagebionetworks.repo.model.file.FileHandle;
 import org.sagebionetworks.repo.model.jdo.KeyFactory;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
 import org.sagebionetworks.repo.model.table.ColumnModel;
-import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
 import org.sagebionetworks.repo.service.metadata.EntityEvent;
 import org.sagebionetworks.repo.service.metadata.EventType;
 import org.sagebionetworks.repo.transactions.WriteTransaction;
@@ -29,23 +26,21 @@ import org.springframework.stereotype.Service;
 @Service
 public class RecordSetManagerImpl implements RecordSetManager {
 
-    private final FileHandleManager fileHandleManager;
-    private final RecordSetSchemaResolver schemaResolver;
     private final ColumnModelManager columnModelManager;
     private final NodeDAO nodeDao;
     private final TableManagerSupport tableManagerSupport;
     private final EntitySchemaValidationResultDao validationResultDao;
+    private final RecordSetSchemaResolver recordSetSchemaResolver;
 
     @Inject
-    public RecordSetManagerImpl(FileHandleManager fileHandleManager, RecordSetSchemaResolver schemaResolver,
-                                ColumnModelManager columnModelManager, NodeDAO nodeDao,
-                                TableManagerSupport tableManagerSupport, EntitySchemaValidationResultDao validationResultDao) {
-        this.fileHandleManager = fileHandleManager;
-        this.schemaResolver = schemaResolver;
+    public RecordSetManagerImpl(ColumnModelManager columnModelManager, NodeDAO nodeDao,
+                                TableManagerSupport tableManagerSupport, EntitySchemaValidationResultDao validationResultDao,
+                                RecordSetSchemaResolver recordSetSchemaResolver) {
         this.columnModelManager = columnModelManager;
         this.nodeDao = nodeDao;
         this.tableManagerSupport = tableManagerSupport;
         this.validationResultDao = validationResultDao;
+        this.recordSetSchemaResolver = recordSetSchemaResolver;
     }
 
     @Override
@@ -71,34 +66,29 @@ public class RecordSetManagerImpl implements RecordSetManager {
     @Override
     @WriteTransaction
     public void inferSchemaAndBindToIndex(UserInfo userInfo, RecordSet entity) {
-        FileHandle dataFileHandle = fileHandleManager.getRawFileHandleUnchecked(entity.getDataFileHandleId());
-        // RecordSet.csvDescriptor is optional, so fall back to the same default as the grid create flow
-        CsvTableDescriptor csvDescriptor = Optional.ofNullable(entity.getCsvDescriptor())
-                .orElse(RecordSetCreateGridHandler.DEFAULT_RECORD_SET_CSV_DESCRIPTOR);
+        // Only index RecordSets that have a bound JSON Schema. The columns are derived from the bound schema.
+        Optional<JsonSchema> jsonSchema = recordSetSchemaResolver.getBoundValidationSchema(entity.getId());
+        if (jsonSchema.isPresent()) {
+            List<ColumnModel> schema = RecordSetSchemaResolver.getJsonSchemaColumns(jsonSchema.get());
+            if (schema.isEmpty()) {
+                throw new IllegalArgumentException("Cannot determine the column model schema from the JSON Schema. At least one property must be present.");
+            }
 
-        // This step occurs within the same transaction as the entity update, so we avoid a full CSV scan.
-        // Because we are not scanning all rows, the inferred columns may be inaccurate. A bound JSON Schema
-        // can be used to 'reconcile' the column models and ensure the schema is correct.
-        boolean doFullCsvScan = false;
-        List<ColumnModel> schema = schemaResolver.getReconciledSchema(entity.getId(), dataFileHandle, csvDescriptor, doFullCsvScan).getSchema();
-        if (schema.isEmpty()) {
-            throw new IllegalArgumentException("Cannot determine the schema from the CSV file, at least one column header must be present.");
+            List<ColumnModel> persistedColumns = columnModelManager.createColumnModels(userInfo, schema);
+            List<String> columnIds = persistedColumns.stream().map(ColumnModel::getId).collect(Collectors.toList());
+
+            Long id = KeyFactory.stringToKey(entity.getId());
+            Long versionNumber = nodeDao.getCurrentRevisionNumber(KeyFactory.keyToString(id));
+            IdAndVersion versionedKey = IdAndVersion.newBuilder().setId(id).setVersion(versionNumber).build();
+            // Versioned binding preserves the schema for this specific snapshot.
+            columnModelManager.bindColumnsToVersionOfObject(columnIds, versionedKey);
+            // Default binding serves queries against "syn123" (no version). The provider
+            // always fires for the current revision, so this is always correct here.
+            columnModelManager.bindColumnsToDefaultVersionOfObject(columnIds, entity.getId());
+
+            // Finally, trigger rebuilding the index.
+            triggerIndexRebuild(entity);
         }
-
-        List<ColumnModel> persistedColumns = columnModelManager.createColumnModels(userInfo, schema);
-        List<String> columnIds = persistedColumns.stream().map(ColumnModel::getId).collect(Collectors.toList());
-
-        Long id = KeyFactory.stringToKey(entity.getId());
-        Long versionNumber = nodeDao.getCurrentRevisionNumber(KeyFactory.keyToString(id));
-        IdAndVersion versionedKey = IdAndVersion.newBuilder().setId(id).setVersion(versionNumber).build();
-        // Versioned binding preserves the schema for this specific snapshot.
-        columnModelManager.bindColumnsToVersionOfObject(columnIds, versionedKey);
-        // Default binding serves queries against "syn123" (no version). The provider
-        // always fires for the current revision, so this is always correct here.
-        columnModelManager.bindColumnsToDefaultVersionOfObject(columnIds, entity.getId());
-
-        // Finally, trigger rebuilding the index.
-        triggerIndexRebuild(entity);
     }
 
     void triggerIndexRebuild(RecordSet entity) {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/table/RecordSetSchemaResolver.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/table/RecordSetSchemaResolver.java
@@ -16,7 +16,9 @@ import org.sagebionetworks.repo.manager.grid.CsvSchemaReconciler;
 import org.sagebionetworks.repo.manager.schema.JsonSchemaManager;
 import org.sagebionetworks.repo.model.file.FileHandle;
 import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.repo.model.schema.Type;
 import org.sagebionetworks.repo.model.table.ColumnModel;
+import org.sagebionetworks.repo.model.table.ColumnType;
 import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
 import org.sagebionetworks.repo.model.table.UploadToTablePreviewRequest;
 import org.springframework.stereotype.Service;
@@ -107,6 +109,63 @@ public class RecordSetSchemaResolver {
 		return new ReconciledSchema(schema, requiredColumnIndices);
 	}
 
+
+	public static List<ColumnModel> getJsonSchemaColumns(JsonSchema validationSchema) {
+		if (validationSchema == null || validationSchema.getProperties() == null) {
+			return Collections.emptyList();
+		}
+		return validationSchema
+				.getProperties()
+				.entrySet()
+				.stream()
+				.map(e -> toColumnModel(e.getKey(), e.getValue()))
+				.toList();
+	}
+
+	/**
+	 * Map a single JSON Schema property to a {@link ColumnModel}. Scalar types map
+	 * to their column equivalents; length-constrained strings map to strings, arrays
+	 * map to a string list; objects, nulls, untyped properties and non-length-constrained
+	 * strings map to MEDIUMTEXT.
+	 *
+	 * @param name     the property (column) name
+	 * @param property the property's JSON Schema
+	 * @return a ColumnModel for the property
+	 */
+	static ColumnModel toColumnModel(String name, JsonSchema property) {
+		ColumnModel column = new ColumnModel().setName(name);
+
+		Type type = property == null ? null : property.getType();
+		if (type == null) {
+			return column.setColumnType(ColumnType.MEDIUMTEXT);
+		}
+		return switch (type) {
+			case integer -> column.setColumnType(ColumnType.INTEGER);
+			case number -> column.setColumnType(ColumnType.DOUBLE);
+			case _boolean -> column.setColumnType(ColumnType.BOOLEAN);
+			case array -> {
+				column = toColumnModel(name, property.getItems());
+				if (column.getColumnType().equals(ColumnType.STRING)) {
+					column.setColumnType(ColumnType.STRING_LIST);
+				} else if (column.getColumnType().equals(ColumnType.INTEGER)) {
+					column.setColumnType(ColumnType.INTEGER_LIST);
+				} else if (column.getColumnType().equals(ColumnType.BOOLEAN)) {
+					column.setColumnType(ColumnType.BOOLEAN_LIST);
+				} else {
+					column.setColumnType(ColumnType.MEDIUMTEXT);
+				}
+				yield column;
+			}
+			case string -> {
+				if (property.getMaxLength() != null) {
+					yield column.setColumnType(ColumnType.STRING).setMaximumSize(property.getMaxLength());
+				}
+				yield column.setColumnType(ColumnType.MEDIUMTEXT);
+			}
+			default -> column.setColumnType(ColumnType.MEDIUMTEXT);
+		};
+	}
+
 	List<ColumnModel> inferSchemaFromCsv(FileHandle fileHandle, CsvTableDescriptor csvDescriptor, boolean fullScan) {
 		try (CSVReader csvReader = csvFileHandleProvider.getCsvReader(fileHandle, csvDescriptor)) {
 			UploadToTablePreviewRequest request = new UploadToTablePreviewRequest()
@@ -123,7 +182,7 @@ public class RecordSetSchemaResolver {
 		}
 	}
 
-	Optional<JsonSchema> getBoundValidationSchema(String entityId) {
+	public Optional<JsonSchema> getBoundValidationSchema(String entityId) {
 		return entityManager.findBoundSchema(entityId)
 				.map(binding -> binding.getJsonSchemaVersionInfo().get$id())
 				.map(jsonSchemaManager::getValidationSchema);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/entity/RecordSetManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/entity/RecordSetManagerImplTest.java
@@ -3,14 +3,14 @@ package org.sagebionetworks.repo.manager.entity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +22,6 @@ import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.sagebionetworks.repo.manager.file.FileHandleManager;
 import org.sagebionetworks.repo.manager.table.ColumnModelManager;
 import org.sagebionetworks.repo.manager.table.RecordSetSchemaResolver;
 import org.sagebionetworks.repo.manager.table.TableManagerSupport;
@@ -31,20 +30,18 @@ import org.sagebionetworks.repo.model.RecordSet;
 import org.sagebionetworks.repo.model.UserInfo;
 import org.sagebionetworks.repo.model.dbo.schema.EntitySchemaValidationResultDao;
 import org.sagebionetworks.repo.model.entity.IdAndVersion;
-import org.sagebionetworks.repo.model.file.FileHandle;
-import org.sagebionetworks.repo.model.file.S3FileHandle;
 import org.sagebionetworks.repo.model.jdo.KeyFactory;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.repo.model.schema.Type;
 import org.sagebionetworks.repo.model.schema.ValidationSummaryStatistics;
 import org.sagebionetworks.repo.model.table.ColumnModel;
+import org.sagebionetworks.repo.model.table.ColumnType;
 import org.sagebionetworks.repo.model.table.CsvTableDescriptor;
 import org.sagebionetworks.repo.service.metadata.EntityEvent;
 import org.sagebionetworks.repo.service.metadata.EventType;
 
 @ExtendWith(MockitoExtension.class)
 public class RecordSetManagerImplTest {
-
-	@Mock
-	private FileHandleManager mockFileHandleManager;
 
 	@Mock
 	private RecordSetSchemaResolver mockSchemaResolver;
@@ -70,8 +67,8 @@ public class RecordSetManagerImplTest {
 	private RecordSet recordSet;
 	private UserInfo userInfo;
 
-	private FileHandle dataFileHandle;
-	private List<ColumnModel> inferredColumns;
+	private JsonSchema boundSchema;
+	private List<ColumnModel> schemaColumns;
 	private List<ColumnModel> persistedColumns;
 	private long newRevisionNumber = 3L;
 	private IdAndVersion versionedKey;
@@ -88,11 +85,18 @@ public class RecordSetManagerImplTest {
 
 		userInfo = new UserInfo(false, 55L);
 
-		dataFileHandle = new S3FileHandle().setId("456");
-		inferredColumns = List.of(new ColumnModel().setName("a"), new ColumnModel().setName("b"));
+		Map<String, JsonSchema> properties = new LinkedHashMap<>();
+		properties.put("a", new JsonSchema().setType(Type.integer));
+		properties.put("b", new JsonSchema().setType(Type._boolean));
+		boundSchema = new JsonSchema().setProperties(properties);
+
+		schemaColumns = List.of(
+			new ColumnModel().setName("a").setColumnType(ColumnType.INTEGER),
+			new ColumnModel().setName("b").setColumnType(ColumnType.BOOLEAN)
+		);
 		persistedColumns = List.of(
-			new ColumnModel().setId("11").setName("a"),
-			new ColumnModel().setId("22").setName("b")
+			new ColumnModel().setId("11").setName("a").setColumnType(ColumnType.INTEGER),
+			new ColumnModel().setId("22").setName("b").setColumnType(ColumnType.BOOLEAN)
 		);
 
 		// The revision number may not have been bumped in the RecordSet DTO, so the
@@ -106,10 +110,8 @@ public class RecordSetManagerImplTest {
 	 */
 	private void setupSchemaBinding() {
 		when(mockNodeDao.getCurrentRevisionNumber("syn123")).thenReturn(newRevisionNumber);
-		when(mockFileHandleManager.getRawFileHandleUnchecked("456")).thenReturn(dataFileHandle);
-		when(mockSchemaResolver.getReconciledSchema(eq("syn123"), eq(dataFileHandle),
-				any(CsvTableDescriptor.class), eq(false))).thenReturn(new RecordSetSchemaResolver.ReconciledSchema(inferredColumns, Collections.emptyList()));
-		when(mockColumnModelManager.createColumnModels(userInfo, inferredColumns)).thenReturn(persistedColumns);
+		when(mockSchemaResolver.getBoundValidationSchema("syn123")).thenReturn(Optional.of(boundSchema));
+		when(mockColumnModelManager.createColumnModels(userInfo, schemaColumns)).thenReturn(persistedColumns);
 	}
 
 	/**
@@ -117,7 +119,7 @@ public class RecordSetManagerImplTest {
 	 */
 	private void verifySchemaBound() {
 		List<String> expectedIds = List.of("11", "22");
-		verify(mockColumnModelManager).createColumnModels(userInfo, inferredColumns);
+		verify(mockColumnModelManager).createColumnModels(userInfo, schemaColumns);
 		verify(mockColumnModelManager).bindColumnsToVersionOfObject(expectedIds, versionedKey);
 		verify(mockColumnModelManager).bindColumnsToDefaultVersionOfObject(expectedIds, "syn123");
 	}
@@ -246,19 +248,31 @@ public class RecordSetManagerImplTest {
 
 	@Test
 	public void testInferSchemaAndBindToIndexWithEmptySchema() {
-		when(mockFileHandleManager.getRawFileHandleUnchecked("456")).thenReturn(dataFileHandle);
-		when(mockSchemaResolver.getReconciledSchema(eq("syn123"), eq(dataFileHandle),
-				any(CsvTableDescriptor.class), eq(false))).thenReturn(
-						new RecordSetSchemaResolver.ReconciledSchema(Collections.emptyList(), Collections.emptyList())
-		);
+		// A bound schema is present but declares no properties, so no columns can be derived.
+		when(mockSchemaResolver.getBoundValidationSchema("syn123")).thenReturn(Optional.of(new JsonSchema()));
 
 		String message = assertThrows(IllegalArgumentException.class, () -> {
 			// call under test
 			recordSetManager.inferSchemaAndBindToIndex(userInfo, recordSet);
 		}).getMessage();
 
-		assertEquals("Cannot determine the schema from the CSV file, at least one column header must be present.", message);
+		assertEquals("Cannot determine the column model schema from the JSON Schema. At least one property must be present.", message);
 
+		verifyNoInteractions(mockColumnModelManager);
+		verifyNoInteractions(mockNodeDao);
+		verifyNoInteractions(mockTableManagerSupport);
+	}
+
+	@Test
+	public void testInferSchemaAndBindToIndexWithNoBoundSchema() {
+		// With no bound JSON Schema the RecordSet is not indexed: the whole binding path is skipped.
+		when(mockSchemaResolver.getBoundValidationSchema("syn123")).thenReturn(Optional.empty());
+
+		// call under test
+		recordSetManager.inferSchemaAndBindToIndex(userInfo, recordSet);
+
+		verifyNoInteractions(mockColumnModelManager);
+		verifyNoInteractions(mockNodeDao);
 		verifyNoInteractions(mockTableManagerSupport);
 	}
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/table/RecordSetSchemaResolverTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/table/RecordSetSchemaResolverTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -166,5 +167,62 @@ public class RecordSetSchemaResolverTest {
 		resolver.getReconciledSchema(entityId, fileHandle, csvDescriptor, true);
 
 		verify(resolver).inferSchemaFromCsv(fileHandle, csvDescriptor, true);
+	}
+
+	@Test
+	public void testToColumnModel() {
+		assertEquals(ColumnType.INTEGER, RecordSetSchemaResolver.toColumnModel("i", new JsonSchema().setType(Type.integer)).getColumnType());
+		assertEquals(ColumnType.DOUBLE, RecordSetSchemaResolver.toColumnModel("n", new JsonSchema().setType(Type.number)).getColumnType());
+		assertEquals(ColumnType.BOOLEAN, RecordSetSchemaResolver.toColumnModel("b", new JsonSchema().setType(Type._boolean)).getColumnType());
+		// An unconstrained string maps to MEDIUMTEXT.
+		assertEquals(ColumnType.MEDIUMTEXT, RecordSetSchemaResolver.toColumnModel("s", new JsonSchema().setType(Type.string)).getColumnType());
+		// A length-constrained string maps to a sized STRING.
+		ColumnModel constrainedString = RecordSetSchemaResolver.toColumnModel("s", new JsonSchema().setType(Type.string).setMaxLength(50L));
+		assertEquals(ColumnType.STRING, constrainedString.getColumnType());
+		assertEquals(50L, constrainedString.getMaximumSize());
+		// An array with no declared items defaults to MEDIUMTEXT.
+		assertEquals(ColumnType.MEDIUMTEXT, RecordSetSchemaResolver.toColumnModel("arr", new JsonSchema().setType(Type.array)).getColumnType());
+		// Arrays map by their element type. A length-constrained string element resolves to STRING -> STRING_LIST.
+		assertEquals(ColumnType.STRING_LIST, RecordSetSchemaResolver.toColumnModel("arr",
+				new JsonSchema().setType(Type.array).setItems(new JsonSchema().setType(Type.string).setMaxLength(50L))).getColumnType());
+		assertEquals(ColumnType.INTEGER_LIST, RecordSetSchemaResolver.toColumnModel("arr",
+				new JsonSchema().setType(Type.array).setItems(new JsonSchema().setType(Type.integer))).getColumnType());
+		assertEquals(ColumnType.BOOLEAN_LIST, RecordSetSchemaResolver.toColumnModel("arr",
+				new JsonSchema().setType(Type.array).setItems(new JsonSchema().setType(Type._boolean))).getColumnType());
+		// An array whose element type has no list equivalent falls back to MEDIUMTEXT: an
+		// unconstrained string element (-> MEDIUMTEXT) and a number element (-> DOUBLE) both do so.
+		assertEquals(ColumnType.MEDIUMTEXT, RecordSetSchemaResolver.toColumnModel("arr",
+				new JsonSchema().setType(Type.array).setItems(new JsonSchema().setType(Type.string))).getColumnType());
+		assertEquals(ColumnType.MEDIUMTEXT, RecordSetSchemaResolver.toColumnModel("arr",
+				new JsonSchema().setType(Type.array).setItems(new JsonSchema().setType(Type.number))).getColumnType());
+		assertEquals(ColumnType.MEDIUMTEXT, RecordSetSchemaResolver.toColumnModel("untyped", new JsonSchema()).getColumnType());
+	}
+
+	@Test
+	public void testGetJsonSchemaColumns() {
+		// A LinkedHashMap preserves insertion order so the derived columns are deterministic.
+		Map<String, JsonSchema> properties = new LinkedHashMap<>();
+		properties.put("a", new JsonSchema().setType(Type.integer));
+		properties.put("b", new JsonSchema().setType(Type._boolean));
+		JsonSchema validationSchema = new JsonSchema().setProperties(properties);
+
+		// call under test
+		List<ColumnModel> columns = RecordSetSchemaResolver.getJsonSchemaColumns(validationSchema);
+
+		assertEquals(List.of(
+				new ColumnModel().setName("a").setColumnType(ColumnType.INTEGER),
+				new ColumnModel().setName("b").setColumnType(ColumnType.BOOLEAN)), columns);
+	}
+
+	@Test
+	public void testGetJsonSchemaColumnsWithNullSchema() {
+		// call under test
+		assertTrue(RecordSetSchemaResolver.getJsonSchemaColumns(null).isEmpty());
+	}
+
+	@Test
+	public void testGetJsonSchemaColumnsWithNullProperties() {
+		// call under test
+		assertTrue(RecordSetSchemaResolver.getJsonSchemaColumns(new JsonSchema()).isEmpty());
 	}
 }

--- a/services/workers/src/test/java/org/sagebionetworks/recordset/worker/RecordSetIndexWorkerIntegrationTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/recordset/worker/RecordSetIndexWorkerIntegrationTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -16,11 +18,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.sagebionetworks.AsynchronousJobWorkerHelper;
 import org.sagebionetworks.repo.manager.UserManager;
 import org.sagebionetworks.repo.manager.file.FileHandleManager;
+import org.sagebionetworks.repo.manager.schema.JsonSchemaManager;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
 import org.sagebionetworks.repo.model.Project;
 import org.sagebionetworks.repo.model.RecordSet;
 import org.sagebionetworks.repo.model.UserInfo;
+import org.sagebionetworks.repo.model.entity.BindSchemaToEntityRequest;
 import org.sagebionetworks.repo.model.file.S3FileHandle;
+import org.sagebionetworks.repo.model.schema.CreateSchemaRequest;
+import org.sagebionetworks.repo.model.schema.JsonSchema;
+import org.sagebionetworks.repo.model.schema.Organization;
+import org.sagebionetworks.repo.model.schema.Type;
 import org.sagebionetworks.repo.model.table.ColumnModel;
 import org.sagebionetworks.repo.model.table.ColumnType;
 import org.sagebionetworks.repo.model.table.MaterializedView;
@@ -38,16 +46,25 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * explicit-version queries against per-version snapshots, and a materialized
  * view defined over a RecordSet.
  * <p>
+ * A RecordSet is only indexed when it has a bound JSON Schema; the column
+ * schema bound to the index is derived from that JSON Schema (not inferred from
+ * the CSV). Because the RecordSetMetadataProvider fires on create/update before
+ * a schema can be bound to the freshly-created entity, the flow is:
+ * create -> bind schema -> update. The update re-fires the provider with the
+ * schema now bound, which binds the column schema and emits the change message
+ * that drives the real RecordSetIndexWorker to build the index.
+ * <p>
  * RecordSets MUST be created/updated through {@link EntityService} (not
  * {@link org.sagebionetworks.repo.manager.EntityManager}) so the
- * RecordSetMetadataProvider fires and binds the column schema; the change
- * message it emits drives the real RecordSetIndexWorker to build the index.
+ * RecordSetMetadataProvider fires.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
 public class RecordSetIndexWorkerIntegrationTest {
 
 	public static final long MAX_WAIT_MS = 1000L * 60 * 2;
+
+	private static final String ORGANIZATION_NAME = "RecordSetIndexWorkerITorg";
 
 	@Autowired
 	private EntityService entityService;
@@ -57,6 +74,9 @@ public class RecordSetIndexWorkerIntegrationTest {
 
 	@Autowired
 	private FileHandleManager fileHandleManager;
+
+	@Autowired
+	private JsonSchemaManager jsonSchemaManager;
 
 	@Autowired
 	private AsynchronousJobWorkerHelper asyncHelper;
@@ -81,8 +101,8 @@ public class RecordSetIndexWorkerIntegrationTest {
 
 	@Test
 	public void testQueryRecordSet() throws Exception {
-		// v1 — three integer columns.
-		RecordSet recordSet = createRecordSet(uploadCsv("a,b,c\n1,2,3\n4,5,6\n"));
+		// Three integer columns, all declared by the bound JSON Schema.
+		RecordSet recordSet = createRecordSet(uploadCsv("a,b,c\n1,2,3\n4,5,6\n"), integerProperties("a", "b", "c"));
 
 		queryAndAssertRows("select * from " + recordSet.getId() + " order by ROW_ID",
 				List.of(List.of("1", "2", "3"), List.of("4", "5", "6")));
@@ -90,16 +110,23 @@ public class RecordSetIndexWorkerIntegrationTest {
 
 	@Test
 	public void testQueryRecordSetWithSchemaChangingUpdate() throws Exception {
-		// v1 — column "c" is purely numeric, so it is inferred as INTEGER.
-		RecordSet recordSet = createRecordSet(uploadCsv("a,b,c\n1,2,3\n4,5,6\n"));
+		// v1 — the bound schema declares all three columns as INTEGER.
+		RecordSet recordSet = createRecordSet(uploadCsv("a,b,c\n1,2,3\n4,5,6\n"), integerProperties("a", "b", "c"));
 		long v1 = recordSet.getVersionNumber();
 
 		// The v1 index is INTEGER for all three columns.
 		queryAndAssertColumnTypes(recordSet.getId(),
 				List.of(ColumnType.INTEGER, ColumnType.INTEGER, ColumnType.INTEGER));
 
-		// v2 — column "c" now contains a non-numeric value, so the inferred schema
-		// changes "c" to STRING. Routed through EntityService so the provider rebinds.
+		// v2 — rebind a schema where "c" is now a (length-constrained) STRING, then update
+		// with non-numeric data for "c" as a new version. Routed through EntityService so the
+		// provider rebinds the column schema from the newly-bound JSON Schema.
+		Map<String, JsonSchema> v2Properties = new LinkedHashMap<>();
+		v2Properties.put("a", new JsonSchema().setType(Type.integer));
+		v2Properties.put("b", new JsonSchema().setType(Type.integer));
+		v2Properties.put("c", new JsonSchema().setType(Type.string).setMaxLength(50L));
+		bindSchema(recordSet.getId(), v2Properties);
+
 		recordSet.setDataFileHandleId(uploadCsv("a,b,c\n7,8,nine\n10,11,twelve\n"));
 		recordSet.setVersionLabel("v2");
 		recordSet = entityService.updateEntity(adminUserInfo.getId(), recordSet, true, null);
@@ -125,10 +152,10 @@ public class RecordSetIndexWorkerIntegrationTest {
 	@Test
 	public void testQueryRecordSetByExplicitVersion() throws Exception {
 		// v1
-		RecordSet recordSet = createRecordSet(uploadCsv("a,b,c\n1,2,3\n4,5,6\n"));
+		RecordSet recordSet = createRecordSet(uploadCsv("a,b,c\n1,2,3\n4,5,6\n"), integerProperties("a", "b", "c"));
 		long v1 = recordSet.getVersionNumber();
 
-		// v2 — different data, same schema shape.
+		// v2 — different data, same schema shape. The schema bound at v1 is reused.
 		recordSet.setDataFileHandleId(uploadCsv("a,b,c\n7,8,9\n10,11,12\n"));
 		recordSet.setVersionLabel("v2");
 		recordSet = entityService.updateEntity(adminUserInfo.getId(), recordSet, true, null);
@@ -146,7 +173,7 @@ public class RecordSetIndexWorkerIntegrationTest {
 
 	@Test
 	public void testQueryRecordSetThroughMaterializedView() throws Exception {
-		RecordSet recordSet = createRecordSet(uploadCsv("a,b,c\n1,2,3\n4,5,6\n"));
+		RecordSet recordSet = createRecordSet(uploadCsv("a,b,c\n1,2,3\n4,5,6\n"), integerProperties("a", "b", "c"));
 
 		// Wait for the RecordSet index so the MV build sees rows to copy.
 		queryAndAssertRows("select * from " + recordSet.getId() + " order by ROW_ID",
@@ -169,13 +196,52 @@ public class RecordSetIndexWorkerIntegrationTest {
 		return fileHandle.getId();
 	}
 
-	private RecordSet createRecordSet(String dataFileHandleId) {
+	/**
+	 * Builds an ordered properties map (column order is preserved by the index) where every
+	 * named property is declared as an INTEGER.
+	 */
+	private static Map<String, JsonSchema> integerProperties(String... names) {
+		Map<String, JsonSchema> properties = new LinkedHashMap<>();
+		for (String name : names) {
+			properties.put(name, new JsonSchema().setType(Type.integer));
+		}
+		return properties;
+	}
+
+	/**
+	 * Registers a new JSON Schema with the given properties and binds it to the entity. A unique
+	 * schema name is used per call so repeated binds (e.g. a schema-changing update) don't collide.
+	 */
+	private void bindSchema(String entityId, Map<String, JsonSchema> properties) {
+		Organization organization = asyncHelper.getOrCreateOrganization(adminUserInfo.getId(), ORGANIZATION_NAME);
+		String schemaName = "s" + UUID.randomUUID().toString().replace("-", "");
+		JsonSchema schema = new JsonSchema()
+				.set$id(organization.getName() + "-" + schemaName)
+				.setProperties(properties);
+		String schema$id = jsonSchemaManager.createJsonSchema(adminUserInfo, new CreateSchemaRequest().setSchema(schema))
+				.getNewVersionInfo().get$id();
+		entityService.bindSchemaToEntity(adminUserInfo.getId(),
+				new BindSchemaToEntityRequest().setEntityId(entityId).setSchema$id(schema$id));
+	}
+
+	/**
+	 * Creates a RecordSet and binds a JSON Schema to it so the index is built. The metadata
+	 * provider fires on create before a schema can be bound (no index yet), so we bind the schema
+	 * and then update to re-fire the provider with the schema present, which builds the v1 index.
+	 */
+	private RecordSet createRecordSet(String dataFileHandleId, Map<String, JsonSchema> properties) {
 		RecordSet rs = new RecordSet()
 				.setName(UUID.randomUUID().toString())
 				.setUpsertKey(List.of("a"));
 		rs.setParentId(project.getId());
 		rs.setDataFileHandleId(dataFileHandleId);
-		return entityService.createEntity(adminUserInfo.getId(), rs, null);
+		rs = entityService.createEntity(adminUserInfo.getId(), rs, null);
+
+		bindSchema(rs.getId(), properties);
+
+		// Re-fire the provider now that a schema is bound so the (v1) index is built.
+		rs.setVersionLabel("v1");
+		return entityService.updateEntity(adminUserInfo.getId(), rs, false, null);
 	}
 
 	/**


### PR DESCRIPTION
Only index RecordSets that have a bound JSON Schema. Remove CSV scanning logic.