### PR TITLE
Fix migration restore when a backup ID column has been renamed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,13 @@ When a DB column is renamed (e.g., `PROJECT_ID` → `OBJECT_ID`), the backup XML
 2. **Stack N+1** (after production has the new column):
    - Remove the old bridge field (`projectId`) and the translator bridge logic. The new field is now the sole source of truth.
 
+Renaming a **backup ID** column needs one more bridge on top of the field bridge above, because a backup's `BackupManifest` records the backup ID column name as it was on the *source* stack, and the destination ranges over that column when deleting the rows it is about to restore:
+
+1. **Stack N**: declare the rename on the backup ID `FieldColumn` — `.withIsBackupId(true).withPreviousColumnName(COL_OLD_NAME)`. The destination then recognizes the old name as referring to the new column. Mark it `@TemporaryCode`.
+2. **Stack N+1**: remove `withPreviousColumnName`. Once production records the new name, a still-declared bridge logs a warning naming the column to clean up; it is otherwise harmless.
+
+The bridge is deliberately opt-in per column: an undeclared column name is passed through to the database and fails loudly, because ranging over the wrong column would delete the wrong rows.
+
 ## Curation Grid (Curator)
 
 See `services/repository-managers/CLAUDE.md` and `lib/lib-grid/CLAUDE.md` for the CRDT-based grid architecture, WebSocket protocol, and AI agent integration.

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/FieldColumn.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/FieldColumn.java
@@ -21,7 +21,8 @@ public class FieldColumn {
 	private boolean isBackupId = false;
 	private boolean isSelfForeignKey = false;
 	private boolean hasFileHandleRef = false;
-	
+	private String previousColumnName = null;
+
 	/**
 	 * @param fieldName - the name of the field as declared in the DBO class.
 	 * @param columnName - the name of the column in the database
@@ -164,9 +165,35 @@ public class FieldColumn {
 		return this;
 	}
 	
+	/**
+	 * The name this column had in the previous release, when it has been renamed.
+	 *
+	 * @return Null unless a rename was declared via {@link #withPreviousColumnName(String)}
+	 */
+	public String getPreviousColumnName() {
+		return previousColumnName;
+	}
+
+	/**
+	 * Declare that this column was renamed, naming the column it replaces. Only meaningful on the backup ID column of a
+	 * MigratableDatabaseObject: a migration source that predates the rename records the old name in its backup manifest,
+	 * and the destination needs to recognize that name as referring to this column.
+	 * <p>
+	 * This is a temporary bridge for a single release. Remove it once production has been deployed with the new column
+	 * name, at which point no manifest names the old column any more.
+	 *
+	 * @param previousColumnName The name of the column in the release before the rename
+	 * @return This {@link FieldColumn} reference for chaining
+	 */
+	public FieldColumn withPreviousColumnName(String previousColumnName) {
+		this.previousColumnName = previousColumnName;
+		return this;
+	}
+
 	@Override
 	public int hashCode() {
-		return Objects.hash(columnName, fieldName, isBackupId, isEtag, hasFileHandleRef, isPrimaryKey, isSelfForeignKey);
+		return Objects.hash(columnName, fieldName, isBackupId, isEtag, hasFileHandleRef, isPrimaryKey, isSelfForeignKey,
+				previousColumnName);
 	}
 
 	@Override
@@ -183,14 +210,14 @@ public class FieldColumn {
 		FieldColumn other = (FieldColumn) obj;
 		return Objects.equals(columnName, other.columnName) && Objects.equals(fieldName, other.fieldName) && isBackupId == other.isBackupId
 				&& isEtag == other.isEtag && hasFileHandleRef == other.hasFileHandleRef && isPrimaryKey == other.isPrimaryKey
-				&& isSelfForeignKey == other.isSelfForeignKey;
+				&& isSelfForeignKey == other.isSelfForeignKey && Objects.equals(previousColumnName, other.previousColumnName);
 	}
 
 	@Override
 	public String toString() {
 		return "FieldColumn [fieldName=" + fieldName + ", columnName=" + columnName + ", isPrimaryKey=" + isPrimaryKey + ", isEtag="
 				+ isEtag + ", isBackupId=" + isBackupId + ", isSelfForeignKey=" + isSelfForeignKey + ", isFileHandleRef=" + hasFileHandleRef
-				+ "]";
+				+ ", previousColumnName=" + previousColumnName + "]";
 	}
 
 }

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/migration/MigratableTableDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/migration/MigratableTableDAOImpl.java
@@ -599,16 +599,53 @@ public class MigratableTableDAOImpl implements MigratableTableDAO {
 	@MigrationWriteTransaction
 	public int deleteByRange(final TypeData type, final long minimumId, final long maximumId) {
 		ValidateArgument.required(type, "MigrationType");
+		final MigrationType migrationType = MigrationType.valueOf(type.getMigrationType());
 		// Foreign Keys must be ignored for this operation.
 		return this.runWithKeyChecksIgnored(() -> {
-			String deleteSQLTemplate = this.deleteByRangeMap.get(MigrationType.valueOf(type.getMigrationType()));
-			String sql = String.format(deleteSQLTemplate, type.getBackupIdColumnName());
+			String deleteSQLTemplate = this.deleteByRangeMap.get(migrationType);
+			String sql = String.format(deleteSQLTemplate,
+					resolveBackupIdColumnName(migrationType, type.getBackupIdColumnName()));
 			NamedParameterJdbcTemplate namedTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
 			Map<String, Object> parameters = new HashMap<>(2);
 			parameters.put(DMLUtils.BIND_MIN_ID, minimumId);
 			parameters.put(DMLUtils.BIND_MAX_ID, maximumId);
 			return namedTemplate.update(sql, parameters);
 		});
+	}
+
+	/**
+	 * Determine the column of this stack's table that holds the backup IDs of a range defined by the migration source.
+	 * The source's name is used as-is unless this type has declared that its backup ID column was renamed away from
+	 * that name.
+	 *
+	 * @param sourceBackupIdColumnName The backup ID column name recorded in the source's manifest
+	 * @return The column to range over on this stack
+	 */
+	String resolveBackupIdColumnName(MigrationType type, String sourceBackupIdColumnName) {
+		FieldColumn backupIdColumn = this.backupIdColumns.get(type);
+		String previousColumnName = backupIdColumn.getPreviousColumnName();
+		if (previousColumnName != null) {
+			if (previousColumnName.equalsIgnoreCase(sourceBackupIdColumnName)) {
+				// The source predates the rename, so its range is expressed in the old column's values. The current
+				// column replaced it and holds those same values.
+				log.info("Migration source named the pre-rename backup ID column '{}' for type {}; ranging over '{}'.",
+						sourceBackupIdColumnName, type, backupIdColumn.getColumnName());
+				return backupIdColumn.getColumnName();
+			}
+			if (backupIdColumn.getColumnName().equalsIgnoreCase(sourceBackupIdColumnName)) {
+				// The source has been deployed with the rename, so nothing names the old column any more. Harmless,
+				// but the bridge is now dead code.
+				log.warn("Migration source named the current backup ID column '{}' for type {}, so the rename bridge"
+						+ " from '{}' is no longer needed and can be removed.", sourceBackupIdColumnName, type,
+						previousColumnName);
+			}
+		}
+		/*
+		 * A manifest's ID range is expressed in the values of the source stack's backup ID column, so that column is
+		 * named directly. Any name this stack does not recognize is passed through so that the database rejects it,
+		 * rather than silently deleting by some other column.
+		 */
+		return sourceBackupIdColumnName;
 	}
 
 	@Override

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/persistence/table/DBODefiningSqlDependency.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/persistence/table/DBODefiningSqlDependency.java
@@ -37,8 +37,14 @@ public class DBODefiningSqlDependency
 
 	private static final String MATERIALIZED_VIEW_TYPE = ObjectType.MATERIALIZED_VIEW.name();
 
+	// The backup ID column name used by the release before this table was generalized. A migration source running that
+	// release records this name in its backup manifest.
+	@TemporaryCode(author = "BryanFauble", comment = "Remove this and the withPreviousColumnName bridge below once production records OBJECT_ID as the backup ID column in its migration manifest.")
+	private static final String LEGACY_BACKUP_ID_COLUMN = "MATERIALIZED_VIEW_ID";
+
 	private static final FieldColumn[] FIELDS = new FieldColumn[] {
-		new FieldColumn("objectId", COL_DEFINING_SQL_DEP_OBJECT_ID, true).withIsBackupId(true),
+		new FieldColumn("objectId", COL_DEFINING_SQL_DEP_OBJECT_ID, true).withIsBackupId(true)
+				.withPreviousColumnName(LEGACY_BACKUP_ID_COLUMN),
 		new FieldColumn("objectVersion", COL_DEFINING_SQL_DEP_OBJECT_VERSION, true),
 		new FieldColumn("objectType", COL_DEFINING_SQL_DEP_OBJECT_TYPE),
 		new FieldColumn("sourceTableId", COL_DEFINING_SQL_DEP_SOURCE_TABLE_ID, true),

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/persistence/table/DBODefiningSqlObject.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/persistence/table/DBODefiningSqlObject.java
@@ -17,6 +17,7 @@ import org.sagebionetworks.repo.model.dbo.TableMapping;
 import org.sagebionetworks.repo.model.dbo.migration.BasicMigratableTableTranslation;
 import org.sagebionetworks.repo.model.dbo.migration.MigratableTableTranslation;
 import org.sagebionetworks.repo.model.migration.MigrationType;
+import org.sagebionetworks.util.TemporaryCode;
 
 /**
  * This DBO represents the node identifier of a defining-SQL object (e.g. a materialized view or a
@@ -29,8 +30,15 @@ public class DBODefiningSqlObject implements MigratableDatabaseObject<DBODefinin
 
 	private static final List<MigratableDatabaseObject<?, ?>> SECONDARY_OBJECTS = Arrays.asList(new DBODefiningSqlDependency());
 	private static final MigratableTableTranslation<DBODefiningSqlObject, DBODefiningSqlObject> TRANSLATOR = new BasicMigratableTableTranslation<>();
+
+	// The backup ID column name used by the release before this table was generalized. A migration source running that
+	// release records this name in its backup manifest.
+	@TemporaryCode(author = "BryanFauble", comment = "Remove this and the withPreviousColumnName bridge below once production records OBJECT_ID as the backup ID column in its migration manifest.")
+	private static final String LEGACY_BACKUP_ID_COLUMN = "MATERIALIZED_VIEW_ID";
+
 	private static final FieldColumn[] FIELDS = new FieldColumn[] {
-		new FieldColumn("id", COL_DEFINING_SQL_OBJECT_ID, true).withIsBackupId(true),
+		new FieldColumn("id", COL_DEFINING_SQL_OBJECT_ID, true).withIsBackupId(true)
+				.withPreviousColumnName(LEGACY_BACKUP_ID_COLUMN),
 		new FieldColumn("etag", COL_DEFINING_SQL_OBJECT_ETAG).withIsEtag(true)
 	};
 

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/migration/MigratableTableDAOImplAutowireTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/migration/MigratableTableDAOImplAutowireTest.java
@@ -28,6 +28,7 @@ import org.sagebionetworks.StackConfiguration;
 import org.sagebionetworks.ids.IdGenerator;
 import org.sagebionetworks.ids.IdType;
 import org.sagebionetworks.repo.model.AuthorizationConstants.BOOTSTRAP_PRINCIPAL;
+import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.UserProfile;
 import org.sagebionetworks.repo.model.UserProfileDAO;
 import org.sagebionetworks.repo.model.dao.table.ColumnModelDAO;
@@ -41,6 +42,8 @@ import org.sagebionetworks.repo.model.dbo.file.FileHandleDao;
 import org.sagebionetworks.repo.model.dbo.persistence.DBOCredential;
 import org.sagebionetworks.repo.model.dbo.persistence.DBONode;
 import org.sagebionetworks.repo.model.dbo.persistence.table.DBOColumnModel;
+import org.sagebionetworks.repo.model.dbo.persistence.table.DBODefiningSqlDependency;
+import org.sagebionetworks.repo.model.dbo.persistence.table.DBODefiningSqlObject;
 import org.sagebionetworks.repo.model.dbo.schema.DBOOrganization;
 import org.sagebionetworks.repo.model.dbo.schema.JsonSchemaDao;
 import org.sagebionetworks.repo.model.dbo.schema.OrganizationDao;
@@ -427,7 +430,113 @@ public class MigratableTableDAOImplAutowireTest {
 		count = migratableTableDAO.deleteByRange(typeData, minId, maxId+1);
 		assertEquals(1, count);
 	}
-	
+
+	/**
+	 * A type that has not declared a rename must not silently range over some other column: deleting by the wrong
+	 * column would remove the wrong rows, so an unrecognized name has to reach the database and be rejected.
+	 */
+	@Test
+	public void testDeleteByRangeWithUndeclaredColumnName() {
+		ColumnModel one = new ColumnModel();
+		one.setColumnType(ColumnType.INTEGER);
+		one.setName("one");
+		one = columnModelDao.createColumnModel(one);
+		long id = Long.parseLong(one.getId());
+
+		TypeData typeData = new TypeData().setMigrationType(MigrationType.COLUMN_MODEL.name())
+				.setBackupIdColumnName("SOME_UNKNOWN_COLUMN");
+
+		// call under test
+		assertThrows(RuntimeException.class, () -> migratableTableDAO.deleteByRange(typeData, id, id));
+
+		// the row is untouched.
+		assertEquals(one, columnModelDao.getColumnModel(one.getId()));
+	}
+
+	/**
+	 * Regression for the migration failure caused by generalizing the materialized view source tables: both types kept
+	 * their MigrationType but renamed their backup id column from MATERIALIZED_VIEW_ID to OBJECT_ID, so a manifest
+	 * written by a stack that predates the rename names a column these tables no longer have.
+	 */
+	@Test
+	public void testDeleteByRangeWithLegacyMaterializedViewColumnName() {
+		long objectId = 987654321L;
+
+		DBODefiningSqlObject object = new DBODefiningSqlObject();
+		object.setId(objectId);
+		object.setEtag(UUID.randomUUID().toString());
+		migratableTableDAO.createOrUpdate(MigrationType.MATERIALIZED_VIEW_ID, Lists.newArrayList(object));
+
+		DBODefiningSqlDependency dependency = new DBODefiningSqlDependency();
+		dependency.setObjectId(objectId);
+		dependency.setObjectVersion(-1L);
+		dependency.setObjectType(ObjectType.MATERIALIZED_VIEW.name());
+		dependency.setSourceTableId(123L);
+		dependency.setSourceTableVersion(-1L);
+		migratableTableDAO.createOrUpdate(MigrationType.MATERIALIZED_VIEW_SOURCE_TABLE, Lists.newArrayList(dependency));
+
+		TypeData secondaryType = new TypeData()
+				.setMigrationType(MigrationType.MATERIALIZED_VIEW_SOURCE_TABLE.name())
+				.setBackupIdColumnName("MATERIALIZED_VIEW_ID");
+		TypeData primaryType = new TypeData().setMigrationType(MigrationType.MATERIALIZED_VIEW_ID.name())
+				.setBackupIdColumnName("MATERIALIZED_VIEW_ID");
+
+		// call under test - secondaries are deleted before their primary, as they are on restore.
+		int secondaryCount = migratableTableDAO.deleteByRange(secondaryType, objectId, objectId);
+		int primaryCount = migratableTableDAO.deleteByRange(primaryType, objectId, objectId);
+
+		assertEquals(1, secondaryCount);
+		assertEquals(1, primaryCount);
+	}
+
+	@Test
+	public void testResolveBackupIdColumnNameWithCurrentColumnName() {
+		// call under test
+		String result = migratableTableDAO.resolveBackupIdColumnName(MigrationType.NODE, "ID");
+
+		assertEquals("ID", result);
+	}
+
+	@Test
+	public void testResolveBackupIdColumnNameWithoutDeclaredRename() {
+		// NODE declares no rename, so an unrecognized name is passed through to fail against the database.
+		// call under test
+		String result = migratableTableDAO.resolveBackupIdColumnName(MigrationType.NODE, "SOME_UNKNOWN_COLUMN");
+
+		assertEquals("SOME_UNKNOWN_COLUMN", result);
+	}
+
+	@Test
+	public void testResolveBackupIdColumnNameWithDeclaredRename() {
+		// call under test
+		String result = migratableTableDAO.resolveBackupIdColumnName(MigrationType.MATERIALIZED_VIEW_SOURCE_TABLE,
+				"MATERIALIZED_VIEW_ID");
+
+		assertEquals("OBJECT_ID", result);
+	}
+
+	@Test
+	public void testResolveBackupIdColumnNameWithDeclaredRenameOnPrimary() {
+		// call under test
+		String result = migratableTableDAO.resolveBackupIdColumnName(MigrationType.MATERIALIZED_VIEW_ID,
+				"MATERIALIZED_VIEW_ID");
+
+		assertEquals("OBJECT_ID", result);
+	}
+
+	/**
+	 * Once the source has been deployed with the rename it names the current column, leaving the bridge as dead code.
+	 * That is a cleanup signal only and must not change the resolved column.
+	 */
+	@Test
+	public void testResolveBackupIdColumnNameWithStaleDeclaredRename() {
+		// call under test
+		String result = migratableTableDAO.resolveBackupIdColumnName(MigrationType.MATERIALIZED_VIEW_SOURCE_TABLE,
+				"OBJECT_ID");
+
+		assertEquals("OBJECT_ID", result);
+	}
+
 	@Test
 	public void testCreateOrUpdate() {
 		// Note: Principal does not need to exists since foreign keys will be off.

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/migration/DefiningSqlDependencyMigrationRestoreAutowireTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/migration/DefiningSqlDependencyMigrationRestoreAutowireTest.java
@@ -6,12 +6,17 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sagebionetworks.repo.model.ObjectType;
 import org.sagebionetworks.repo.model.daemon.BackupAliasType;
 import org.sagebionetworks.repo.model.dbo.MigratableDatabaseObject;
+import org.sagebionetworks.repo.model.dbo.migration.MigratableTableDAO;
 import org.sagebionetworks.repo.model.dbo.persistence.table.DBODefiningSqlDependency;
+import org.sagebionetworks.repo.model.migration.BackupManifest;
+import org.sagebionetworks.repo.model.migration.MigrationType;
+import org.sagebionetworks.repo.model.migration.TypeData;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -28,14 +33,31 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * {@link BackupFileStream} runs the registered translator (the migration-restore path at
  * {@code BackupFileStreamImpl#readFileFromStream}) and must populate {@code objectId} /
  * {@code objectVersion} from the legacy fields and default {@code objectType} to
- * {@code MATERIALIZED_VIEW}.
+ * {@code MATERIALIZED_VIEW}. Restoring the same fixture through {@link MigrationManager} additionally covers the
+ * manifest-driven delete-by-range step.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:test-context.xml" })
 public class DefiningSqlDependencyMigrationRestoreAutowireTest {
 
+	private static final long LEGACY_OBJECT_ID = 555L;
+
 	@Autowired
 	private BackupFileStream backupFileStream;
+
+	@Autowired
+	private MigrationManager migrationManager;
+
+	@Autowired
+	private MigratableTableDAO migratableTableDao;
+
+	@AfterEach
+	public void after() {
+		migratableTableDao.deleteByRange(migratableTableDao.getTypeData(MigrationType.MATERIALIZED_VIEW_SOURCE_TABLE),
+				LEGACY_OBJECT_ID, LEGACY_OBJECT_ID);
+		migratableTableDao.deleteByRange(migratableTableDao.getTypeData(MigrationType.MATERIALIZED_VIEW_ID),
+				LEGACY_OBJECT_ID, LEGACY_OBJECT_ID);
+	}
 
 	@Test
 	public void testReadLegacyMaterializedViewSourceTableBackup() {
@@ -55,6 +77,43 @@ public class DefiningSqlDependencyMigrationRestoreAutowireTest {
 		expected.setSourceTableVersion(-1L);
 
 		assertEquals(List.of(expected), restored);
+	}
+
+	/**
+	 * The manifest a pre-rename production stack writes names its own backup id column,
+	 * {@code MATERIALIZED_VIEW_ID}, which the renamed tables here no longer have. Restoring through the real entry
+	 * point covers the delete-by-range step that the read-only test above bypasses.
+	 */
+	@Test
+	public void testRestoreStreamWithLegacyManifest() {
+		InputStream stream = getClass().getClassLoader()
+				.getResourceAsStream("MaterializedViewSourceTableLegacyBackup.zip");
+
+		BackupManifest manifest = new BackupManifest().setAliasType(BackupAliasType.MIGRATION_TYPE_NAME)
+				.setBatchSize(100L).setMinimumId(LEGACY_OBJECT_ID).setMaximumId(LEGACY_OBJECT_ID)
+				.setPrimaryType(new TypeData().setMigrationType(MigrationType.MATERIALIZED_VIEW_ID.name())
+						.setBackupIdColumnName("MATERIALIZED_VIEW_ID"))
+				.setSecondaryTypes(List.of(
+						new TypeData().setMigrationType(MigrationType.MATERIALIZED_VIEW_SOURCE_TABLE.name())
+								.setBackupIdColumnName("MATERIALIZED_VIEW_ID")));
+
+		// Call under test
+		long restoredRowCount = migrationManager.restoreStream(stream, manifest).getRestoredRowCount();
+
+		assertEquals(1L, restoredRowCount);
+
+		DBODefiningSqlDependency expected = new DBODefiningSqlDependency();
+		expected.setObjectId(LEGACY_OBJECT_ID);
+		expected.setObjectVersion(-1L);
+		expected.setObjectType(ObjectType.MATERIALIZED_VIEW.name());
+		expected.setSourceTableId(123L);
+		expected.setSourceTableVersion(-1L);
+
+		List<MigratableDatabaseObject<?, ?>> persisted = new ArrayList<>();
+		migratableTableDao.streamDatabaseObjects(MigrationType.MATERIALIZED_VIEW_SOURCE_TABLE, LEGACY_OBJECT_ID,
+				LEGACY_OBJECT_ID, 100L).forEach(persisted::add);
+
+		assertEquals(List.of(expected), persisted);
 	}
 
 }


### PR DESCRIPTION
Migration from production into the new stack fails with:

```
BadSqlGrammarException: bad SQL grammar
[DELETE FROM DEFINING_SQL_DEPENDENCY WHERE `MATERIALIZED_VIEW_ID` BETWEEN ? AND ?]
```

### Cause

`MigratableTableDAOImpl.deleteByRange` composed its DELETE from two stacks: the **table name** from the destination's own cached SQL template, but the **column name** interpolated straight out of the *source* stack's `BackupManifest`.

Generalizing the materialized view source fan-out renamed both tables and their backup ID columns (`MATERIALIZED_VIEW_ID` → `OBJECT_ID`) while keeping the existing `MigrationType` names. Production still runs the pre-rename code, so its manifest records `MATERIALIZED_VIEW_ID`, which the destination then pasted into its own renamed table.

Both `MATERIALIZED_VIEW_ID` and `MATERIALIZED_VIEW_SOURCE_TABLE` were affected — the secondary just surfaced first, because secondaries are deleted before their primary.

### Fix

Declare the rename on the backup ID `FieldColumn`:

```java
new FieldColumn("objectId", COL_DEFINING_SQL_DEP_OBJECT_ID, true)
        .withIsBackupId(true)
        .withPreviousColumnName(LEGACY_BACKUP_ID_COLUMN)
```

Only the declared previous name redirects to the current column. Every other name is passed through to the database exactly as before, so a type that has not opted in behaves identically to today, and an unrecognized column still fails loudly instead of ranging over the wrong column and deleting the wrong rows. Marked `@TemporaryCode` alongside the existing field-name bridge so both are removed together.

A stale bridge is harmless rather than fatal: once the source records the current column name the bridge no longer fires, and logs a warning naming the column to clean up.

### Testing

Verified against MySQL 8.0. Removing only the per-column declaration, with the framework support still in place, reproduces the original production error verbatim — confirming the behavior is entirely opt-in.

- `MigratableTableDAOImplAutowireTest` — 40 pass, incl. a regression test for the exact failure and one asserting an undeclared column still throws and leaves its row untouched
- `dbo.migration` package — 87 pass
- `MigrationManagerImplTest` — 67 pass
- `DefiningSqlDependencyMigrationRestoreAutowireTest` — gains an end-to-end `restoreStream` test driven by a production-shaped manifest