### PR TITLE
Evolve CLAUDE.md files + document previously-uncovered modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ Backend platform for Sage Bionetworks' Synapse — a collaborative research data
 - **MySQL 8.x** via Spring JdbcTemplate (no ORM, no Spring Data)
 - **Tomcat 10x** (WAR deployment)
 - **Jackson 2.20.0**, Log4j 2, Guava 30.1.1
-- **AWS SDK v1** (1.12.x) + **AWS SDK v2** (2.29.x), Google Cloud Storage
+- **AWS SDK v1** (1.12.x) + **AWS SDK v2** (2.40.x), Google Cloud Storage — v1 is being phased out client-by-client for v2 (see `lib/stackConfiguration` `AwsClientFactory` → `AwsClientFactoryV2`)
+- **Spring AI** (`spring-ai-bom`, `spring-ai-agentcore-bom`) — Bedrock Converse `ChatModel` + AgentCore code-interpreter for the AI agent feature (wired in `SpringAiConfiguration`)
 - **No Lombok**
 
 ## Build Commands
@@ -45,6 +46,8 @@ platform (root)
 │   ├── lib-worker/               # Worker framework
 │   ├── lib-grid/                 # JSON-Joy CRDT model objects (CBOR encoding)
 │   ├── lib-grid-db/              # Grid CRDT relational database persistence
+│   ├── lib-database-configuration/ # DataSource/JdbcTemplate beans + @WriteTransaction annotations
+│   ├── lib-docusign/             # DocuSign e-signature integration
 │   └── ...                       # id-generator, database-semaphore, lib-upload, etc.
 ├── services/
 │   ├── repository-managers/      # Business logic (Manager interfaces + impls)
@@ -67,7 +70,7 @@ platform (root)
 - Package: `org.sagebionetworks.repo.manager`
 - Interface + Impl pattern (e.g., `EntityManager` / `EntityManagerImpl`)
 - `@Service` on implementations, constructor injection preferred
-- `@WriteTransaction` for write operations (from `org.sagebionetworks.repo.transactions`)
+- `@WriteTransaction` for write operations (`org.sagebionetworks.repo.transactions`, defined in the `lib-database-configuration` module)
 - Also: `@MandatoryWriteTransaction`, `@NewWriteTransaction`
 - Input validation: `ValidateArgument.required(value, "fieldName")`
 
@@ -86,7 +89,7 @@ platform (root)
 
 ## Testing
 
-- Unit tests: `*Test.java` — JUnit 5 + Mockito 2.27
+- Unit tests: `*Test.java` — JUnit 5 + Mockito 5.x
   - `@ExtendWith(MockitoExtension.class)`, `@Mock`, `@InjectMocks`
 - Integration tests: `IT*.java` (in integration-test module)
 - **Mockito 5.x** — strict stubbing is enabled by default
@@ -140,7 +143,8 @@ Key classes:
 When creating new database tables, the DBO must implement `MigratableDatabaseObject<D, B>`:
 - Provide a `MigrationType` (order matters — must come after dependencies)
 - Provide a `MigratableTableTranslation` for backup/restore conversion
-- Register primary types in `lib/jdomodels/src/main/resources/dbo-beans.spb.xml` (order matters)
+- Register primary types by placing the DBO in a package scanned by `DboAutoDiscovery` (`lib/jdomodels/.../repo/model/config/`) and annotating the DAO `@Repository` — the old `dbo-beans.spb.xml` was removed. If the package is not in `DboAutoDiscovery.DBO_PACKAGES`, the type is silently never discovered or migrated.
+- DDL creation order is derived automatically by `DboDependencyAnalyzer` (parses `FOREIGN KEY ... REFERENCES` from each DDL) — no manual ordering
 - Secondary types are discovered automatically via `getSecondaryTypes()`
 - Primary tables need an etag column (NOT NULL) for change detection; secondary tables need a foreign key to their owner's backup ID
 - Key test: `MigratableTableDAOImplAutowireTest.testAllMigrationTypesRegistered()` (`lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/migration/MigratableTableDAOImplAutowireTest.java`) — validates all `MigrationType` values have registered DBOs
@@ -194,8 +198,8 @@ See `services/repository-managers/CLAUDE.md` and `lib/lib-grid/CLAUDE.md` for th
 1. **Java 21 LTS** — Java 21 language features are now available (records, text blocks, pattern matching, sealed classes, virtual threads)
 2. **jakarta namespace** — migrated from javax.* for Spring 6 compatibility
 3. **Spring 6.1** — no Spring Boot APIs
-4. **Mockito 2.27** — no mockStatic, no Mockito 4/5 features
+4. **Mockito 5.x** — strict stubbing enabled by default (no lenient stubbing; fix argument matchers instead)
 5. **No Lombok**
 6. **No Spring Data** — all DB via JdbcTemplate
 7. **WAR packaging** — not executable JARs
-8. **Migration-safe schema changes** — new DBO tables must implement `MigratableDatabaseObject` and be registered in `dbo-beans.spb.xml`; data moves between tables require a two-stack mirroring/backfill rollout
+8. **Migration-safe schema changes** — new DBO tables must implement `MigratableDatabaseObject` and live in a package scanned by `DboAutoDiscovery`; data moves between tables require a two-stack mirroring/backfill rollout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ Key classes:
 When creating new database tables, the DBO must implement `MigratableDatabaseObject<D, B>`:
 - Provide a `MigrationType` (order matters — must come after dependencies)
 - Provide a `MigratableTableTranslation` for backup/restore conversion
-- Register primary types by placing the DBO in a package scanned by `DboAutoDiscovery` (`lib/jdomodels/.../repo/model/config/`) and annotating the DAO `@Repository` — the old `dbo-beans.spb.xml` was removed. If the package is not in `DboAutoDiscovery.DBO_PACKAGES`, the type is silently never discovered or migrated.
+- Primary types are discovered by `DboAutoDiscovery` classpath scan — place the DBO under an existing `org.sagebionetworks.repo.model.dbo.*` persistence package (follow the standard package pattern rather than inventing a new package name) and annotate the DAO `@Repository`. Only packages listed in `DboAutoDiscovery.DBO_PACKAGES` are scanned, so a DBO in a new/creative package is silently never discovered or migrated.
 - DDL creation order is derived automatically by `DboDependencyAnalyzer` (parses `FOREIGN KEY ... REFERENCES` from each DDL) — no manual ordering
 - Secondary types are discovered automatically via `getSecondaryTypes()`
 - Primary tables need an etag column (NOT NULL) for change detection; secondary tables need a foreign key to their owner's backup ID

