### PR TITLE
Retry createIndex on transient IOException

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -108,6 +108,14 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	static int VALIDATE_MAX_RETRIES = 10;
 	static long VALIDATE_INITIAL_BACKOFF_MS = 1000L;
 
+	// Retry budget for the createIndex transport call. A create-index request against the
+	// managed domain can hit a transient read timeout or other IOException before the domain
+	// acknowledges; absorb those before failing the build so a single network blip doesn't
+	// turn into a hard failure. OpenSearchException (including resource_already_exists) is
+	// permanent and not retried.
+	static int CREATE_INDEX_MAX_RETRIES = 3;
+	static long CREATE_INDEX_INITIAL_BACKOFF_MS = 1000L;
+
 	// Cleanup retry for the readiness-probe sentinel. AOSS doesn't honor refresh=wait_for,
 	// so a single delete that fails on a transient network blip would orphan the sentinel
 	// (visible only to MATCH_ALL queries since _row_id = -1 cannot collide with real ids,
@@ -194,38 +202,49 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 				.collect(Collectors.toMap(ColumnModel::getName, ColumnModel::getId, (a2, b) -> a2));
 		Map<String, ColumnAnalyzerOverrideEntry> overrideMap = buildOverrideMap(columnAnalyzerOverrides, nameToId);
 
