### PR TITLE
PLFM-6950

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/config/ManagerConfiguration.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/config/ManagerConfiguration.java
@@ -285,10 +285,11 @@ public class ManagerConfiguration {
 	@Bean
 	public Map<OAuthProvider, OAuthProviderBinding> oauthProvidersBindingMap(StackConfiguration config,
 			SimpleHttpClient client) {
-		return Map.of(OAuthProvider.GOOGLE_OAUTH_2_0, googleOAuthProvider(config, client), 
+		return Map.of(OAuthProvider.GOOGLE_OAUTH_2_0, googleOAuthProvider(config, client),
 				OAuthProvider.ORCID, orcidOAuthProvider(config, client),
 				OAuthProvider.ARCUS_BIOSCIENCES, arcusBioOAuthProvider(config, client),
-				OAuthProvider.SAGE_BIONETWORKS, sageBioOAuthProvider(config, client)
+				OAuthProvider.SAGE_BIONETWORKS, sageBioOAuthProvider(config, client),
+				OAuthProvider.NIH_RESEARCHER_AUTH_SERVICE, nihRASOAuthProvider(config, client)
 				);
 	}
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/oauth/OAuthManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/oauth/OAuthManagerImpl.java
@@ -1,7 +1,9 @@
 package org.sagebionetworks.repo.manager.oauth;
 
 import java.net.URISyntaxException;
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
@@ -25,6 +27,11 @@ public class OAuthManagerImpl implements OAuthManager {
 	private Map<OAuthProvider, OAuthProviderBinding> oauthProvidersBindingMap;
 	
 	public OAuthManagerImpl(Map<OAuthProvider, OAuthProviderBinding> oauthProvidersBindingMap) {
+		Set<OAuthProvider> missing = EnumSet.allOf(OAuthProvider.class);
+		missing.removeAll(oauthProvidersBindingMap.keySet());
+		if (!missing.isEmpty()) {
+			throw new IllegalStateException("Missing OAuthProviderBinding for: " + missing);
+		}
 		this.oauthProvidersBindingMap = oauthProvidersBindingMap;
 	}
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/oauth/OAuthManagerImplUnitTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/oauth/OAuthManagerImplUnitTest.java
@@ -1,16 +1,19 @@
 package org.sagebionetworks.repo.manager.oauth;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.repo.model.oauth.OAuthProvider;
@@ -18,21 +21,28 @@ import org.sagebionetworks.repo.model.principal.AliasType;
 
 @ExtendWith(MockitoExtension.class)
 public class OAuthManagerImplUnitTest {
-	
-	@Mock
-	private Map<OAuthProvider, OAuthProviderBinding> mockProviderMap;
-	@InjectMocks
-	private OAuthManagerImpl oauthManager;
-	
+
 	@Mock
 	private OAuthProviderBinding mockProvider;
-	
+
+	private OAuthManagerImpl oauthManager;
+
 	private OAuthProvider PROVIDER_ENUM = OAuthProvider.ORCID;
-	
 
 	@BeforeEach
 	public void before() throws Exception {
-		when(mockProviderMap.get(any())).thenReturn(mockProvider);
+		Map<OAuthProvider, OAuthProviderBinding> providerMap = Arrays.stream(OAuthProvider.values())
+				.collect(Collectors.toMap(p -> p, p -> mockProvider));
+		oauthManager = new OAuthManagerImpl(providerMap);
+	}
+
+	@Test
+	public void testConstructorWithMissingProvider() {
+		Map<OAuthProvider, OAuthProviderBinding> incompleteMap = new HashMap<>();
+		incompleteMap.put(OAuthProvider.GOOGLE_OAUTH_2_0, mockProvider);
+
+		// call under test
+		assertThrows(IllegalStateException.class, () -> new OAuthManagerImpl(incompleteMap));
 	}
 
 	@Test
@@ -43,7 +53,6 @@ public class OAuthManagerImplUnitTest {
 		assertEquals(expected, oauthManager.getAuthorizationUrl(PROVIDER_ENUM, redirUrl, null));
 	}
 
-	
 	@Test
 	public void testGetAuthorizationUrlWithState() {
 		String redirUrl = "redirectUrl";
@@ -54,7 +63,6 @@ public class OAuthManagerImplUnitTest {
 		assertEquals(expected, oauthManager.getAuthorizationUrl(PROVIDER_ENUM, redirUrl, state));
 	}
 
-	
 	@Test
 	public void testValidateUserWithProvider() {
 		String authCode = "xxx";
@@ -65,7 +73,6 @@ public class OAuthManagerImplUnitTest {
 		assertEquals(expected, oauthManager.validateUserWithProvider(PROVIDER_ENUM, authCode, redirUrl));
 	}
 
-	
 	@Test
 	public void testRetrieveProvidersId() {
 		String authCode = "xxx";


### PR DESCRIPTION
In the previous PR we neglected to add the NIH_RESEARCHER_AUTH_SERVICE provider to the list of registered providers in a Spring bean definition.  This PR (1) fixes the mistake, (2) adds a check to the OAuthManagerImpl constructor that all providers are added, and (3) adds a test that the check works properly.  This will ensure that we don't make the same mistake in the future.