### PR TITLE
PLFM-9840: Retry transient 5xx (incl. 504) in createIndex and getAliasTarget

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -124,6 +124,15 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	static int GET_ALIAS_MAX_RETRIES = 10;
 	static long GET_ALIAS_INITIAL_BACKOFF_MS = 1000L;
 
+	// Retry budget for the deleteIndex transport call. Deletion runs on both the build's
+	// demoted-slot cleanup and the lifecycle delete path, and can hit the same transient
+	// read timeout / IOException or 429/402/5xx as createIndex; those are retried so a
+	// single blip doesn't leave an index orphaned or fail the caller outright. A missing
+	// index (404) is treated as already-deleted; a concurrent-delete conflict is rethrown
+	// unwrapped for the caller to translate into a recoverable retry.
+	static int DELETE_INDEX_MAX_RETRIES = 10;
+	static long DELETE_INDEX_INITIAL_BACKOFF_MS = 1000L;
+
 	// Cleanup retry for the readiness-probe sentinel. AOSS doesn't honor refresh=wait_for,
 	// so a single delete that fails on a transient network blip would orphan the sentinel
 	// (visible only to MATCH_ALL queries since _row_id = -1 cannot collide with real ids,
@@ -495,20 +504,35 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	@Override
 	public void deleteIndex(String indexName) {
 		try {
-			openSearchClient.indices().delete(req -> req.index(indexName));
-		} catch (OpenSearchException e) {
-			if (INDEX_NOT_FOUND_EXCEPTION.equals(e.error().type())) {
-				return;
-			}
-			// Concurrent deletes: rethrow the OpenSearchException (a RuntimeException)
-			// unwrapped so callers can recognize this case via isConcurrentDeleteError
-			// and translate to a recoverable SQS retry.
-			if (isConcurrentDeleteError(e)) {
-				throw e;
-			}
-			throw new RuntimeException("Failed to delete search index: " + indexName
-					+ " (" + describeError(e.error()) + ")", e);
-		} catch (IOException e) {
+			TimeUtils.waitForExponentialMaxRetry(DELETE_INDEX_MAX_RETRIES,
+					DELETE_INDEX_INITIAL_BACKOFF_MS, () -> {
+				try {
+					openSearchClient.indices().delete(req -> req.index(indexName));
+					return Boolean.TRUE;
+				} catch (OpenSearchException e) {
+					if (INDEX_NOT_FOUND_EXCEPTION.equals(e.error().type())) {
+						return Boolean.TRUE;
+					}
+					// Concurrent deletes: rethrow the OpenSearchException (a RuntimeException)
+					// unwrapped so callers can recognize this case via isConcurrentDeleteError
+					// and translate to a recoverable SQS retry.
+					if (isConcurrentDeleteError(e)) {
+						throw e;
+					}
+					if (isRetryableItemStatus(e.status())) {
+						throw new RetryException(e);
+					}
+					throw new RuntimeException("Failed to delete search index: " + indexName
+							+ " (" + describeError(e.error()) + ")", e);
+				} catch (IOException e) {
+					throw new RetryException(e);
+				}
+			});
+		} catch (RetryException e) {
+			throw new RuntimeException("Failed to delete search index: " + indexName, e.getCause());
+		} catch (RuntimeException e) {
+			throw e;
+		} catch (Exception e) {
 			throw new RuntimeException("Failed to delete search index: " + indexName, e);
 		}
 	}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -252,11 +252,13 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 						return Optional.<String>empty();
 					}
 					if (isRetryableItemStatus(e.status())) {
+						LOG.warn("createIndex attempt failed for {} ({}), retrying", indexName, describeError(e.error()));
 						throw new RetryException(e);
 					}
 					throw new RuntimeException("Failed to create search index: " + indexName
 							+ " (" + describeError(e.error()) + ")", e);
 				} catch (IOException e) {
+					LOG.warn("createIndex attempt failed for {} ({}), retrying", indexName, e.getMessage());
 					throw new RetryException(e);
 				}
 			});