--- a/client/synapseJavaClient/CLAUDE.md
+++ b/client/synapseJavaClient/CLAUDE.md
@@ -1,0 +1,51 @@
+# client/synapseJavaClient
+
+The Java REST client SDK for the Synapse platform. Consumed by `integration-test/` and external callers. Source under `src/main/java/org/sagebionetworks/client/`.
+
+## Class hierarchy
+
+Each impl extends the one above; add methods at the layer that matches their scope:
+
+- `BaseClient` / `BaseClientImpl` — auth, endpoints, and the low-level HTTP transport. All the `*JSONEntity` / `getJson` / download / upload helper methods live in `BaseClientImpl`. New transport helpers go here.
+- `SynapseClient` / `SynapseClientImpl` — the public repo/file API surface and all URL path constants.
+- `SynapseAdminClient` / `SynapseAdminClientImpl` — admin-only ops (migration, stack status, change messages, features).
+
+Support types: `ClientUtils` (URL building + status→exception mapping), `Method` enum, `RestEndpointType` enum (`repo`, `file`, `auth` — **no `drs`**), `AsynchJobType` (async registry). The wire is touched only by the separate `client/simpleHttpClient` module (`SimpleHttpClient`); go through `BaseClientImpl` helpers, never call it directly from `SynapseClientImpl`.
+
+## Adding an endpoint method
+
+Two-file change (admin variants go in the admin client/impl instead):
+
+1. Add the signature + Javadoc to the `SynapseClient` interface, `throws SynapseException`.
+2. Add the `@Override` impl to `SynapseClientImpl`, and add the URL as a `private static final String` constant near the others (constants are often composed, e.g. `SUBMISSION_BUNDLE = SUBMISSION + BUNDLE`). Guard args with `ValidateArgument.required(x, "x")`.
+
+The impl body is almost always a one-liner delegating to a `BaseClientImpl` helper, chosen by verb + body shape. Every helper takes `(endpoint, uri, ...)` where `endpoint` is `getRepoEndpoint()` / `getFileEndpoint()` / `getAuthEndpoint()` / `getDrsEndpoint()`:
+
+- `getJSONEntity(endpoint, uri, Type.class)` — GET returning a POJO
+- `postJSONEntity` / `putJSONEntity(endpoint, uri, body, Type.class)` — POST/PUT with body → POJO
+- `voidPost` / `voidPut` — POST/PUT with no response body
+- `deleteUri` / `putUri` — DELETE / bodyless PUT
+- `getPaginatedResults(endpoint, uri, Type.class)` → `PaginatedResults<T>`
+- `getListOfJSONEntity`, `getBooleanResult`, `getStringDirect`, `getUrl` (follows a redirect → pre-signed URL)
+
+Serialization is automatic via `EntityFactory` — request POJOs implement `JSONEntity` and are imported from `org.sagebionetworks.repo.model.*` (auto-generated in `lib-auto-generated`; do NOT create them here). Never hand-write JSON.
+
+## Async job endpoints
+
+1. Add an `AsynchJobType` enum entry: `MyJob("/my/path", MyResponse.class, RestEndpointType.repo)` (response extends `AsynchronousResponseBody`). If the request `HasEntityId`, the URL is auto-prefixed with `/entity/{id}`.
+2. Add a `String startXxx(req)` calling `startAsynchJob(type, req)` (returns a token) and a `MyResponse getXxxResults(token)` casting `getAsyncResult(type, token, ...)`. Polling primitive `getAsynchJobResponse` throws `SynapseResultNotReadyException` (HTTP 202) until ready; callers loop.
+
+## Errors and retry
+
+- Status→exception mapping is centralized in `ClientUtils.throwException(status, reason)`: 401→Unauthorized, 403→Forbidden, 404→NotFound, 400→BadRequest, 423→Locked, 412→ConflictingUpdate, 410→Deprecated, 429→TooManyRequests, else→`UnknownSynapseServerException`. To add a mapping, add the branch here + a subclass under `client/exceptions/` extending `SynapseServerException`.
+- **Retry is automatic** in `BaseClientImpl.performRequestWithRetry` (503, 429, `SocketTimeoutException`, up to 5× with exponential backoff). Do NOT add ad-hoc retry loops.
+
+## Gotchas
+
+- **Pick the right base endpoint.** File/bulk-download → `getFileEndpoint()`, auth → `getAuthEndpoint()`, DRS → `getDrsEndpoint()`, else `getRepoEndpoint()`. The `AsynchJobType`'s `RestEndpointType` must match or the async call hits the wrong host.
+- **DRS quirk**: `RestEndpointType` has no `drs` case (`getEndpointForType` throws on it) — DRS methods call `getJSONEntity(getDrsEndpoint(), ...)` directly and cannot use the async machinery.
+- **Prefer POST-with-request-body over long query strings** for list/paginated endpoints (the codebase is moving to request-body pagination with an opaque `nextPageToken`; see the `listEDucTemplates` refactor). If the request POJO has a `nextPageToken` field, don't also append it as a query param.
+- **Reuse existing `V2` path constants** rather than inventing new strings for versioned resources.
+- **Never build multipart/file transfer by hand** — use `downloadFromSynapse` / `getUrl` / `putFileToURL` / the `MultipartUpload` + `upload/*` classes.
+
+Exemplars: `startSearchIndexQuery`/`getSearchIndexQueryResults` (async start/poll pair), `listEDucTemplates` (`postJSONEntity(getRepoEndpoint(), EDUC_TEMPLATE, request, EDucTemplatePage.class)`).

--- a/integration-test/CLAUDE.md
+++ b/integration-test/CLAUDE.md
@@ -1,0 +1,45 @@
+# integration-test
+
+End-to-end tests that exercise the real HTTP API through the Synapse Java client against a running Tomcat with both WARs deployed. This is where controller wiring is verified (deep logic is covered by manager unit tests). Module has no production code (`src/main` is a placeholder); all tests live flat under `src/test/java/org/sagebionetworks/`.
+
+## Running
+
+- **`mvn verify`** (from this module, or `mvn verify -pl integration-test` from root) runs the ITs.
+- ITs are `IT*.java`, run by the **maven-failsafe** plugin in the `verify` lifecycle. **`mvn test` does NOT run them** — surefire explicitly excludes `IT*.java`.
+- The server is a real **Tomcat 10** started by the **cargo** plugin (NOT an in-process embedded server) at `pre-integration-test`, stopped at `post-integration-test`. It deploys both `services-repository` and `services-workers` WARs. Cargo passes ~40 `org.sagebionetworks.*` system properties (stack/instance, AWS creds, DB URLs, table-cluster endpoints, etc.) into the container — a properly configured dev stack must supply these or dependent tests fail/skip. ITs are **not hermetic**.
+- **Debug against a running server**: set `-Dorg.sagebionetworks.integration.debug=true` so cargo starts the WARs and waits, letting you run individual ITs from an IDE.
+
+## Test structure
+
+- Naming: new tests are `IT<Feature>Test` / `IT<Feature>ControllerTest`; legacy numbered names (`IT500SynapseJavaClient`) coexist.
+- Non-`IT*` classes in the package are **shared helpers, not tests**: `SynapseClientHelper`, `AsyncJobHelper`, `OAuthHelper`, `AccessRequirementUtil`, `EmailValidationUtil`, `ITTestExtension`.
+- Fixtures live in `src/test/resources/` (`docs/`, `images/`, `SmallTextFiles/`, ...), loaded via the classloader (note the `.replaceAll("%20", " ")` workaround for spaces in resource paths).
+
+## Clients and users — use the extension, don't hand-roll
+
+Annotate the class `@ExtendWith(ITTestExtension.class)`. The extension injects by **type** into constructor / `@BeforeAll` / `@BeforeEach` / `@Test` params:
+
+- `SynapseAdminClient` — admin client.
+- `SynapseClient` — a client for a freshly created, auto-**certified** test user (created lazily).
+- `StackConfiguration`, `WarehouseTestHelper`, `AmazonS3`.
+
+The extension bootstraps the admin (basic-auth → bearer token, **ensures admin 2FA is enabled**, then `clearAllLocks()`) in `beforeAll` and **auto-deletes the extension's test user** in `afterAll`. `SynapseClientHelper.createUser(admin, client)` creates additional users (random UUID identity, marked certified).
+
+- **Extra users you create yourself must be torn down yourself** — static `SynapseClient` + `Long userToDelete`, created in `@BeforeAll`, deleted in `@AfterAll` inside try/catch (see `ITGridControllerTest`).
+- **Entity cleanup is manual**: keep a `List<Entity> entitiesToDelete`, populate on create, delete each in `@AfterEach`.
+- Call `adminSynapse.clearAllLocks()` in `@BeforeEach` if your feature acquires semaphore locks (tables, migration, async) — leftover locks are the top source of cross-test flakiness. Tests that mutate stack status must reset it to `READ_WRITE` in both `@BeforeEach` and `@AfterEach`.
+
+## Calling the service
+
+- All HTTP goes through `SynapseClient`/`SynapseClientImpl` (user) or `SynapseAdminClient`/`SynapseAdminClientImpl` (admin) from the `synapseJavaClient` dependency. Every new controller endpoint needs a client method + an IT that exercises it.
+- For endpoints intentionally absent from the Java client, use raw `SimpleHttpClient` against `synapse.getRepoEndpoint()` (see `ITUnsupportedMethodTest`, the only class not using the extension).
+
+## Gotchas
+
+- **Async jobs — always poll, never assume immediate results.** Use `AsyncJobHelper.assertAysncJobResult(client, AsynchJobType, request, assertions, timeoutMs, maxRetries)` (note the sic spelling `Aysnc`). It polls with backoff, swallows `SynapseResultNotReadyException`, and re-submits up to `maxRetries`; use `AsyncJobHelper.INFINITE_RETRIES` for eventual-consistency-heavy jobs (grid, tables). `assertQueryBundleResults(...)` is the table-query convenience.
+- **Eventual consistency**: previews, search indexing, DOI, and message delivery are async — never assert on them synchronously after the create call. Poll with `TimeUtils.waitFor(...)` or the `waitForPreviewToBeCreated`/`waitForQuery`/`waitForMessage` helpers.
+- **WebSocket/grid**: `AsyncJobHelper.createConnection(presignedUrl, queue)` opens a client pushing messages onto a `BlockingQueue`; `waitForMessage(...)` polls with a 10s timeout.
+- **Ordering**: failsafe runs classes alphabetically — never rely on cross-class ordering.
+- **Hand-built clients must be certified** — a `SynapseClientImpl` you construct directly must be marked certified or entity/upload calls fail (the extension/`createUser` users already are).
+
+Exemplars to copy: `ITGridControllerTest` (full lifecycle: injection, second user, async `INFINITE_RETRIES`, WebSocket, ACL grant), `IT101Administration` (admin + stack status + `clearAllLocks`), `ITUnsupportedMethodTest` (raw HTTP, no extension).