+		CreateIndexRequest request = CreateIndexRequest.of(req -> req
+				.index(indexName)
+				.settings(s -> s
+					.numberOfShards(numberOfShards)
+					.numberOfReplicas(numberOfReplicas)
+					.analysis(a -> {
+						buildAnalysisSettings(a, resolvedAnalyzers, defaultAnalyzer);
+						return a;
+					}))
+				.mappings(m -> {
+					buildMappings(m, columns, defaultAnalyzer,
+							overrideMap, resolvedAnalyzers, benefactorCount);
+					return m;
+				})
+		);
+
+		String appliedConfigJson = request.toJsonString();
+
 		try {
-			CreateIndexRequest request = CreateIndexRequest.of(req -> req
-					.index(indexName)
-					.settings(s -> s
-						.numberOfShards(numberOfShards)
-						.numberOfReplicas(numberOfReplicas)
-						.analysis(a -> {
-							buildAnalysisSettings(a, resolvedAnalyzers, defaultAnalyzer);
-							return a;
-						}))
-					.mappings(m -> {
-						buildMappings(m, columns, defaultAnalyzer,
-								overrideMap, resolvedAnalyzers, benefactorCount);
-						return m;
-					})
-			);
-
-			String appliedConfigJson = request.toJsonString();
-			CreateIndexResponse response = openSearchClient.indices().create(request);
-
-			if (!response.acknowledged()) {
-				throw new IllegalStateException("Search index " + indexName + " creation was not acknowledged.");
-			}
-
-			return Optional.of(appliedConfigJson);
-		} catch (OpenSearchException e) {
-			if ("resource_already_exists_exception".equals(e.error().type())) {
-				return Optional.empty();
-			}
-			throw new RuntimeException("Failed to create search index: " + indexName
-					+ " (" + describeError(e.error()) + ")", e);
-		} catch (IOException e) {
+			return TimeUtils.waitForExponentialMaxRetry(CREATE_INDEX_MAX_RETRIES,
+					CREATE_INDEX_INITIAL_BACKOFF_MS, () -> {
+				try {
+					CreateIndexResponse response = openSearchClient.indices().create(request);
+					if (!response.acknowledged()) {
+						throw new IllegalStateException(
+								"Search index " + indexName + " creation was not acknowledged.");
+					}
+					return Optional.of(appliedConfigJson);
+				} catch (OpenSearchException e) {
+					if ("resource_already_exists_exception".equals(e.error().type())) {
+						return Optional.<String>empty();
+					}
+					throw new RuntimeException("Failed to create search index: " + indexName
+							+ " (" + describeError(e.error()) + ")", e);
+				} catch (IOException e) {
+					throw new RetryException(e);
+				}
+			});
+		} catch (RetryException e) {
+			throw new RuntimeException("Failed to create search index: " + indexName, e.getCause());
+		} catch (RuntimeException e) {
+			throw e;
+		} catch (Exception e) {
 			throw new RuntimeException("Failed to create search index: " + indexName, e);
 		}
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -141,6 +141,7 @@ public class OpenSearchManagerImplTest {
 	private long originalBulkInitialBackoffMs;
 	private long originalProbeInitialBackoffMs;
 	private long originalSentinelCleanupInitialBackoffMs;
+	private long originalCreateIndexInitialBackoffMs;
 
 	@BeforeEach
 	public void setUp() {
@@ -152,6 +153,8 @@ public class OpenSearchManagerImplTest {
 		OpenSearchManagerImpl.INDEX_WRITABLE_INITIAL_BACKOFF_MS = 1L;
 		originalSentinelCleanupInitialBackoffMs = OpenSearchManagerImpl.SENTINEL_CLEANUP_INITIAL_BACKOFF_MS;
 		OpenSearchManagerImpl.SENTINEL_CLEANUP_INITIAL_BACKOFF_MS = 1L;
+		originalCreateIndexInitialBackoffMs = OpenSearchManagerImpl.CREATE_INDEX_INITIAL_BACKOFF_MS;
+		OpenSearchManagerImpl.CREATE_INDEX_INITIAL_BACKOFF_MS = 1L;
 	}
 
 	@AfterEach
@@ -159,6 +162,7 @@ public class OpenSearchManagerImplTest {
 		OpenSearchManagerImpl.BULK_INDEX_INITIAL_BACKOFF_MS = originalBulkInitialBackoffMs;
 		OpenSearchManagerImpl.INDEX_WRITABLE_INITIAL_BACKOFF_MS = originalProbeInitialBackoffMs;
 		OpenSearchManagerImpl.SENTINEL_CLEANUP_INITIAL_BACKOFF_MS = originalSentinelCleanupInitialBackoffMs;
+		OpenSearchManagerImpl.CREATE_INDEX_INITIAL_BACKOFF_MS = originalCreateIndexInitialBackoffMs;
 	}
 
 	/**
@@ -1016,6 +1020,23 @@ public class OpenSearchManagerImplTest {
 
 		assertEquals(ioException, ex.getCause());
 		assertEquals("Failed to create search index: " + indexName, ex.getMessage());
+	}
+
+	@Test
+	public void testCreateIndexWithTransientIOExceptionRetriesThenSucceeds() throws IOException {
+		String indexName = "search-index-syn1";
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		when(indicesClient.create(argThat((CreateIndexRequest req) -> indexName.equals(req.index()))))
+				.thenThrow(new IOException("read timed out"))
+				.thenReturn(org.opensearch.client.opensearch.indices.CreateIndexResponse.of(
+						r -> r.acknowledged(true).shardsAcknowledged(true).index(indexName)));
+
+		// call under test
+		Optional<String> result = manager.createIndex(indexName, Collections.emptyList(), null,
+				Collections.emptyList(), Collections.emptyMap(), 0, 1, 0);
+
+		assertTrue(result.isPresent());
+		verify(indicesClient, times(2)).create(any(CreateIndexRequest.class));
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

A CI build failed with a single test error:

```
[ERROR] testRoundTripWithColumnAnalyzerOverride  <<< ERROR!
java.lang.RuntimeException: Failed to create search index: test-index-010728cb
Caused by: java.net.SocketTimeoutException: Read timed out
```

`OpenSearchManagerImpl.createIndex` was the only OpenSearch transport call in the class without a retry wrapper. Every sibling call (`waitForIndexWritable`, sentinel cleanup, `bulkIndex`, `validateOneAnalyzerEntry`) wraps its call in `TimeUtils.waitForExponentialMaxRetry` and treats `IOException` as retryable. A single transient socket read-timeout on `indices().create()` therefore failed the whole build outright.

## Fix

Wrap the `indices().create()` call in `TimeUtils.waitForExponentialMaxRetry` (3 attempts, 1000ms initial backoff), treating `IOException`/`SocketTimeoutException` as retryable. Permanent-error semantics are unchanged:

- `resource_already_exists_exception` → `Optional.empty()` (no retry)
- other `OpenSearchException` → `RuntimeException` with error detail
- not-acknowledged → `IllegalStateException`
- exhausted retries → `RuntimeException("Failed to create search index: ...")` with the original `IOException` cause

## Tests

- New unit test: transient `IOException` then success → one retry, index created.
- Existing `createIndex` tests (persistent IOException, already-exists, not-acknowledged, permanent OpenSearchException) pass unchanged.
- Full `OpenSearchManagerImplTest`: 157/157 pass.