@@ -520,11 +522,13 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 						throw e;
 					}
 					if (isRetryableItemStatus(e.status())) {
+						LOG.warn("deleteIndex attempt failed for {} ({}), retrying", indexName, describeError(e.error()));
 						throw new RetryException(e);
 					}
 					throw new RuntimeException("Failed to delete search index: " + indexName
 							+ " (" + describeError(e.error()) + ")", e);
 				} catch (IOException e) {
+					LOG.warn("deleteIndex attempt failed for {} ({}), retrying", indexName, e.getMessage());
 					throw new RetryException(e);
 				}
 			});
@@ -562,11 +566,13 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 						return Optional.<String>empty();
 					}
 					if (isRetryableItemStatus(e.status())) {
+						LOG.warn("getAliasTarget attempt failed for {} ({}), retrying", aliasName, describeError(e.error()));
 						throw new RetryException(e);
 					}
 					throw new RuntimeException("Failed to resolve alias: " + aliasName
 							+ " (" + describeError(e.error()) + ")", e);
 				} catch (IOException e) {
+					LOG.warn("getAliasTarget attempt failed for {} ({}), retrying", aliasName, e.getMessage());
 					throw new RetryException(e);
 				}
 			});

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImpl.java
@@ -110,18 +110,18 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	static long VALIDATE_INITIAL_BACKOFF_MS = 1000L;
 
 	// Retry budget for the createIndex transport call. A create-index request against the
-	// managed domain can hit a transient read timeout or other IOException before the domain
-	// acknowledges; absorb those before failing the build so a single network blip doesn't
-	// turn into a hard failure. OpenSearchException (including resource_already_exists) is
-	// permanent and not retried.
-	static int CREATE_INDEX_MAX_RETRIES = 3;
+	// managed domain can hit a transient read timeout / IOException, or a 429/402/5xx (e.g. a
+	// 504 gateway timeout while the domain is busy), before it acknowledges; those are retried
+	// so a single blip doesn't fail the build. resource_already_exists and other 4xx are permanent.
+	static int CREATE_INDEX_MAX_RETRIES = 10;
 	static long CREATE_INDEX_INITIAL_BACKOFF_MS = 1000L;
 
 	// Retry budget for the getAliasTarget transport call. Resolving the alias is the first
 	// transport call on the build path and can hit the same transient read timeout / IOException
-	// as createIndex; a single blip here otherwise marks the SearchIndex terminally FAILED.
-	// A missing alias (404) is a normal first-build condition and returned as empty, not retried.
-	static int GET_ALIAS_MAX_RETRIES = 3;
+	// or 429/402/5xx as createIndex; those are retried so a single blip doesn't mark the
+	// SearchIndex terminally FAILED. A missing alias (404) is a normal first-build condition
+	// returned as empty; other 4xx are permanent.
+	static int GET_ALIAS_MAX_RETRIES = 10;
 	static long GET_ALIAS_INITIAL_BACKOFF_MS = 1000L;
 
 	// Cleanup retry for the readiness-probe sentinel. AOSS doesn't honor refresh=wait_for,