--- a/lib/jdomodels/CLAUDE.md
+++ b/lib/jdomodels/CLAUDE.md
@@ -102,7 +102,7 @@ Naming: `TABLE_` prefix for table names, `COL_` for columns, `DDL_` for DDL path
 
 ## Spring Configuration
 
-DBO registration is **classpath auto-discovery** via Java config in `src/main/java/org/sagebionetworks/repo/model/config/` — there are no `*-spb.xml` files in this module anymore.
+DBO registration is **classpath auto-discovery** via Java config in `src/main/java/org/sagebionetworks/repo/model/config/`.
 
 - **`JdoModelsConfig`** — `@Configuration`/`@ComponentScan` entry point; also bootstraps principal IDs (**do not change those IDs** — they are real production objects).
 - **`DboAutoDiscovery`** — classpath-scans the fixed `DBO_PACKAGES` array for `DatabaseObject` implementations and auto-classifies primary vs secondary via `getSecondaryTypes()`. A new DBO in a package **not** in `DBO_PACKAGES` is silently never registered or migrated (no startup error).

--- a/lib/jdomodels/CLAUDE.md
+++ b/lib/jdomodels/CLAUDE.md
@@ -54,12 +54,12 @@ new FieldColumn("changeNumber", COL_CHANGES_CHANGE_NUM, true)  // isPrimaryKey
 4. Implement `getMigratableTableType()` returning a `MigrationType` enum value
 5. Add table/column constants to `SqlConstants`
 6. Create DDL file in `src/main/resources/schema/`
-7. Register in `src/main/resources/dbo-beans.spb.xml` (order matters — after dependencies)
+7. Place the DBO/DAO in a package listed in `DboAutoDiscovery.DBO_PACKAGES` and annotate the DAO `@Repository` — registration is by classpath auto-discovery, not XML (see [Spring Configuration](#spring-configuration))
 
 ### Primary vs Secondary Tables
 
-- **Primary**: Has etag column (`withIsEtag(true)`), migrated independently, registered in `dbo-beans.spb.xml`
-- **Secondary**: Owned by a primary table, discovered via `getSecondaryTypes()`, has FK to owner's backup ID, NOT registered in `dbo-beans.spb.xml`
+- **Primary**: Has etag column (`withIsEtag(true)`), migrated independently, discovered by `DboAutoDiscovery` (classpath scan) as a top-level `DatabaseObject`
+- **Secondary**: Owned by a primary table, discovered via the owner's `getSecondaryTypes()`, has FK to owner's backup ID — never scanned directly
 
 ## DAO Pattern
 
@@ -102,8 +102,13 @@ Naming: `TABLE_` prefix for table names, `COL_` for columns, `DDL_` for DDL path
 
 ## Spring Configuration
 
-- **`dbo-beans.spb.xml`** — registers primary migratable DBO types in migration order (dependencies first). This is the most important config file for migration.
-- Additional `*-spb.xml` files for feature-specific beans
+DBO registration is **classpath auto-discovery** via Java config in `src/main/java/org/sagebionetworks/repo/model/config/` — there are no `*-spb.xml` files in this module anymore.
+
+- **`JdoModelsConfig`** — `@Configuration`/`@ComponentScan` entry point; also bootstraps principal IDs (**do not change those IDs** — they are real production objects).
+- **`DboAutoDiscovery`** — classpath-scans the fixed `DBO_PACKAGES` array for `DatabaseObject` implementations and auto-classifies primary vs secondary via `getSecondaryTypes()`. A new DBO in a package **not** in `DBO_PACKAGES` is silently never registered or migrated (no startup error).
+- **`DboDependencyAnalyzer`** — topologically sorts DDL creation order by parsing `FOREIGN KEY ... REFERENCES` out of each DDL file, so ordering is derived, not hand-maintained.
+
+For the migration engine's startup invariants (enum order, CHANGE-last, backup-column validation), see `dbo/migration/CLAUDE.md`.
 
 ## Database Split
 
@@ -121,6 +126,8 @@ MyClass obj = JDOSecondaryPropertyUtils.createObjectFromJSON(MyClass.class, json
 ```
 
 Do NOT create custom `ObjectMapper` or `JSONObjectAdapter` serialization code in DAO classes — the utilities in `JDOSecondaryPropertyUtils` are already tested and handle null/error cases.
+
+For **opaque, non-`JSONEntity`** JSON columns — where the value is a free-form `Map`/`List`/`JSONObject`/scalar rather than a generated POJO (e.g. `TextAnalyzer.settings`, `SynonymSet.definition`, `SearchConfiguration.defaultAnalyzer`) — use `OpaqueJsonColumnCodecUtil` (`dbo.search`) instead. Pass the actual `Map`/`List`/`JSONObject`; **never pre-stringify JSON before `serialize()`** — a `String` is encoded as a JSON scalar (quoted), not as raw JSON passthrough.
 
 ## SQL Patterns
 

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/migration/CLAUDE.md
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/migration/CLAUDE.md
@@ -1,0 +1,20 @@
+# dbo/migration
+
+The migration engine that backs cross-stack data replication. The parent `lib/jdomodels/CLAUDE.md` covers the DBO/`MigratableTableTranslation` authoring pattern; this package is the engine (`MigratableTableDAOImpl`) that discovers, orders, backs up, and restores those types.
+
+## Startup invariants (enforced, will fail the stack)
+
+`MigratableTableDAOImpl.initialize()` asserts several things at startup — violating them throws immediately, which is intentional (a misordered migration corrupts data silently otherwise):
+
+- **Primary `MigrationType` registration order must match the `MigrationType` enum order.** Discovery order (from `DboAutoDiscovery`) and enum order must agree (`MigratableTableDAOImpl.java:159`).
+- **`MigrationType.CHANGE` must be the last type** (`:165`) — asynchronous message triggering depends on CHANGE migrating last, so downstream index rebuild sees a complete state.
+- **Every backup-ID column must be a `bigint` and unique-constrained** (`:308`, PLFM-2512) — a non-unique or wrong-typed backup id loses rows during migration.
+
+## Mechanics worth knowing
+
+- **`runWithKeyChecksIgnored`** — toggles FK/unique constraint checking off around bulk restore, then back on. Use it for restore batches, not ad-hoc.
+- **`BatchUtility`** — chunks batch operations by an estimated `max_allowed_packet` byte budget rather than a fixed row count, so large rows don't blow the MySQL packet limit.
+
+## Anti-Patterns — Do NOT
+
+- **Do NOT insert a new primary `MigratableDatabaseObject` out of `MigrationType` enum order, and never after `CHANGE`.** The startup assertions above will reject it; place the new enum value with its dependencies before it and keep `CHANGE` last.

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/migration/CLAUDE.md
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/migration/CLAUDE.md
@@ -6,7 +6,7 @@ The migration engine that backs cross-stack data replication. The parent `lib/jd
 
 `MigratableTableDAOImpl.initialize()` asserts several things at startup — violating them throws immediately, which is intentional (a misordered migration corrupts data silently otherwise):
 
-- **Primary `MigrationType` registration order must match the `MigrationType` enum order.** Discovery order (from `DboAutoDiscovery`) and enum order must agree (`MigratableTableDAOImpl.java:159`).
+- **Primary types are discovered and sorted to `MigrationType` enum order automatically** by `DboAutoDiscovery` — there is no manual registration list. `initialize()` re-asserts the discovered order is non-decreasing in enum index as a sanity check (`MigratableTableDAOImpl.java:159`).
 - **`MigrationType.CHANGE` must be the last type** (`:165`) — asynchronous message triggering depends on CHANGE migrating last, so downstream index rebuild sees a complete state.
 - **Every backup-ID column must be a `bigint` and unique-constrained** (`:308`, PLFM-2512) — a non-unique or wrong-typed backup id loses rows during migration.
 
@@ -17,4 +17,4 @@ The migration engine that backs cross-stack data replication. The parent `lib/jd
 
 ## Anti-Patterns — Do NOT
 
-- **Do NOT insert a new primary `MigratableDatabaseObject` out of `MigrationType` enum order, and never after `CHANGE`.** The startup assertions above will reject it; place the new enum value with its dependencies before it and keep `CHANGE` last.
+- **Do NOT declare a new `MigrationType` enum value out of dependency order, and never after `CHANGE`.** Discovery sorts primary types to enum order, so the enum declaration is what controls migration order — place the new value with its dependencies before it and keep `CHANGE` last, or the startup assertions above will reject it.

--- a/lib/lib-auto-generated/CLAUDE.md
+++ b/lib/lib-auto-generated/CLAUDE.md
@@ -82,6 +82,7 @@ src/main/resources/schema/org/sagebionetworks/
 - **Required fields**: `"required": true` on a property
 - **Map types**: For map-like properties, either define the sub-type schema explicitly OR treat the entire value as a plain `"type": "string"` (expecting a JSON string). Do NOT use `Map<String, String>` where the string values are themselves serialized JSON — this creates ambiguous "JSON within JSON" that bypasses schema validation.
 - **Descriptions must match implementation**: Schema descriptions (especially for optional fields like "If null, lists X") are API contracts. Always verify the implementation matches the schema description. If behavior changes, update the schema text to match.
+- **Mirroring an external API's shape**: When a schema family models a pass-through external API (e.g. the `search/dsl/` package — 60+ schemas mirroring the OpenSearch query DSL, `$ref`-composed), keep field names and nesting **identical to that external spec** rather than Synapse-idiomatic naming, so the objects serialize straight through to the external service.
 
 ## Generated Code Patterns
 

--- a/lib/lib-database-configuration/CLAUDE.md
+++ b/lib/lib-database-configuration/CLAUDE.md
@@ -1,0 +1,43 @@
+# lib/lib-database-configuration
+
+Foundational module holding the JDBC/DataSource beans and the `@WriteTransaction`-family annotations. Extracted from `lib/models` to break a dependency cycle, so it must stay dependency-light — most other modules depend on it.
+
+## What lives here
+
+- `org.sagebionetworks.repo.model.config.DatabaseInfrastructureConfiguration` — the `DataSource` / `JdbcTemplate` / `PlatformTransactionManager` beans for both databases.
+- `org.sagebionetworks.repo.transactions.*` — the transaction meta-annotations applied on manager/DAO methods across the codebase.
+
+## Two databases, two bean sets — qualify explicitly
+
+There are parallel beans for the **main (transactional)** DB and the **migration** DB. They are NOT interchangeable; inject the one you mean by `@Qualifier`:
+
+| Concern | Main DB | Migration DB |
+|---------|---------|--------------|
+| DataSource | `@Qualifier("dataSourcePool")` | `@Qualifier("migrationDataSourcePool")` |
+| TransactionManager | `txManager` | `migrationTxManager` |
+| JdbcTemplate | `@Qualifier("jdbcTemplate")` | `migrationJdbcTemplate` |
+
+`namedParameterJdbcTemplate` wraps the main `jdbcTemplate`.
+
+## Transaction annotations
+
+Each annotation is a `@Transactional` meta-annotation pinned to a specific `transactionManager` + `Propagation`, all at `Isolation.READ_COMMITTED`. Choosing the wrong one silently changes locking/commit semantics — pick by intent, don't copy blindly:
+
+| Annotation | transactionManager | Propagation | Use when |
+|-----------|--------------------|-------------|----------|
+| `@WriteTransaction` | `txManager` | `REQUIRED` | Standard write — join or create a transaction |
+| `@MandatoryWriteTransaction` | `txManager` | `MANDATORY` | Must run inside an existing transaction (throws if none) |
+| `@NewWriteTransaction` | `txManager` | `REQUIRES_NEW` | Must commit independently (suspends the outer tx) |
+| `@MigrationWriteTransaction` | `migrationTxManager` | `REQUIRED` | Writes against the migration DB |
+| `@TransactionNotSupported` | `txManager` | `NOT_SUPPORTED` | Must run with no transaction |
+
+Read-only operations take no annotation (default Spring behavior).
+
+## Constraints
+
+- **`dataSource.setMaxTotal(-1)` (unbounded connection pool) is intentional** — do not "fix" it to a bounded value without reading PLFM-8344 (`DatabaseInfrastructureConfiguration.java:40`). A bound here caused production stalls.
+- **Keep this module's dependencies minimal.** It exists specifically to break the `lib/models` ↔ transaction-annotation cycle; pulling heavy deps back in re-creates the cycle.
+
+## Anti-Patterns — Do NOT
+
+- **Do NOT call a `@NewWriteTransaction` method from within an existing transaction when it updates rows the outer transaction already locked** — the new (suspended-outer) transaction blocks on the outer's locks and self-deadlocks (evidence: `NewWriteTransaction.java` javadoc warning).

--- a/lib/lib-openapi/CLAUDE.md
+++ b/lib/lib-openapi/CLAUDE.md
@@ -1,0 +1,24 @@
+# lib/lib-openapi
+
+Build-time **javadoc doclet** that reflects over the annotated REST controllers and emits the OpenAPI specification JSON. It is not run by tests — it runs via the `maven-javadoc-plugin` in `services/repository/pom.xml`. Package: `org.sagebionetworks.translator`.
+
+## How it runs
+
+`ControllerModelDoclet` is invoked as a doclet from `services/repository/pom.xml` with `additionalparam`:
+`--target-file,<...>/openapispecification.json,--factory-path,org.sagebionetworks.server.ServerSideOnlyFactory,--should-run,true`.
+
+- **`--should-run,true` is mandatory.** If it's anything but `true`, the doclet silently no-ops (prints a NOTE and produces no spec). This is deliberate so a normal javadoc build doesn't try to generate the spec — but it means "no spec was generated" is usually a missing/false `--should-run`, not a code bug.
+
+## Conventions that affect controller authors
+
+`ControllerToControllerModelTranslator` turns controller methods into the model. When adding or changing a controller method, respect what the translator enforces (it throws at build time otherwise):
+
+- A controller class **must** carry the `ControllerInfo` annotation, and each translated method **must** have a `RequestMapping`.
+- **`@Deprecated` methods are skipped** — they do not appear in the generated spec.
+- **Each parameter must have exactly one relevant annotation** — `annotations.size() != 1` throws. A parameter with zero or multiple binding annotations breaks the build.
+- Parameter types the API doesn't expose (e.g. `HttpServletResponse`, the user-id param) must be in the `PARAMETERS_NOT_REQUIRED_TO_BE_TRANSLATED` allowlist, or translation fails on them.
+- Generic wrapper types are mapped via the `CUSTOM_GENERIC_CLASS_TO_GENERIC_PROPERTY` map; a new generic container type used in a response may need an entry there.
+
+## Related
+
+A sibling doclet framework, `lib/lib-javadoc` (`SpringMVCDoclet`), generates the HTML API docs from the same controllers via Velocity templates — separate output, separate pipeline.

--- a/lib/lib-schema-id/CLAUDE.md
+++ b/lib/lib-schema-id/CLAUDE.md
@@ -1,0 +1,17 @@
+# lib/lib-schema-id
+
+Parser and model for JSON Schema `$id` strings. A Synapse schema `$id` is `organizationName-schemaName[-semanticVersion]` (semver optional), and this module parses/represents/re-renders that grammar.
+
+## Grammar as a composite tree
+
+The `$id` is modeled as a tree of `org.sagebionetworks.schema.element.Element` nodes, each of which renders itself into a shared buffer via `abstract void toString(StringBuilder)` — a visitor-style composition, not a plain `Object.toString()`. Build the string by creating a `StringBuilder` and calling the root's `toString(builder)`.
+
+- `SchemaId` (root) = `OrganizationName` + `DASH` + `SchemaName` + optional (`DASH` + `SemanticVersion`).
+- `SimpleBranch` wraps a single child and delegates (`final`); leaves like `SimpleString`/`AlphanumericIdentifier` append their own text.
+- `SemanticVersion` decomposes into `VersionCore` / `Prerelease` / `Build` sub-elements.
+
+## Conventions
+
+- **The join separator is `SchemaId.DASH` (`"-"`)** — reuse the constant; don't hardcode delimiters when composing or splitting.
+- **Compose via `toString(StringBuilder)`, never string concatenation** — the whole point of the `Element` hierarchy is that each node knows how to render itself, so new grammar pieces must implement `toString(StringBuilder)` rather than overriding a bare `toString()`.
+- Elements reject null children in their constructors (`IllegalArgumentException`) — construct fully-formed subtrees.

--- a/lib/lib-table-cluster/CLAUDE.md
+++ b/lib/lib-table-cluster/CLAUDE.md
@@ -8,15 +8,6 @@ Operations against the **index database** — the derived/computed MySQL instanc
 - `SQLUtils` (~2000 lines) — the SQL-string builder for index tables (CREATE/ALTER/INSERT/SELECT generation from column models). **Reuse it; do not hand-build index SQL** — it encodes column-type→SQL mapping, list-column `JSON_TABLE` unnesting, and naming rules you would otherwise get subtly wrong.
 - `description/IndexDescription` — describes a queryable object (table, view, materialized view, search index) and its dependencies.
 
-## IndexDescription: don't override the hash defaults
-
-`IndexDescription` provides `default` methods that compute a table's identity hash by walking its dependency graph:
-
-- `recursiveAppendIdAndChangeNumber(StringBuilder)` — appends this object's id + change number, then recurses into each dependency.
-- `getTableHash()` — the cache/staleness key, built from that recursive walk.
-
-Implementors supply the leaf data (id, change number, dependencies) but **must not override these default methods** — a view's hash must be derived identically to every other object's, or cache invalidation and rebuild detection break.
-
 ## Database split
 
 This module targets the **index database** only. The main (transactional) DB is handled by `lib/jdomodels`. The two use separate `DataSource`/`JdbcTemplate` beans (see `lib/lib-database-configuration`).

--- a/lib/lib-table-cluster/CLAUDE.md
+++ b/lib/lib-table-cluster/CLAUDE.md
@@ -1,0 +1,26 @@
+# lib/lib-table-cluster
+
+Operations against the **index database** — the derived/computed MySQL instance that backs table queries, materialized views, entity replication, and search index builds. This is the "index database" that other modules' CLAUDE.md files refer to; it starts empty on a new stack and is rebuilt from change messages.
+
+## Core types
+
+- `TableIndexDAO` / `TableIndexDAOImpl` — the DAO for building and querying index tables, replication data, and per-table status.
+- `SQLUtils` (~2000 lines) — the SQL-string builder for index tables (CREATE/ALTER/INSERT/SELECT generation from column models). **Reuse it; do not hand-build index SQL** — it encodes column-type→SQL mapping, list-column `JSON_TABLE` unnesting, and naming rules you would otherwise get subtly wrong.
+- `description/IndexDescription` — describes a queryable object (table, view, materialized view, search index) and its dependencies.
+
+## IndexDescription: don't override the hash defaults
+
+`IndexDescription` provides `default` methods that compute a table's identity hash by walking its dependency graph:
+
+- `recursiveAppendIdAndChangeNumber(StringBuilder)` — appends this object's id + change number, then recurses into each dependency.
+- `getTableHash()` — the cache/staleness key, built from that recursive walk.
+
+Implementors supply the leaf data (id, change number, dependencies) but **must not override these default methods** — a view's hash must be derived identically to every other object's, or cache invalidation and rebuild detection break.
+
+## Database split
+
+This module targets the **index database** only. The main (transactional) DB is handled by `lib/jdomodels`. The two use separate `DataSource`/`JdbcTemplate` beans (see `lib/lib-database-configuration`).
+
+## Anti-Patterns — Do NOT
+
+- **Do NOT batch-delete replication rows without sorting the IDs first.** `TableIndexDAOImpl.deleteObjectData` copies the id list and calls `Collections.sort` before the batch delete specifically to impose a consistent lock-acquisition order and prevent deadlocks between concurrent deletes (evidence: `TableIndexDAOImpl.java:787`, comment "sort to prevent deadlock"). Any new batch mutation over object IDs must do the same.

--- a/lib/models/CLAUDE.md
+++ b/lib/models/CLAUDE.md
@@ -7,9 +7,12 @@ DAO interfaces and shared exception types. This module defines the persistence c
 ```
 org.sagebionetworks.repo.model
 ├── dao/                    # DAO interfaces (NodeDAO, AccessControlListDAO, etc.)
+├── schema/                 # JSON Schema helpers, e.g. JsonSchemaProperties
 ├── (root)                  # Core interfaces, enums, utility classes
 └── ...                     # Domain-specific sub-packages
 ```
+
+Reusable helper worth knowing: `schema/JsonSchemaProperties.java` walks a `JsonSchema` through `$ref`/`allOf`/`anyOf`/`oneOf`/`if-then-else` to collect top-level property names (used to derive `ColumnModel`s from a bound schema) — prefer it over re-implementing schema traversal.
 
 ## DAO Interfaces
 

--- a/lib/stackConfiguration/CLAUDE.md
+++ b/lib/stackConfiguration/CLAUDE.md
@@ -1,0 +1,28 @@
+# lib/stackConfiguration
+
+Environment/stack configuration and AWS client construction. Every stack is identified by `stack` (dev/prod) + `instance`; this module resolves all config properties and builds AWS clients from them.
+
+## Accessing configuration
+
+- Spring code injects the `StackConfiguration` bean normally.
+- Code **outside** the Spring context reads config via `StackConfigurationSingleton.singleton()`.
+
+**`StackConfigurationSingleton` bootstraps with Guice, not Spring** (`Guice.createInjector(new StackConfigurationGuiceModule())`). This is the one place in the codebase using Guice DI — it exists so non-Spring code paths can still get a fully-wired `StackConfiguration`. Do NOT "fix" it to Spring DI; the whole point is to avoid requiring a Spring context here.
+
+## Queue name resolution
+
+`stackConfig.getQueueName("BASE_NAME")` returns `{stack}-{instance}-BASE_NAME`. Workers use this to resolve SQS queue URLs at runtime; the physical queues are provisioned by the separate Synapse-Stack-Builder project.
+
+## AWS client construction — v1/v2 migration in progress
+
+Two factories coexist while the codebase migrates from AWS SDK v1 to v2:
+
+- `aws/AwsClientFactory` — SDK **v1** clients (legacy).
+- `aws/v2/AwsClientFactoryV2` — SDK **v2** clients.
+- `aws/ProfileCredentialsProviderV2V1Adapter` — bridges the two credential-provider hierarchies so a single resolved credential source feeds both.
+
+**New AWS clients should use `AwsClientFactoryV2` (v2).** When a subsystem still needs a v1 client, reuse the adapter rather than constructing a parallel credential chain.
+
+## Constraints
+
+- **No secrets in code or config committed here** — property *names* only; values come from the deployed stack.

--- a/services/repository-managers/CLAUDE.md
+++ b/services/repository-managers/CLAUDE.md
@@ -186,6 +186,21 @@ These entity types share a common pattern. Follow it whenever introducing a new 
 
 Failing the parse synchronously in the metadata provider means malformed `definingSql` is rejected with `IllegalArgumentException` (HTTP 400) at create/update time, instead of silently FAILED'ing during the async build.
 
+`SearchIndex` adds a managed-OpenSearch-domain build path and row-level benefactor ACL on top of this pattern — see `manager/search/CLAUDE.md` for the domain/shard/ACL specifics and DSL validation.
+
+`RecordSet` is also queryable but **not** defining-SQL driven: `RecordSetManagerImpl`/`RecordSetIndexManagerImpl` require a bound JSON Schema and derive columns from it (via `RecordSetSchemaResolver`), not from CSV inference — a RecordSet with no bound schema is not indexed.
+
+## Plugin-Registry Pattern
+
+Several subsystems resolve behavior by a `Map` keyed on an enum, built from an autowired `List` of `@Service` beans (one bean per key) in `ManagerConfiguration`. When adding a new variant, add a `@Service` bean — do not edit a central switch. Instances:
+
+- **Entity metadata providers** (`repo/service/metadata/`) — keyed by `EntityType`; strict `{DTO}MetadataProvider` naming. Missing/misnamed → the new entity type is silently unwired. See `service/metadata/CLAUDE.md`.
+- **OIDC claim providers** (`repo/manager/oauth/claimprovider/`) — keyed by `OIDCClaimName`. See `manager/oauth/CLAUDE.md`.
+- **File handle association providers** (`repo/manager/file/`) — keyed by `FileHandleAssociateType`.
+- **Agent return-control handlers** (`repo/manager/agent/`) — `ReturnControlHandlerProvider` keyed by actionGroup+function; `CodeInterpreterTools` exposes Spring AI `@Tool` methods with a staging-bucket copy-then-presign flow.
+
+Sub-packages with their own deep conventions have their own files: `manager/search/` (OpenSearch domain build + DSL validation), `manager/oauth/` (OIDC/claim providers), `service/metadata/` (entity provider registry), `manager/file/scanner/` (auto-SQL file-handle scanners), `manager/dataaccess/` (access-request submission state machine), and `grid/internal/replica/` (CRDT internals).
+
 ## Curation Grid (Curator)
 
 A spreadsheet-style collaborative editing feature that allows data curators to annotate files (FileEntity annotations) and manage record-based metadata (RecordSet entities). Unlike the standard Controller → Manager → DAO pattern, the grid uses a **CRDT (Conflict-free Replicated Data Type)** architecture based on the [JSON-Joy](https://jsonjoy.com/) specification, enabling real-time multi-user and AI-assisted editing.
@@ -222,7 +237,7 @@ The AI Grid Assistant binds to a grid session via `GridAgentSessionContext` (con
 
 ### Validation Worker
 
-A dedicated worker listens to grid changes via an SQS queue, validates each changed row against the bound **JSON Schema**, and writes validation results back as CRDT patches to `rows[*].metadata.rowValidation`.
+A dedicated worker listens to grid changes via an SQS queue, validates each changed row against the bound **JSON Schema** (`GridRowValidator` + `ValidationSummaryAccumulator` in `grid/internal/replica/validation/`), and writes validation results back as CRDT patches to `rows[*].metadata.rowValidation`. For the replica/patch/validation internals, see `grid/internal/replica/CLAUDE.md`.
 
 ### Key REST APIs
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/dataaccess/CLAUDE.md
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/dataaccess/CLAUDE.md
@@ -1,0 +1,11 @@
+# manager/dataaccess
+
+Managers for the data-access request/approval flow — access requirements, research-project submissions, and their approval state.
+
+## Bean-name collision — qualify the submission manager
+
+`SubmissionManagerImpl` is registered as `@Service("dataAccessSubmissionManager")`. **Inject it with `@Qualifier("dataAccessSubmissionManager")`** — the unqualified bean name `submissionManager` collides with the evaluations `SubmissionManager`, so an unqualified inject is ambiguous / resolves to the wrong bean (evidence: `SubmissionManagerImpl.java:76`).
+
+## Submission state machine
+
+A submission transitions only `SUBMITTED → APPROVED` or `SUBMITTED → REJECTED`, enforced via `ValidateArgument.requirement(...)` in the manager (not a DB constraint). Validation also checks etag match and that no conflicting submission state already exists. When adding a transition, add the guard here — the state machine is code-enforced, so a missing check silently allows an illegal transition.

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/scanner/CLAUDE.md
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/file/scanner/CLAUDE.md
@@ -1,0 +1,15 @@
+# manager/file/scanner
+
+Scans DBO tables for file-handle references so orphaned/associated file handles can be reconciled. The non-obvious part: the scanner generates its SQL automatically from DBO metadata rather than hand-written queries.
+
+## Metadata-driven SQL
+
+`BasicFileHandleAssociationScanner` builds min/max range queries and batched `SELECT`s directly off a `TableMapping`'s `FieldColumn[]`:
+
+- It locates the column with `FieldColumn.hasFileHandleRef() == true` (the file-handle column) and the `FieldColumn.isBackupId() == true` column (the range/scan key).
+- **It throws at construction if either column is missing** — a table with no file-handle-ref column, or no backup-id column, cannot be scanned. So a new scannable DBO must set `withHasFileHandleRef(true)` and have a backup-id column in its `FieldColumn` definitions.
+- Row mapping is pluggable via `RowMapperSupplier` (e.g. `SerializedFieldRowMapperSupplier` for file handles stored inside a serialized blob column).
+
+## Adding a scanner for a new table
+
+Point `BasicFileHandleAssociationScanner` at the DBO's `TableMapping` and supply a `RowMapperSupplier`. Do not hand-write range/scan SQL — the generated SQL keeps the scan batched over the backup-id range consistently across all association types.

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/CLAUDE.md
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/CLAUDE.md
@@ -1,0 +1,16 @@
+# grid/internal/replica
+
+CRDT replica internals for the Curation Grid. The parent `services/repository-managers/CLAUDE.md` covers the grid's hub-and-replica overview, WebSocket/json-rx protocol, and CRDT document model; this package is the server-side machinery that builds, validates, and merges replica patches. Sub-packages: `change`, `validation`, `merge`, `model`, `view`, `export`.
+
+## Patch-span byte budgeting
+
+CRDT patches are size-bounded, not count-bounded. `PatchUtils.MAX_BYTES_PER_PATCH` (128,000) and `MAX_CHANGE_SET_SIZE` cap how much a single patch / change-set may carry; builders chunk work to stay under these. When emitting patches, budget by serialized bytes via `PatchUtils`, and let `PatchSpanPublisherProxy` track cumulative span across a whole change-set so the logical clock advances correctly — don't emit unbounded patches.
+
+## Change-handler registry
+
+Replica changes are dispatched through a `ChangeHandler<T>` registry keyed by `IntendedChangeType`, resolved from a constructor-injected `List<ChangeHandler<?>>`. To handle a new intended-change type, add a `ChangeHandler` bean — do not extend a central switch.
+
+## Anti-Patterns — Do NOT
+
+- **Do NOT skip re-applying validation results when they are unchanged.** `GridReplicaValidationManagerImpl` re-applies results unconditionally so the client can use the timestamp to detect staleness, and to avoid an infinite snapshot-triggered revalidation loop (evidence: `validation/GridReplicaValidationManagerImpl.java:196`, PLFM-9342). "Optimizing" this to skip no-op writes reintroduces both bugs.
+- **Do NOT re-enable constant caching in `ChangePatchBuilder`.** It is deliberately disabled (evidence: `change/GridReplicaPatchBuilderManagerImpl.java:70`, "disable constant caching due to PLFM-9192").

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/CLAUDE.md
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/CLAUDE.md
@@ -13,4 +13,3 @@ Replica changes are dispatched through a `ChangeHandler<T>` registry keyed by `I
 ## Anti-Patterns — Do NOT
 
 - **Do NOT skip re-applying validation results when they are unchanged.** `GridReplicaValidationManagerImpl` re-applies results unconditionally so the client can use the timestamp to detect staleness, and to avoid an infinite snapshot-triggered revalidation loop (evidence: `validation/GridReplicaValidationManagerImpl.java:196`, PLFM-9342). "Optimizing" this to skip no-op writes reintroduces both bugs.
-- **Do NOT re-enable constant caching in `ChangePatchBuilder`.** It is deliberately disabled (evidence: `change/GridReplicaPatchBuilderManagerImpl.java:70`, "disable constant caching due to PLFM-9192").

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/oauth/CLAUDE.md
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/oauth/CLAUDE.md
@@ -1,0 +1,13 @@
+# manager/oauth
+
+OAuth 2.0 / OpenID Connect provider logic — token issuance, consent, and OIDC claim population. Uses `io.jsonwebtoken` (JJWT) for JWT signing/verification, distinct from the rest of the manager layer.
+
+## Claim-provider plugin registry
+
+Each OIDC claim is produced by its own `OIDCClaimProvider` `@Service` bean (`claimprovider/` — e.g. `EmailClaimProvider`, `CompanyClaimProvider`, `GA4GHPassportClaimProvider`). They are assembled into a `Map<OIDCClaimName, OIDCClaimProvider>` in `ManagerConfiguration.claimProviders(List<OIDCClaimProvider>)` — the map is keyed by the provider's declared `OIDCClaimName`.
+
+**To support a new claim, add a new `OIDCClaimProvider` `@Service`** keyed to its `OIDCClaimName`; it is picked up automatically. Do not add claim logic to a central method — the registry is the extension point. A claim with no registered provider is simply never populated.
+
+## Notes
+
+- Consent/claim decisions gate what user data is released into tokens — treat the claim providers as the authorization surface for released PII, not just formatting.

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/CLAUDE.md
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/CLAUDE.md
@@ -1,0 +1,28 @@
+# manager/search
+
+OpenSearch-backed search: index lifecycle/build, the query surface, and DSL validation. `SearchIndex` is one of the defining-SQL entity types (see the parent `services/repository-managers/CLAUDE.md` "Defining-SQL Entities" section for the shared bind-schema-on-create/update pattern); this package owns the search-specific build and query internals.
+
+## Managed OpenSearch domain + build
+
+`SearchIndexLifecycleManagerImpl` builds/deletes indexes against a **managed OpenSearch domain** (not AOSS). Key runtime facts:
+
+- **Endpoint is discovered via `describeDomain`**, not injected from config — code must resolve it at runtime.
+- **Shard count is computed from the source table's byte size** at build time (clamped to a max), so index topology tracks data size.
+- The build reads the bound schema (via `tableManagerSupport.getTableSchema`) rather than re-translating the defining SQL.
+
+## Row-level access control
+
+SearchIndex enforces per-row ACL through **benefactor columns**: one non-analyzed `_benefactor_N` long field per source dependency, populated at index time. At query time `BenefactorAccessFilter` (in `manager/table/`, shared with the table-query SQL path so both gates compute accessibility identically) produces filters that are AND-ed into every OpenSearch query via `OpenSearchManager.search(..., accessFilters)` / `autocomplete(...)`. Any new query path must apply these access filters — an unfiltered query leaks rows across benefactors.
+
+## DSL validation (defense-in-depth)
+
+The API accepts an opaque OpenSearch query DSL (typed passthrough POJOs generated in `lib-auto-generated`'s `search/dsl/`). `SearchDslValidator` is the safety layer behind the POJO's structural allowlist: it enforces per-kind allowlists (`ALLOWED_QUERY_KINDS`, aggregation kinds), depth/clause caps, rejects leading wildcards, and rejects anything the OpenSearch client supports but nobody explicitly allowlisted. `SearchFieldRewriter` and `SearchOpaqueJsonUtil` handle field rewriting and opaque-JSON traversal. Preserve the extensive rationale comments — the caps and rejections are security controls, not arbitrary limits.
+
+## Anti-Patterns — Do NOT
+
+- **Do NOT add `Global` aggregations to the `SearchDslValidator` allowlist.** A `Global` aggregation escapes the top-level query scope and would bypass the row-level benefactor ACL filter injected there (evidence: `SearchDslValidator.java:152`).
+- **Do NOT emit a query without the benefactor `accessFilters`** — see row-level access control above.
+
+## Legacy
+
+`search/oss/` (and the worker `search/oss/worker/SearchIndexWorker`) is the older queue-driven index writer; the lifecycle/query path here supersedes it for SearchIndex entities.

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/metadata/CLAUDE.md
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/service/metadata/CLAUDE.md
@@ -1,0 +1,22 @@
+# service/metadata
+
+The **entity provider** plugin architecture — type-specific hooks that run during entity create/update/delete/version operations. This is how per-`EntityType` behavior is attached without a central switch.
+
+## Extension interfaces
+
+An entity provider implements one or more marker interfaces (all extend `EntityProvider<T>`), each invoked at a specific point:
+
+- `EntityValidator` — validate on create/update
+- `TypeSpecificCreateProvider` / `TypeSpecificUpdateProvider` / `TypeSpecificDeleteProvider` / `TypeSpecificVersionDeleteProvider` — lifecycle hooks
+- `TypeSpecificMetadataProvider` — post-read metadata population
+- `DefiningSqlProvider` — for defining-SQL entity types
+
+## Registry + naming convention
+
+`MetadataProviderFactoryImpl` holds a `Map<EntityType, EntityProvider<?>>` populated by an `@Autowired` constructor/setter that takes each concrete provider bean explicitly, keyed by `EntityType`.
+
+**Adding a new entity type:** create a `@Service` provider named `{DTO}MetadataProvider` (e.g. `DatasetMetadataProvider`, `RecordSetMetadataProvider`) implementing the hook interfaces you need, and wire it into `MetadataProviderFactoryImpl`'s provider map. **If you skip the wiring or misname the class, the entity type is silently unwired** — its validators and lifecycle hooks never run, with no startup error. This is the most common mistake when introducing a new entity type.
+
+## Notes
+
+- `AllTypesValidator` runs for every entity regardless of type (name/hierarchy rules), separate from the type-specific `EntityValidator`s.

--- a/services/repository/CLAUDE.md
+++ b/services/repository/CLAUDE.md
@@ -45,6 +45,19 @@ public class EntityController {
 
 `org.sagebionetworks.repo.service.ServiceProvider` — facade that exposes all service interfaces. Controllers inject this single bean rather than individual managers.
 
+### One controller per resource family
+
+A related family of resource types can share a single `@Controller`. Example: `SearchManagementController` serves TextAnalyzer, ColumnAnalyzerOverride, SynonymSet, SearchConfiguration, SearchConfigBinding, and the async search query/autocomplete endpoints — it replaced four separate controllers (`SearchQueryController`, `SynonymSetController`, `TextAnalyzerController`, `ColumnAnalyzerOverrideController`). Prefer consolidating a tightly related family over one controller per type.
+
+## Servlet Filter Chain
+
+Request filters are declared in `src/main/webapp/WEB-INF/web.xml`; **filter order is the `<filter-mapping>` declaration order and is load-bearing**. Some filter classes live in the `services/authutil` module (`SimpleCORSFilter`, `CookieSessionTokenFilter`) — that module has no CLAUDE.md of its own because its behavior is only meaningful in this chain. Current order: `trailingSlashRedirect → httpToHttps → unexpectedException → requestSizeThrottle → httpMethod → cookie → simpleCORS → stackStatus → authFilter → adminServiceAuth → … → throttles → …`.
+
+Guardrails (each has bitten before — do not "clean up"):
+- **Keep `unexpectedExceptionFilter` high in the chain, above the auth/business filters** — it is the last-chance handler that logs unexpected errors before they reach users (PLFM-3205/3206).
+- **Do NOT add `/auth/v1/*` paths to `acceptTermsOfUseFilter` or `twoFactorAuthRequiredFilter`** `<url-pattern>`s — users must be able to accept the terms of use / enable 2FA before those filters would otherwise block them.
+- **Do NOT broaden `cloudMailInAuthFilter` beyond `/cloudMailInMessage/*`** — CloudMailIn does not send BasicAuth on the `/cloudMailInAuthorization/*` endpoint, so the filter is deliberately scoped out of it.
+
 ## Spring Configuration
 
 - `web.xml` → `ContextLoaderListener` loads root context, `DispatcherServlet` loads MVC context

--- a/services/workers/CLAUDE.md
+++ b/services/workers/CLAUDE.md
@@ -158,6 +158,8 @@ Common transient exceptions to catch and retry:
 - `AmazonServiceException` (service errors)
 - `TemporarilyUnavailableException`
 
+**Worker-specific exception semantics matter.** In `SearchIndexLifecycleWorker`, a `NotFoundException` on the source entity means "entity is gone → clean up its index" (falls back to the delete path), NOT a generic permanent failure — preserve that fallback when editing the exception cascade.
+
 ## Worker Categories
 
 | Package | Type | Description |
@@ -166,12 +168,14 @@ Common transient exceptions to catch and retry:
 | `table/` | Message-driven | Table index management, materialized view updates |
 | `replication/` | Batch message | Entity replication to index database |
 | `file/` | Message-driven | File preview generation |
-| `search/` | Message-driven | Search index (OpenSearch) updates |
+| `search/oss/worker/` | Message-driven | Legacy OpenSearch index writer (`SearchIndexWorker`, queue-driven) |
+| `search/workers/` | Mixed | `SearchIndexLifecycleWorker` (change-message-driven, builds/deletes managed-domain SearchIndex) + `SearchQueryWorker` (`AsyncJobRunner`) |
+| `recordset/worker/` | Message-driven | `RecordSetIndexWorker` — builds the queryable index for a RecordSet version |
 | `schema/` | Message-driven | JSON Schema validation |
 | `migration/` | Batch message | Data migration workers |
 | `log/` | Scheduled | S3 log collation |
 | `agent/` | Message-driven | AI agent chat processing |
-| `grid/` | Message-driven | Grid CRDT patch processing, validation |
+| `grid/` | Mixed | Grid CRDT patch processing + validation (message-driven) plus `GridQueryWorker`/`GridUpdateWorker` (`AsyncJobRunner`) |
 
 ## Key Architectural Worker: ChangeSentMessageSynchWorker
 
@@ -192,7 +196,7 @@ This worker drives index rebuilding after migration:
 
 ## Testing
 
-- JUnit 5 + Mockito 2.27 (`@ExtendWith(MockitoExtension.class)`)
+- JUnit 5 + Mockito 5.x (`@ExtendWith(MockitoExtension.class)`)
 - Mock managers/DAOs, verify expected calls
 - Test both success paths and error handling (RecoverableMessageException vs permanent failure)
 - Test ObjectType/ChangeType filtering logic


### PR DESCRIPTION
## What this is

Docs-only: refreshes the CLAUDE.md agent-guidance files and adds coverage for modules/sub-packages that had none. No code, build, or test changes.

## Corrections to existing files (7)

Fixes drift that would send an agent down dead paths:
- **`dbo-beans.spb.xml` → classpath auto-discovery** — that file was removed repo-wide; registration is now via `DboAutoDiscovery`/`DboDependencyAnalyzer`/`JdoModelsConfig`. Was cited in both root and `lib/jdomodels`.
- **Mockito 2.27 → 5.x** — root file self-contradicted (one line said 2.27, another 5.x); pom is 5.23.0.
- **AWS SDK v2 2.29.x → 2.40.x**; added **Spring AI** to the tech stack; added `lib-database-configuration` + `lib-docusign` to the module list.
- **Worker categories** — split the `search/` row (legacy `search/oss/worker` vs new `search/workers`), added `recordset/`, noted grid async workers.
- `SearchManagementController` consolidation + a **Servlet Filter Chain** section (ordering guardrails).

## New files (14)

**Modules (7):** `lib-database-configuration`, `lib-table-cluster`, `stackConfiguration`, `integration-test`, `client/synapseJavaClient`, `lib-openapi`, `lib-schema-id`.

**Nested sub-packages (7):** `manager/grid/internal/replica`, `manager/oauth`, `manager/search`, `service/metadata`, `dbo/migration`, `manager/file/scanner`, `manager/dataaccess`.

Each was selected on the test "would an agent working from the parent CLAUDE.md make a mistake here?" — capturing load-bearing conventions and gotchas (transaction/deadlock semantics, migration-order invariants, DSL allowlist, filter ordering, etc.).

## Altitude principle

Subsystem detail lives in the child file that owns its scope; parent/ancestor files keep only cross-cutting facts plus a one-line pointer — so an agent working on an unrelated area doesn't ingest that detail into context.

All references verified against `develop`.