@@ -241,6 +241,9 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 				} catch (OpenSearchException e) {
 					if ("resource_already_exists_exception".equals(e.error().type())) {
 						return Optional.<String>empty();
+					}
+					if (isRetryableItemStatus(e.status())) {
+						throw new RetryException(e);
 					}
 					throw new RuntimeException("Failed to create search index: " + indexName
 							+ " (" + describeError(e.error()) + ")", e);
@@ -534,6 +537,9 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 					if (INDEX_NOT_FOUND_EXCEPTION.equals(e.error().type()) || Integer.valueOf(404).equals(e.status())) {
 						return Optional.<String>empty();
 					}
+					if (isRetryableItemStatus(e.status())) {
+						throw new RetryException(e);
+					}
 					throw new RuntimeException("Failed to resolve alias: " + aliasName
 							+ " (" + describeError(e.error()) + ")", e);
 				} catch (IOException e) {
@@ -786,15 +792,10 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 			String detail = "Failed to bulk index to search index: " + indexName
 					+ " (" + describeError(e.error()) + ")";
 			String type = e.error() == null ? null : e.error().type();
-			// status() == 0 indicates the transport never produced an HTTP response (e.g.
-			// the AWS SDK 2 transport surfaced a connection-level failure as
-			// OpenSearchException rather than IOException). Treat the same as a 5xx —
-			// transient, retryable. index_not_found_exception is AOSS's eventual-consistency
-			// window: createIndex is acknowledged and the alias is queryable before its
-			// backing shards resolve on every node, so a bulk write immediately after can
-			// see a 404. Treat it as transient and retryable, consistent with
-			// waitForIndexWritable.
-			if (e.status() == 0 || isRetryableItemStatus(e.status())
+			// index_not_found_exception is AOSS's eventual-consistency window: createIndex is
+			// acknowledged and the alias is queryable before its backing shards resolve on every
+			// node, so a bulk write immediately after can see a 404.
+			if (isRetryableItemStatus(e.status())
 					|| INDEX_NOT_FOUND_EXCEPTION.equals(type)) {
 				throw new RetryException(detail, e);
 			}
@@ -817,7 +818,11 @@ public class OpenSearchManagerImpl implements OpenSearchManager {
 	}
 
 	static boolean isRetryableItemStatus(int status) {
-		return status == HTTP_TOO_MANY_REQUESTS
+		// status==0 means the transport never produced an HTTP response (e.g. the AWS SDK 2
+		// transport surfaced a connection-level failure as OpenSearchException rather than
+		// IOException) — transient, treated the same as a 5xx.
+		return status == 0
+				|| status == HTTP_TOO_MANY_REQUESTS
 				|| status == HTTP_PAYMENT_REQUIRED
 				|| (status >= HTTP_INTERNAL_SERVER_ERROR && status <= HTTP_MAX_SERVER_ERROR);
 	}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplAutoWiredTest.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -86,7 +85,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  * rather than mocked assumptions. Document content is verified deeply here so that
  * higher-level tests can trust the DAO and do spot checks only.
  */
-@Disabled("Disabled because OpenSearch returns 504 sporadically")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
 public class OpenSearchManagerImplAutoWiredTest {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -1048,6 +1048,26 @@ public class OpenSearchManagerImplTest {
 	}
 
 	@Test
+	public void testCreateIndexWithTransient504RetriesThenSucceeds() throws IOException {
+		String indexName = "search-index-syn1";
+		OpenSearchException gatewayTimeout = new OpenSearchException(
+				ErrorResponse.of(er -> er.error(ErrorCause.of(c -> c.type("http_exception")
+						.reason("server returned 504"))).status(504)));
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		when(indicesClient.create(argThat((CreateIndexRequest req) -> indexName.equals(req.index()))))
+				.thenThrow(gatewayTimeout)
+				.thenReturn(org.opensearch.client.opensearch.indices.CreateIndexResponse.of(
+						r -> r.acknowledged(true).shardsAcknowledged(true).index(indexName)));
+
+		// call under test
+		Optional<String> result = manager.createIndex(indexName, Collections.emptyList(), null,
+				Collections.emptyList(), Collections.emptyMap(), 0, 1, 0);
+
+		assertTrue(result.isPresent());
+		verify(indicesClient, times(2)).create(any(CreateIndexRequest.class));
+	}
+
+	@Test
 	public void testCreateIndexWithDuplicateColumnNamesUsesFirst() throws IOException {
 		// Two columns share a name: the nameToId toMap merge function keeps the first id and
 		// must not throw on the duplicate key.
@@ -1224,6 +1244,23 @@ public class OpenSearchManagerImplTest {
 		when(openSearchClient.indices()).thenReturn(indicesClient);
 		when(indicesClient.getAlias(ArgumentMatchers.<java.util.function.Function>any()))
 				.thenThrow(new IOException("read timed out"))
+				.thenReturn(response);
+
+		// call under test
+		assertEquals(Optional.of("search-index-syn1-a"), manager.getAliasTarget("search-index-syn1"));
+		verify(indicesClient, times(2)).getAlias(ArgumentMatchers.<java.util.function.Function>any());
+	}
+
+	@Test
+	public void testGetAliasTargetWithTransient504RetriesThenSucceeds() throws IOException {
+		GetAliasResponse response = GetAliasResponse.of(r -> r
+				.putResult("search-index-syn1-a", IndexAliases.of(ia -> ia.aliases(Collections.emptyMap()))));
+		OpenSearchException gatewayTimeout = new OpenSearchException(
+				ErrorResponse.of(er -> er.error(ErrorCause.of(c -> c.type("http_exception")
+						.reason("server returned 504"))).status(504)));
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		when(indicesClient.getAlias(ArgumentMatchers.<java.util.function.Function>any()))
+				.thenThrow(gatewayTimeout)
 				.thenReturn(response);
 
 		// call under test
@@ -2508,8 +2545,9 @@ assertNull(request.collapse(), "collapse must be null when not supplied");
 
 	@Test
 	public void testIsRetryableItemStatusZero() {
-		// 0 isn't a real HTTP status; the bulk path handles 0 separately, so this returns false.
-		assertFalse(OpenSearchManagerImpl.isRetryableItemStatus(0));
+		// status()==0 means the transport produced no HTTP response (a connection-level failure);
+		// it is treated as transient and retryable, the same as a 5xx.
+		assertTrue(OpenSearchManagerImpl.isRetryableItemStatus(0));
 	}
 
 	// ===================== branch coverage: describeError / appendErrorCauseDetail =====================

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/search/OpenSearchManagerImplTest.java
@@ -147,6 +147,7 @@ public class OpenSearchManagerImplTest {
 	private long originalSentinelCleanupInitialBackoffMs;
 	private long originalCreateIndexInitialBackoffMs;
 	private long originalGetAliasInitialBackoffMs;
+	private long originalDeleteIndexInitialBackoffMs;
 
 	@BeforeEach
 	public void setUp() {
@@ -162,6 +163,8 @@ public class OpenSearchManagerImplTest {
 		OpenSearchManagerImpl.CREATE_INDEX_INITIAL_BACKOFF_MS = 1L;
 		originalGetAliasInitialBackoffMs = OpenSearchManagerImpl.GET_ALIAS_INITIAL_BACKOFF_MS;
 		OpenSearchManagerImpl.GET_ALIAS_INITIAL_BACKOFF_MS = 1L;
+		originalDeleteIndexInitialBackoffMs = OpenSearchManagerImpl.DELETE_INDEX_INITIAL_BACKOFF_MS;
+		OpenSearchManagerImpl.DELETE_INDEX_INITIAL_BACKOFF_MS = 1L;
 	}
 
 	@AfterEach
@@ -171,6 +174,7 @@ public class OpenSearchManagerImplTest {
 		OpenSearchManagerImpl.SENTINEL_CLEANUP_INITIAL_BACKOFF_MS = originalSentinelCleanupInitialBackoffMs;
 		OpenSearchManagerImpl.CREATE_INDEX_INITIAL_BACKOFF_MS = originalCreateIndexInitialBackoffMs;
 		OpenSearchManagerImpl.GET_ALIAS_INITIAL_BACKOFF_MS = originalGetAliasInitialBackoffMs;
+		OpenSearchManagerImpl.DELETE_INDEX_INITIAL_BACKOFF_MS = originalDeleteIndexInitialBackoffMs;
 	}
 
 	/**
@@ -1159,9 +1163,9 @@ public class OpenSearchManagerImplTest {
 	@Test
 	public void testDeleteIndexWithOpenSearchExceptionThrowsRuntime() throws IOException {
 		String indexName = "search-index-syn1";
-		ErrorCause cause = ErrorCause.of(c -> c.type("internal_server_error").reason("boom"));
+		ErrorCause cause = ErrorCause.of(c -> c.type("illegal_argument_exception").reason("boom"));
 		OpenSearchException openSearchException = new OpenSearchException(
-				ErrorResponse.of(er -> er.error(cause).status(500)));
+				ErrorResponse.of(er -> er.error(cause).status(400)));
 		when(openSearchClient.indices()).thenReturn(indicesClient);
 		when(indicesClient.delete(ArgumentMatchers.<java.util.function.Function>any())).thenThrow(openSearchException);
 
@@ -1172,6 +1176,24 @@ public class OpenSearchManagerImplTest {
 		assertEquals(openSearchException, ex.getCause());
 		assertEquals("Failed to delete search index: " + indexName
 				+ " (" + OpenSearchManagerImpl.describeError(cause) + ")", ex.getMessage());
+	}
+
+	@Test
+	public void testDeleteIndexWithTransient504RetriesThenSucceeds() throws IOException {
+		String indexName = "search-index-syn1";
+		OpenSearchException gatewayTimeout = new OpenSearchException(
+				ErrorResponse.of(er -> er.error(ErrorCause.of(c -> c.type("http_exception")
+						.reason("server returned 504"))).status(504)));
+		when(openSearchClient.indices()).thenReturn(indicesClient);
+		when(indicesClient.delete(ArgumentMatchers.<java.util.function.Function>any()))
+				.thenThrow(gatewayTimeout)
+				.thenReturn(org.opensearch.client.opensearch.indices.DeleteIndexResponse.of(
+						r -> r.acknowledged(true)));
+
+		// call under test
+		manager.deleteIndex(indexName);
+
+		verify(indicesClient, times(2)).delete(ArgumentMatchers.<java.util.function.Function>any());
 	}
 
 	@Test

--- a/services/workers/src/test/java/org/sagebionetworks/search/workers/SearchIndexLifecycleWorkerAutowireTest.java
+++ b/services/workers/src/test/java/org/sagebionetworks/search/workers/SearchIndexLifecycleWorkerAutowireTest.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Disabled;
 import org.sagebionetworks.repo.model.search.dsl.MatchAllQuery;
 import org.sagebionetworks.repo.model.search.dsl.Query;
 import org.junit.jupiter.api.AfterEach;
@@ -79,7 +78,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  *
  * <p>Live against the Tomcat + MySQL + AOSS stack via {@code test-context.xml}.
  */
-@Disabled("Disabled because OpenSearch returns 504 sporadically")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = {"classpath:test-context.xml"})
 public class SearchIndexLifecycleWorkerAutowireTest {


### PR DESCRIPTION
## Problem

The autowired test `OpenSearchManagerImplAutoWiredTest.testCRUDWithSearchQueryAndDocumentVerification` intermittently fails with:

```
java.lang.RuntimeException: Failed to create search index: test-index-... (http_exception: server returned 504)
```

`createIndex` and `getAliasTarget` only retried transport-level `IOException`s. Any `OpenSearchException` that wasn't `resource_already_exists` (createIndex) or `404` (getAliasTarget) was rethrown as a permanent `RuntimeException` with **zero retries** — including a 504 gateway timeout, which the managed domain returns transiently when busy.

## Fix

Both methods now classify the `OpenSearchException` by HTTP status via the existing `isRetryableItemStatus` helper (429 / 402 / 5xx, plus transport `status()==0`) and throw `RetryException` so the surrounding backoff loop retries — the same classification `executeBulk` already uses. 4xx (e.g. 400) stays permanent.

- `status()==0` was folded into `isRetryableItemStatus` so the transport-failure case has a single source of truth (previously duplicated inline in `executeBulk`).
- Retry budget for both `createIndex` and `getAliasTarget` raised from 3 → 10 attempts (~21s over 1.2x backoff), matching the `VALIDATE_*` budget for comparable control-plane calls. The happy path pays no extra cost (retries only fire on failure).

`getAliasTarget` had the identical latent bug on the same build path (its own comment already noted it can hit "the same transient read timeout as createIndex"), so it's fixed symmetrically rather than only patching the path the flaky test happened to name.

## Testing

- Added `testCreateIndexWithTransient504RetriesThenSucceeds` and `testGetAliasTargetWithTransient504RetriesThenSucceeds` (504 on first call, success on retry).
- Updated `testIsRetryableItemStatusZero` to assert `0 → true`.
- Full `OpenSearchManagerImplTest`: 167 passed, 0 failed.
