### PR TITLE
PLFM-9853 - Handle case where CSV data may not match column type

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/CsvDataStream.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/CsvDataStream.java
@@ -60,10 +60,19 @@ public class CsvDataStream implements DataStream {
 			String stringValue = currentRow[mapping.getCsvIndex()];
 			
 			if (mapping.isUpsertColumn()) {
+				// Upsert key columns are stored in a typed, NOT NULL temp table column and
+				// drive the join against the grid's temp table, so a value that cannot be
+				// represented as the column's type must fail the import rather than being
+				// carried through as text.
 				stringValue = checkUpsertKeyValue(stringValue);
+				values[i] = columnTranslators[i].translateNullable(stringValue).getValue();
+			} else {
+				// Non-key columns are packed untyped into a JSON array (see
+				// GridCsvImportDaoImpl#mapRow), so a value that doesn't fit the column's
+				// declared type — e.g. inferred from a different revision's data — is
+				// carried through as raw text instead of failing the whole import.
+				values[i] = columnTranslators[i].translateLeniently(stringValue).getValue();
 			}
-			
-			values[i] = columnTranslators[i].translateNullable(stringValue).getValue();
 		}
 		
 		return values;

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/row/translator/Translator.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/row/translator/Translator.java
@@ -30,5 +30,36 @@ public interface Translator {
 	 */
 	ConValue translate(String string);
 
+	default ConValue translateLeniently(String string) {
+		return translateLeniently(string, true);
+	}
+
+	/**
+	 * Like {@link #translateNullable(String, boolean)}, but never throws: a value
+	 * this translator's type cannot represent is carried through untranslated
+	 * rather than failing the caller. This is for callers re-reading data against
+	 * a schema that was not derived from (and so is not guaranteed to fit) the data
+	 * being read, e.g. a schema inferred from one CSV revision applied to another.
+	 * <p>
+	 * A blank value is treated as no value (the same result
+	 * {@link #translateNullable(String, boolean)} produces for {@code null}), since
+	 * a blank cell carries no type information for any column type. A non-blank
+	 * value this translator cannot parse is translated as {@link ConType#STRING}.
+	 *
+	 * @param string             the raw value; {@code null} is treated as no value.
+	 * @param isRequiredProperty whether a no-value result should be
+	 *                           {@link ConType#NULL} (required) or
+	 *                           {@link ConType#UNDEFINED} (not required).
+	 */
+	default ConValue translateLeniently(String string, boolean isRequiredProperty) {
+		try {
+			return translateNullable(string, isRequiredProperty);
+		} catch (RuntimeException e) {
+			if (string == null || string.trim().isEmpty()) {
+				return translateNullable(null, isRequiredProperty);
+			}
+			return new ConValue(ConType.STRING, string);
+		}
+	}
 
 }

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/row/translator/Translator.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/row/translator/Translator.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.repo.manager.grid.row.translator;
 
+import org.json.JSONException;
+
 import org.sagebionetworks.repo.model.grid.patch.ConType;
 import org.sagebionetworks.repo.model.grid.patch.ConValue;
 
@@ -36,15 +38,14 @@ public interface Translator {
 
 	/**
 	 * Like {@link #translateNullable(String, boolean)}, but never throws: a value
-	 * this translator's type cannot represent is carried through untranslated
-	 * rather than failing the caller. This is for callers re-reading data against
-	 * a schema that was not derived from (and so is not guaranteed to fit) the data
-	 * being read, e.g. a schema inferred from one CSV revision applied to another.
+	 * this translator's type cannot represent is translated as
+	 * {@link ConType#STRING} rather than failing the caller.
 	 * <p>
-	 * A blank value is treated as no value (the same result
-	 * {@link #translateNullable(String, boolean)} produces for {@code null}), since
-	 * a blank cell carries no type information for any column type. A non-blank
-	 * value this translator cannot parse is translated as {@link ConType#STRING}.
+	 * A blank value is treated as no value for column types whose translator cannot
+	 * represent one. Types that accept any string — STRING, BOOLEAN and the list
+	 * types — translate a blank value exactly as
+	 * {@link #translateNullable(String, boolean)} does, because leniency never
+	 * alters a translation that already succeeds.
 	 *
 	 * @param string             the raw value; {@code null} is treated as no value.
 	 * @param isRequiredProperty whether a no-value result should be
@@ -52,9 +53,18 @@ public interface Translator {
 	 *                           {@link ConType#UNDEFINED} (not required).
 	 */
 	default ConValue translateLeniently(String string, boolean isRequiredProperty) {
+		// Only the exceptions the translators actually throw are tolerated: a parse
+		// failure is an IllegalArgumentException (NumberFormatException, Joda's date
+		// parser) and org.json throws JSONException. A translator defect such as an
+		// NPE must still fail loudly rather than produce a text cell.
 		try {
 			return translateNullable(string, isRequiredProperty);
-		} catch (RuntimeException e) {
+		} catch (IllegalArgumentException | JSONException e) {
+			// This blank check MUST stay inside the catch rather than guarding the try:
+			// it must apply only to types whose translator rejects a blank value.
+			// Hoisting it would turn a blank STRING cell from "" into no value, which
+			// changes the row hash that RowSourceItem#getHash feeds to the sync's
+			// change detection, so unchanged rows would be reported as changed.
 			if (string == null || string.trim().isEmpty()) {
 				return translateNullable(null, isRequiredProperty);
 			}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/synch/handler/RecordSetSourceHandler.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/synch/handler/RecordSetSourceHandler.java
@@ -113,7 +113,16 @@ public class RecordSetSourceHandler implements SourceHandler {
 		this.recordSetExporter = recordSetExporter;
 		this.gridRowValidator = gridRowValidator;
 		this.nodeDao = nodeDao;
-		initialize();
+		try {
+			initialize();
+		} catch (RuntimeException | IOException e) {
+			// initialize() creates the temp file before it can fail (e.g. while loading
+			// the baseline revision). Since construction never completes, this handler
+			// is never returned to a try-with-resources, so close() would otherwise
+			// never run and the temp file would leak on every retry of a failing sync.
+			close();
+			throw e;
+		}
 	}
 
 	void initialize() throws IOException {
@@ -222,6 +231,16 @@ public class RecordSetSourceHandler implements SourceHandler {
 	 * rows. A blank key cell is stored as {@link ConType#UNDEFINED} rather than
 	 * translated, so a non-parseable (e.g. empty INTEGER) key value does not fail
 	 * the whole sync.
+	 *
+	 * <p>
+	 * This row's column types come from the <em>latest</em> revision's schema (see
+	 * {@link #initialize()}), but this method is also used to re-read the synced
+	 * <em>baseline</em> revision ({@link #loadBaselineHashes}) — an independent,
+	 * immutable CSV that may hold values incompatible with that schema (e.g. a
+	 * value inferred as an integer in the latest revision but alphanumeric in the
+	 * baseline). Translation is therefore lenient: a cell that cannot be
+	 * represented as its column's type is carried through as raw text instead of
+	 * failing the sync.
 	 */
 	RowSourceItem createSynchRow(String[] csvRow, Map<String, Integer> headerIndex) {
 		TreeMap<String, ConValue> data = new TreeMap<>();
@@ -233,7 +252,8 @@ public class RecordSetSourceHandler implements SourceHandler {
 				// possibly fail) — mark it undefined so it reads as a keyless row.
 				data.put(name, new ConValue(ConType.UNDEFINED, null));
 			} else {
-				data.put(name, translators.get(name).translateNullable(raw, requiredColumnNames.contains(name)));
+				data.put(name,
+						translators.get(name).translateLeniently(raw, requiredColumnNames.contains(name)));
 			}
 		}
 		String key = hasCompleteUpsertKey(data) ? UpsertKeyEncoder.encodeFromData(data, upsertKey)

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/synch/handler/RecordSetSourceHandler.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/grid/synch/handler/RecordSetSourceHandler.java
@@ -226,21 +226,7 @@ public class RecordSetSourceHandler implements SourceHandler {
 	 * A row with a complete upsertKey is keyed deterministically via
 	 * {@link UpsertKeyEncoder}, so it matches the grid copy row for the same logical
 	 * row. A row with an <em>incomplete</em> upsertKey (any key column null/blank)
-	 * cannot be matched, so it is given a fresh random UUID key. The UUID ensures
-	 * keyless rows are never matched to a copy row AND are always imported as new
-	 * rows. A blank key cell is stored as {@link ConType#UNDEFINED} rather than
-	 * translated, so a non-parseable (e.g. empty INTEGER) key value does not fail
-	 * the whole sync.
-	 *
-	 * <p>
-	 * This row's column types come from the <em>latest</em> revision's schema (see
-	 * {@link #initialize()}), but this method is also used to re-read the synced
-	 * <em>baseline</em> revision ({@link #loadBaselineHashes}) — an independent,
-	 * immutable CSV that may hold values incompatible with that schema (e.g. a
-	 * value inferred as an integer in the latest revision but alphanumeric in the
-	 * baseline). Translation is therefore lenient: a cell that cannot be
-	 * represented as its column's type is carried through as raw text instead of
-	 * failing the sync.
+	 * cannot be matched, so it is given a fresh random UUID key.
 	 */
 	RowSourceItem createSynchRow(String[] csvRow, Map<String, Integer> headerIndex) {
 		TreeMap<String, ConValue> data = new TreeMap<>();
@@ -252,10 +238,16 @@ public class RecordSetSourceHandler implements SourceHandler {
 				// possibly fail) — mark it undefined so it reads as a keyless row.
 				data.put(name, new ConValue(ConType.UNDEFINED, null));
 			} else {
-				data.put(name,
-						translators.get(name).translateLeniently(raw, requiredColumnNames.contains(name)));
+				// Column types come from the latest revision's schema, but this method also
+				// re-reads the synced baseline revision — an independent, immutable CSV that
+				// may hold a value that schema cannot represent (e.g. alphanumeric where the
+				// latest revision inferred an integer). Translate leniently so such a cell is
+				// carried through as text instead of failing the whole sync.
+				data.put(name, translators.get(name).translateLeniently(raw, requiredColumnNames.contains(name)));
 			}
 		}
+		// The UUID ensures keyless rows are never matched to a copy row AND are always
+		// imported as new rows.
 		String key = hasCompleteUpsertKey(data) ? UpsertKeyEncoder.encodeFromData(data, upsertKey)
 				: UUID.randomUUID().toString();
 		return new RowSourceItem(data, key);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/CsvDataStreamTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/CsvDataStreamTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.StringReader;
 
+import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sagebionetworks.repo.model.table.ColumnType;
@@ -179,5 +180,63 @@ public class CsvDataStreamTest {
 			new CsvDataStream(csvReader, columnMapping);
 		}).getMessage());
 		
+	}
+
+	/**
+	 * A blank cell in a non-key INTEGER column must not fail the import: blank
+	 * cells carry no type information during schema inference, so a column can
+	 * legitimately be typed INTEGER despite having blanks.
+	 */
+	@Test
+	public void testStreamWithBlankNonKeyIntegerCell() {
+		csvReader = new CSVReader(new StringReader(
+			"0,,data0" + System.lineSeparator()
+		));
+
+		dataStream = new CsvDataStream(csvReader, columnMapping);
+
+		// call under test
+		Object[] row = dataStream.next();
+
+		// A "no value" cell is represented as JSONObject.NULL (not a Java null),
+		// consistent with how ConValue represents ConType.NULL everywhere else.
+		assertArrayEquals(new Object[] { 0L, JSONObject.NULL, "data0" }, row);
+	}
+
+	/**
+	 * A non-key column may hold a value inferred from a different revision's data
+	 * that doesn't fit its declared type (e.g. an INTEGER column upserted from a
+	 * grid that has since gained non-numeric values). It must be carried through
+	 * as raw text rather than failing the whole import.
+	 */
+	@Test
+	public void testStreamWithUnparseableNonKeyIntegerCell() {
+		csvReader = new CSVReader(new StringReader(
+			"0,not-a-number,data0" + System.lineSeparator()
+		));
+
+		dataStream = new CsvDataStream(csvReader, columnMapping);
+
+		// call under test
+		Object[] row = dataStream.next();
+
+		assertArrayEquals(new Object[] { 0L, "not-a-number", "data0" }, row);
+	}
+
+	/**
+	 * The upsert key columns are stored in a typed, NOT NULL temp table column and
+	 * drive the join against the grid's temp table, so an unparseable key value
+	 * must still fail the import rather than being carried through as text.
+	 */
+	@Test
+	public void testStreamWithUnparseableUpsertKeyValueStillThrows() {
+		csvReader = new CSVReader(new StringReader(
+			"not-a-number,1,data0" + System.lineSeparator()
+		));
+
+		dataStream = new CsvDataStream(csvReader, columnMapping);
+
+		// call under test
+		assertThrows(NumberFormatException.class, dataStream::next);
 	}
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/CsvDataStreamTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/internal/replica/merge/CsvDataStreamTest.java
@@ -229,7 +229,7 @@ public class CsvDataStreamTest {
 	 * must still fail the import rather than being carried through as text.
 	 */
 	@Test
-	public void testStreamWithUnparseableUpsertKeyValueStillThrows() {
+	public void testStreamWithUnparseableUpsertKeyValue() {
 		csvReader = new CSVReader(new StringReader(
 			"not-a-number,1,data0" + System.lineSeparator()
 		));

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/row/translator/TranslatorTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/row/translator/TranslatorTest.java
@@ -1,6 +1,7 @@
 package org.sagebionetworks.repo.manager.grid.row.translator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.sagebionetworks.repo.model.grid.patch.ConType;
@@ -94,7 +95,7 @@ public class TranslatorTest {
 	}
 
 	@Test
-	public void testTranslateLenientlyOneArgOverloadDefaultsToRequired() {
+	public void testTranslateLenientlyWithNoIsRequiredPropertyArgument() {
 		// call under test
 		ConValue con = new LongTranslator().translateLeniently("JH-2-009-518B9-A_1");
 		assertEquals(new ConValue(ConType.STRING, "JH-2-009-518B9-A_1"), con);
@@ -115,6 +116,26 @@ public class TranslatorTest {
 		// call under test
 		ConValue con = new BooleanTranslator().translateLeniently("not-a-boolean", true);
 		assertEquals(new ConValue(ConType.BOOLEAN, false), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithMalformedJsonArray() {
+		// org.json throws JSONException, which is not an IllegalArgumentException, so
+		// the narrowed catch must list it explicitly.
+		// call under test
+		ConValue con = new ArrayTranslator().translateLeniently("[1,2", true);
+		assertEquals(new ConValue(ConType.STRING, "[1,2"), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithTranslatorDefect() {
+		// Leniency tolerates a value that does not fit the column type, NOT a defect in
+		// the translator itself — that must still fail loudly.
+		Translator defective = string -> {
+			throw new NullPointerException("boom");
+		};
+		// call under test
+		assertThrows(NullPointerException.class, () -> defective.translateLeniently("anything", true));
 	}
 
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/row/translator/TranslatorTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/row/translator/TranslatorTest.java
@@ -1,0 +1,120 @@
+package org.sagebionetworks.repo.manager.grid.row.translator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.sagebionetworks.repo.model.grid.patch.ConType;
+import org.sagebionetworks.repo.model.grid.patch.ConValue;
+
+/**
+ * Tests the {@link Translator#translateLeniently} default methods, exercised
+ * through the real {@link Translator} implementations (no mocking: these are
+ * plain value objects, not system boundaries).
+ */
+public class TranslatorTest {
+
+	@Test
+	public void testTranslateLenientlyWithNullAndRequiredPropertyIsNull() {
+		// call under test
+		ConValue con = new LongTranslator().translateLeniently(null, true);
+		assertEquals(new ConValue(ConType.NULL, null), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithNullAndNotRequiredIsUndefined() {
+		// call under test
+		ConValue con = new LongTranslator().translateLeniently(null, false);
+		assertEquals(new ConValue(ConType.UNDEFINED, null), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithBlankAndRequiredIsNull() {
+		// call under test
+		ConValue con = new LongTranslator().translateLeniently("", true);
+		assertEquals(new ConValue(ConType.NULL, null), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithWhitespaceOnlyAndRequiredIsNull() {
+		// call under test
+		ConValue con = new LongTranslator().translateLeniently("   ", true);
+		assertEquals(new ConValue(ConType.NULL, null), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithBlankAndNotRequiredIsUndefined() {
+		// call under test
+		ConValue con = new LongTranslator().translateLeniently("", false);
+		assertEquals(new ConValue(ConType.UNDEFINED, null), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithUnparseableLongFallsBackToString() {
+		// call under test
+		ConValue con = new LongTranslator().translateLeniently("JH-2-009-518B9-A_1", true);
+		assertEquals(new ConValue(ConType.STRING, "JH-2-009-518B9-A_1"), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithParseableLongTranslatesNormally() {
+		// call under test
+		ConValue con = new LongTranslator().translateLeniently("42", true);
+		assertEquals(new ConValue(ConType.LONG, 42L), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithUnparseableDoubleFallsBackToString() {
+		// call under test
+		ConValue con = new DoubleTranslator().translateLeniently("not-a-double", true);
+		assertEquals(new ConValue(ConType.STRING, "not-a-double"), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithUnparseableDateFallsBackToString() {
+		// call under test
+		ConValue con = new DateTranslator().translateLeniently("not-a-date", true);
+		assertEquals(new ConValue(ConType.STRING, "not-a-date"), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithBlankDateIsNull() {
+		// A blank cell in a DATE column carries no type information (it is legitimate
+		// for the column to still be inferred as DATE), so it must not fall back to
+		// the literal blank string.
+		// call under test
+		ConValue con = new DateTranslator().translateLeniently("", true);
+		assertEquals(new ConValue(ConType.NULL, null), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithNonJsonFallsBackToString() {
+		// call under test
+		ConValue con = new JSONTranslator().translateLeniently("notJSON", true);
+		assertEquals(new ConValue(ConType.STRING, "notJSON"), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyOneArgOverloadDefaultsToRequired() {
+		// call under test
+		ConValue con = new LongTranslator().translateLeniently("JH-2-009-518B9-A_1");
+		assertEquals(new ConValue(ConType.STRING, "JH-2-009-518B9-A_1"), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithStringTranslatorMatchesStrictBehavior() {
+		// StringTranslator never throws, so leniency must not change its behavior,
+		// including for a blank value (which is a valid empty string, not "no value").
+		// call under test
+		ConValue con = new StringTranslator().translateLeniently("", true);
+		assertEquals(new ConValue(ConType.STRING, ""), con);
+	}
+
+	@Test
+	public void testTranslateLenientlyWithBooleanTranslatorMatchesStrictBehavior() {
+		// BooleanTranslator never throws, so leniency must not change its behavior.
+		// call under test
+		ConValue con = new BooleanTranslator().translateLeniently("not-a-boolean", true);
+		assertEquals(new ConValue(ConType.BOOLEAN, false), con);
+	}
+
+}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/row/translator/TranslatorTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/row/translator/TranslatorTest.java
@@ -10,7 +10,7 @@ import org.sagebionetworks.repo.model.grid.patch.ConValue;
 /**
  * Tests the {@link Translator#translateLeniently} default methods, exercised
  * through the real {@link Translator} implementations (no mocking: these are
- * plain value objects, not system boundaries).
+ * plain value objects).
  */
 public class TranslatorTest {
 

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/synch/handler/RecordSetSourceHandlerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/synch/handler/RecordSetSourceHandlerTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -591,6 +593,37 @@ public class RecordSetSourceHandlerTest {
 				mockRecordSetExporter, mockGridRowValidator, mockNodeDao);
 	}
 
+	/**
+	 * Build a handler over an explicit latest/baseline row pair, for tests that need a
+	 * specific value in a specific column. A null baselineRow gives the baseline
+	 * revision a header and no data rows.
+	 */
+	private RecordSetSourceHandler buildHandlerWithRows(ReconciledSchema schema, String[] header, String[] latestRow,
+			String[] baselineRow) throws IOException {
+		when(mockEntityManager.getEntity(mockUser, "syn1", RecordSet.class)).thenReturn(recordSet);
+		when(mockFileHandleManager.getRawFileHandleUnchecked("fhLatest")).thenReturn(latestFileHandle);
+		when(mockSchemaResolver.getReconciledSchema(eq("syn1"), eq(latestFileHandle), any())).thenReturn(schema);
+		when(mockCsvFileHandleProvider.getCsvReader(latestFileHandle, csvDescriptor)).thenReturn(mockLatestReader);
+		when(mockLatestReader.readNext()).thenReturn(header, latestRow, null);
+
+		when(mockEntityManager.getEntityForVersion(mockUser, "syn1", 2L, RecordSet.class))
+				.thenReturn(baselineRecordSet);
+		when(mockFileHandleManager.getRawFileHandleUnchecked("fhBaseline")).thenReturn(baselineFileHandle);
+		when(mockCsvFileHandleProvider.getCsvReader(baselineFileHandle, csvDescriptor)).thenReturn(mockBaselineReader);
+		if (baselineRow == null) {
+			when(mockBaselineReader.readNext()).thenReturn(header, null);
+		} else {
+			when(mockBaselineReader.readNext()).thenReturn(header, baselineRow, null);
+		}
+
+		when(mockFileProvider.createTempFile(any(), any())).thenReturn(tempFile);
+		when(mockFileProvider.createFileOutputStream(tempFile)).thenReturn(new FileOutputStream(tempFile));
+
+		return new RecordSetSourceHandler(mockUser, session, mockEntityManager, mockFileHandleManager,
+				mockCsvFileHandleProvider, mockSchemaResolver, mockFileProvider, mockRecordSetExporter,
+				mockGridRowValidator, mockNodeDao);
+	}
+
 	@Test
 	public void testIsColumnDeletedByUserWhenFullySyncedAndNotSchemaProperty() throws IOException {
 		// Source has [id, name, extra]. "extra" is NOT in the JSON schema and the grid is
@@ -657,37 +690,18 @@ public class RecordSetSourceHandlerTest {
 	}
 
 	/**
-	 * Regression test for the reported NumberFormatException: the "id" column is
-	 * inferred as INTEGER from the latest revision's CSV, but the synced baseline
-	 * revision (an independent, immutable CSV) holds a non-numeric value in that
-	 * same column. Loading the baseline hashes must not fail the whole sync.
+	 * Regression test for PLFM-9853. The "id" column is inferred as INTEGER from
+	 * the latest revision's CSV, but the synced baseline revision (an independent,
+	 * immutable CSV) holds a non-numeric value in that same column. Loading the
+	 * baseline hashes must not fail the whole sync.
 	 */
 	@Test
-	public void testInitializeDoesNotThrowWhenBaselineHasTypeIncompatibleKeyValue() throws IOException {
-		when(mockEntityManager.getEntity(mockUser, "syn1", RecordSet.class)).thenReturn(recordSet);
-		when(mockFileHandleManager.getRawFileHandleUnchecked("fhLatest")).thenReturn(latestFileHandle);
-		when(mockSchemaResolver.getReconciledSchema(eq("syn1"), eq(latestFileHandle), any()))
-				.thenReturn(reconciledSchema);
-		when(mockCsvFileHandleProvider.getCsvReader(latestFileHandle, csvDescriptor)).thenReturn(mockLatestReader);
-		when(mockLatestReader.readNext()).thenReturn(new String[] { "id", "name" }, new String[] { "1", "Alice" },
-				null);
-
-		when(mockEntityManager.getEntityForVersion(mockUser, "syn1", 2L, RecordSet.class))
-				.thenReturn(baselineRecordSet);
-		when(mockFileHandleManager.getRawFileHandleUnchecked("fhBaseline")).thenReturn(baselineFileHandle);
-		when(mockCsvFileHandleProvider.getCsvReader(baselineFileHandle, csvDescriptor)).thenReturn(mockBaselineReader);
+	public void testInitializeWithTypeIncompatibleBaselineKeyValue() throws IOException {
+		// call under test — must not throw NumberFormatException
 		// The baseline (older) revision holds a non-numeric specimen id in the "id"
 		// column, which the latest revision's CSV inference typed as INTEGER.
-		when(mockBaselineReader.readNext()).thenReturn(new String[] { "id", "name" },
-				new String[] { "JH-2-009-518B9-A_1", "Alice" }, null);
-
-		when(mockFileProvider.createTempFile(any(), any())).thenReturn(tempFile);
-		when(mockFileProvider.createFileOutputStream(tempFile)).thenReturn(new FileOutputStream(tempFile));
-
-		// call under test — must not throw NumberFormatException
-		RecordSetSourceHandler handler = new RecordSetSourceHandler(mockUser, session, mockEntityManager,
-				mockFileHandleManager, mockCsvFileHandleProvider, mockSchemaResolver, mockFileProvider,
-				mockRecordSetExporter, mockGridRowValidator, mockNodeDao);
+		RecordSetSourceHandler handler = buildHandlerWithRows(reconciledSchema, new String[] { "id", "name" },
+				new String[] { "1", "Alice" }, new String[] { "JH-2-009-518B9-A_1", "Alice" });
 
 		// The real numeric-keyed baseline row is gone (replaced by the mismatched
 		// row), so the latest revision's numeric key is no longer in the baseline...
@@ -705,28 +719,9 @@ public class RecordSetSourceHandlerTest {
 	 * perturb the row's content hash.
 	 */
 	@Test
-	public void testChangedSinceBaselineWithTypeIncompatibleValueUnchangedIsNotChanged() throws IOException {
-		when(mockEntityManager.getEntity(mockUser, "syn1", RecordSet.class)).thenReturn(recordSet);
-		when(mockFileHandleManager.getRawFileHandleUnchecked("fhLatest")).thenReturn(latestFileHandle);
-		when(mockSchemaResolver.getReconciledSchema(eq("syn1"), eq(latestFileHandle), any()))
-				.thenReturn(reconciledSchema);
-		when(mockCsvFileHandleProvider.getCsvReader(latestFileHandle, csvDescriptor)).thenReturn(mockLatestReader);
-		when(mockLatestReader.readNext()).thenReturn(new String[] { "id", "name" },
-				new String[] { "JH-2-009-518B9-A_1", "Alice" }, null);
-
-		when(mockEntityManager.getEntityForVersion(mockUser, "syn1", 2L, RecordSet.class))
-				.thenReturn(baselineRecordSet);
-		when(mockFileHandleManager.getRawFileHandleUnchecked("fhBaseline")).thenReturn(baselineFileHandle);
-		when(mockCsvFileHandleProvider.getCsvReader(baselineFileHandle, csvDescriptor)).thenReturn(mockBaselineReader);
-		when(mockBaselineReader.readNext()).thenReturn(new String[] { "id", "name" },
-				new String[] { "JH-2-009-518B9-A_1", "Alice" }, null);
-
-		when(mockFileProvider.createTempFile(any(), any())).thenReturn(tempFile);
-		when(mockFileProvider.createFileOutputStream(tempFile)).thenReturn(new FileOutputStream(tempFile));
-
-		RecordSetSourceHandler handler = new RecordSetSourceHandler(mockUser, session, mockEntityManager,
-				mockFileHandleManager, mockCsvFileHandleProvider, mockSchemaResolver, mockFileProvider,
-				mockRecordSetExporter, mockGridRowValidator, mockNodeDao);
+	public void testChangedSinceBaselineWithUnchangedTypeIncompatibleValue() throws IOException {
+		RecordSetSourceHandler handler = buildHandlerWithRows(reconciledSchema, new String[] { "id", "name" },
+				new String[] { "JH-2-009-518B9-A_1", "Alice" }, new String[] { "JH-2-009-518B9-A_1", "Alice" });
 
 		String fallbackKey = UpsertKeyEncoder
 				.encode(List.of(new ConValue(ConType.STRING, "JH-2-009-518B9-A_1")));
@@ -740,33 +735,15 @@ public class RecordSetSourceHandlerTest {
 	 * be inferred INTEGER despite having blanks), so translating one must not throw.
 	 */
 	@Test
-	public void testCreateSynchRowWithBlankNonKeyIntegerCellDoesNotThrow() throws IOException {
+	public void testCreateSynchRowWithBlankNonKeyIntegerCell() throws IOException {
 		ReconciledSchema schemaWithNumericNonKeyColumn = new ReconciledSchema(List.of(
 				new ColumnModel().setName("id").setColumnType(ColumnType.INTEGER),
 				new ColumnModel().setName("name").setColumnType(ColumnType.STRING).setMaximumSize(50L),
 				new ColumnModel().setName("age").setColumnType(ColumnType.INTEGER)),
 				List.of(), Collections.emptyList());
 
-		when(mockSchemaResolver.getReconciledSchema(eq("syn1"), eq(latestFileHandle), any()))
-				.thenReturn(schemaWithNumericNonKeyColumn);
-		when(mockEntityManager.getEntity(mockUser, "syn1", RecordSet.class)).thenReturn(recordSet);
-		when(mockFileHandleManager.getRawFileHandleUnchecked("fhLatest")).thenReturn(latestFileHandle);
-		when(mockCsvFileHandleProvider.getCsvReader(latestFileHandle, csvDescriptor)).thenReturn(mockLatestReader);
-		when(mockLatestReader.readNext()).thenReturn(new String[] { "id", "name", "age" },
-				new String[] { "1", "Alice", "" }, null);
-
-		when(mockEntityManager.getEntityForVersion(mockUser, "syn1", 2L, RecordSet.class))
-				.thenReturn(baselineRecordSet);
-		when(mockFileHandleManager.getRawFileHandleUnchecked("fhBaseline")).thenReturn(baselineFileHandle);
-		when(mockCsvFileHandleProvider.getCsvReader(baselineFileHandle, csvDescriptor)).thenReturn(mockBaselineReader);
-		when(mockBaselineReader.readNext()).thenReturn(new String[] { "id", "name", "age" }, null);
-
-		when(mockFileProvider.createTempFile(any(), any())).thenReturn(tempFile);
-		when(mockFileProvider.createFileOutputStream(tempFile)).thenReturn(new FileOutputStream(tempFile));
-
-		RecordSetSourceHandler handler = new RecordSetSourceHandler(mockUser, session, mockEntityManager,
-				mockFileHandleManager, mockCsvFileHandleProvider, mockSchemaResolver, mockFileProvider,
-				mockRecordSetExporter, mockGridRowValidator, mockNodeDao);
+		RecordSetSourceHandler handler = buildHandlerWithRows(schemaWithNumericNonKeyColumn,
+				new String[] { "id", "name", "age" }, new String[] { "1", "Alice", "" }, null);
 
 		Map<String, Integer> headerIndex = Map.of("id", 0, "name", 1, "age", 2);
 		// call under test — a blank cell in a non-key INTEGER column must not throw
@@ -782,7 +759,7 @@ public class RecordSetSourceHandlerTest {
 	 * and the temp file would leak unless the constructor cleans up on failure.
 	 */
 	@Test
-	public void testConstructorDeletesTempFileWhenInitializeFailsAfterCreatingIt() throws IOException {
+	public void testConstructorWithInitializeFailureAfterTempFileCreated() throws IOException {
 		when(mockEntityManager.getEntity(mockUser, "syn1", RecordSet.class)).thenReturn(recordSet);
 		when(mockFileHandleManager.getRawFileHandleUnchecked("fhLatest")).thenReturn(latestFileHandle);
 		when(mockSchemaResolver.getReconciledSchema(eq("syn1"), eq(latestFileHandle), any()))
@@ -807,6 +784,9 @@ public class RecordSetSourceHandlerTest {
 				mockFileProvider, mockRecordSetExporter, mockGridRowValidator, mockNodeDao));
 
 		assertFalse(tempFile.exists());
+		// Nothing past the failure point may have run.
+		verify(mockFileHandleManager, never()).getRawFileHandleUnchecked("fhBaseline");
+		verify(mockCsvFileHandleProvider, never()).getCsvReader(eq(baselineFileHandle), any());
 	}
 
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/synch/handler/RecordSetSourceHandlerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/synch/handler/RecordSetSourceHandlerTest.java
@@ -716,7 +716,7 @@ public class RecordSetSourceHandlerTest {
 	/**
 	 * A row unchanged across both revisions, including its type-incompatible
 	 * value, must still be reported as unchanged — the leniency fallback must not
-	 * perturb the row's content hash.
+	 * affect the row's content hash.
 	 */
 	@Test
 	public void testChangedSinceBaselineWithUnchangedTypeIncompatibleValue() throws IOException {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/synch/handler/RecordSetSourceHandlerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/grid/synch/handler/RecordSetSourceHandlerTest.java
@@ -656,5 +656,158 @@ public class RecordSetSourceHandlerTest {
 		assertTrue(ids.contains(9999L));
 	}
 
+	/**
+	 * Regression test for the reported NumberFormatException: the "id" column is
+	 * inferred as INTEGER from the latest revision's CSV, but the synced baseline
+	 * revision (an independent, immutable CSV) holds a non-numeric value in that
+	 * same column. Loading the baseline hashes must not fail the whole sync.
+	 */
+	@Test
+	public void testInitializeDoesNotThrowWhenBaselineHasTypeIncompatibleKeyValue() throws IOException {
+		when(mockEntityManager.getEntity(mockUser, "syn1", RecordSet.class)).thenReturn(recordSet);
+		when(mockFileHandleManager.getRawFileHandleUnchecked("fhLatest")).thenReturn(latestFileHandle);
+		when(mockSchemaResolver.getReconciledSchema(eq("syn1"), eq(latestFileHandle), any()))
+				.thenReturn(reconciledSchema);
+		when(mockCsvFileHandleProvider.getCsvReader(latestFileHandle, csvDescriptor)).thenReturn(mockLatestReader);
+		when(mockLatestReader.readNext()).thenReturn(new String[] { "id", "name" }, new String[] { "1", "Alice" },
+				null);
+
+		when(mockEntityManager.getEntityForVersion(mockUser, "syn1", 2L, RecordSet.class))
+				.thenReturn(baselineRecordSet);
+		when(mockFileHandleManager.getRawFileHandleUnchecked("fhBaseline")).thenReturn(baselineFileHandle);
+		when(mockCsvFileHandleProvider.getCsvReader(baselineFileHandle, csvDescriptor)).thenReturn(mockBaselineReader);
+		// The baseline (older) revision holds a non-numeric specimen id in the "id"
+		// column, which the latest revision's CSV inference typed as INTEGER.
+		when(mockBaselineReader.readNext()).thenReturn(new String[] { "id", "name" },
+				new String[] { "JH-2-009-518B9-A_1", "Alice" }, null);
+
+		when(mockFileProvider.createTempFile(any(), any())).thenReturn(tempFile);
+		when(mockFileProvider.createFileOutputStream(tempFile)).thenReturn(new FileOutputStream(tempFile));
+
+		// call under test — must not throw NumberFormatException
+		RecordSetSourceHandler handler = new RecordSetSourceHandler(mockUser, session, mockEntityManager,
+				mockFileHandleManager, mockCsvFileHandleProvider, mockSchemaResolver, mockFileProvider,
+				mockRecordSetExporter, mockGridRowValidator, mockNodeDao);
+
+		// The real numeric-keyed baseline row is gone (replaced by the mismatched
+		// row), so the latest revision's numeric key is no longer in the baseline...
+		assertFalse(handler.wasInSyncedBaseline(keyOne));
+		// ...and the mismatched value is preserved (as text) under its own key rather
+		// than being dropped, so it is not misdetected as a user deletion of "id"=1.
+		String fallbackKey = UpsertKeyEncoder
+				.encode(List.of(new ConValue(ConType.STRING, "JH-2-009-518B9-A_1")));
+		assertTrue(handler.wasInSyncedBaseline(fallbackKey));
+	}
+
+	/**
+	 * A row unchanged across both revisions, including its type-incompatible
+	 * value, must still be reported as unchanged — the leniency fallback must not
+	 * perturb the row's content hash.
+	 */
+	@Test
+	public void testChangedSinceBaselineWithTypeIncompatibleValueUnchangedIsNotChanged() throws IOException {
+		when(mockEntityManager.getEntity(mockUser, "syn1", RecordSet.class)).thenReturn(recordSet);
+		when(mockFileHandleManager.getRawFileHandleUnchecked("fhLatest")).thenReturn(latestFileHandle);
+		when(mockSchemaResolver.getReconciledSchema(eq("syn1"), eq(latestFileHandle), any()))
+				.thenReturn(reconciledSchema);
+		when(mockCsvFileHandleProvider.getCsvReader(latestFileHandle, csvDescriptor)).thenReturn(mockLatestReader);
+		when(mockLatestReader.readNext()).thenReturn(new String[] { "id", "name" },
+				new String[] { "JH-2-009-518B9-A_1", "Alice" }, null);
+
+		when(mockEntityManager.getEntityForVersion(mockUser, "syn1", 2L, RecordSet.class))
+				.thenReturn(baselineRecordSet);
+		when(mockFileHandleManager.getRawFileHandleUnchecked("fhBaseline")).thenReturn(baselineFileHandle);
+		when(mockCsvFileHandleProvider.getCsvReader(baselineFileHandle, csvDescriptor)).thenReturn(mockBaselineReader);
+		when(mockBaselineReader.readNext()).thenReturn(new String[] { "id", "name" },
+				new String[] { "JH-2-009-518B9-A_1", "Alice" }, null);
+
+		when(mockFileProvider.createTempFile(any(), any())).thenReturn(tempFile);
+		when(mockFileProvider.createFileOutputStream(tempFile)).thenReturn(new FileOutputStream(tempFile));
+
+		RecordSetSourceHandler handler = new RecordSetSourceHandler(mockUser, session, mockEntityManager,
+				mockFileHandleManager, mockCsvFileHandleProvider, mockSchemaResolver, mockFileProvider,
+				mockRecordSetExporter, mockGridRowValidator, mockNodeDao);
+
+		String fallbackKey = UpsertKeyEncoder
+				.encode(List.of(new ConValue(ConType.STRING, "JH-2-009-518B9-A_1")));
+		// call under test
+		assertFalse(handler.changedSinceBaseline(fallbackKey));
+	}
+
+	/**
+	 * Regression test for a blank cell in a non-key column typed INTEGER: blank
+	 * cells carry no type information during inference (a column can legitimately
+	 * be inferred INTEGER despite having blanks), so translating one must not throw.
+	 */
+	@Test
+	public void testCreateSynchRowWithBlankNonKeyIntegerCellDoesNotThrow() throws IOException {
+		ReconciledSchema schemaWithNumericNonKeyColumn = new ReconciledSchema(List.of(
+				new ColumnModel().setName("id").setColumnType(ColumnType.INTEGER),
+				new ColumnModel().setName("name").setColumnType(ColumnType.STRING).setMaximumSize(50L),
+				new ColumnModel().setName("age").setColumnType(ColumnType.INTEGER)),
+				List.of(), Collections.emptyList());
+
+		when(mockSchemaResolver.getReconciledSchema(eq("syn1"), eq(latestFileHandle), any()))
+				.thenReturn(schemaWithNumericNonKeyColumn);
+		when(mockEntityManager.getEntity(mockUser, "syn1", RecordSet.class)).thenReturn(recordSet);
+		when(mockFileHandleManager.getRawFileHandleUnchecked("fhLatest")).thenReturn(latestFileHandle);
+		when(mockCsvFileHandleProvider.getCsvReader(latestFileHandle, csvDescriptor)).thenReturn(mockLatestReader);
+		when(mockLatestReader.readNext()).thenReturn(new String[] { "id", "name", "age" },
+				new String[] { "1", "Alice", "" }, null);
+
+		when(mockEntityManager.getEntityForVersion(mockUser, "syn1", 2L, RecordSet.class))
+				.thenReturn(baselineRecordSet);
+		when(mockFileHandleManager.getRawFileHandleUnchecked("fhBaseline")).thenReturn(baselineFileHandle);
+		when(mockCsvFileHandleProvider.getCsvReader(baselineFileHandle, csvDescriptor)).thenReturn(mockBaselineReader);
+		when(mockBaselineReader.readNext()).thenReturn(new String[] { "id", "name", "age" }, null);
+
+		when(mockFileProvider.createTempFile(any(), any())).thenReturn(tempFile);
+		when(mockFileProvider.createFileOutputStream(tempFile)).thenReturn(new FileOutputStream(tempFile));
+
+		RecordSetSourceHandler handler = new RecordSetSourceHandler(mockUser, session, mockEntityManager,
+				mockFileHandleManager, mockCsvFileHandleProvider, mockSchemaResolver, mockFileProvider,
+				mockRecordSetExporter, mockGridRowValidator, mockNodeDao);
+
+		Map<String, Integer> headerIndex = Map.of("id", 0, "name", 1, "age", 2);
+		// call under test — a blank cell in a non-key INTEGER column must not throw
+		RowSourceItem row = handler.createSynchRow(new String[] { "1", "Alice", "" }, headerIndex);
+		assertEquals(new ConValue(ConType.UNDEFINED, null), row.getData().get("age"));
+	}
+
+	/**
+	 * The handler creates its temp file during initialize() (for the latest
+	 * revision), before loadBaselineHashes reads the baseline revision. Because
+	 * initialize() runs from the constructor, a failure there escapes before the
+	 * handler is ever returned to a try-with-resources, so close() would never run
+	 * and the temp file would leak unless the constructor cleans up on failure.
+	 */
+	@Test
+	public void testConstructorDeletesTempFileWhenInitializeFailsAfterCreatingIt() throws IOException {
+		when(mockEntityManager.getEntity(mockUser, "syn1", RecordSet.class)).thenReturn(recordSet);
+		when(mockFileHandleManager.getRawFileHandleUnchecked("fhLatest")).thenReturn(latestFileHandle);
+		when(mockSchemaResolver.getReconciledSchema(eq("syn1"), eq(latestFileHandle), any()))
+				.thenReturn(reconciledSchema);
+		when(mockCsvFileHandleProvider.getCsvReader(latestFileHandle, csvDescriptor)).thenReturn(mockLatestReader);
+		when(mockLatestReader.readNext()).thenReturn(new String[] { "id", "name" }, new String[] { "1", "Alice" },
+				null);
+
+		// Fail after the temp file has already been created, while loading the
+		// baseline (a failure unrelated to translation, e.g. a missing entity).
+		when(mockEntityManager.getEntityForVersion(mockUser, "syn1", 2L, RecordSet.class))
+				.thenThrow(new IllegalStateException("boom"));
+
+		when(mockFileProvider.createTempFile(any(), any())).thenReturn(tempFile);
+		when(mockFileProvider.createFileOutputStream(tempFile)).thenReturn(new FileOutputStream(tempFile));
+
+		assertTrue(tempFile.exists());
+
+		// call under test
+		assertThrows(IllegalStateException.class, () -> new RecordSetSourceHandler(mockUser, session,
+				mockEntityManager, mockFileHandleManager, mockCsvFileHandleProvider, mockSchemaResolver,
+				mockFileProvider, mockRecordSetExporter, mockGridRowValidator, mockNodeDao));
+
+		assertFalse(tempFile.exists());
+	}
+
 }
 


### PR DESCRIPTION
## Problem

RecordSet grid `PULL` sync (`RecordSetSourceHandler`) re-reads two independent CSV revisions through the schema inferred from the latest revision:

1.  the *latest* revision (source of the current schema)
2. the *previously synced baseline* revision

When the baseline holds a value that schema can't represent (e.g. an alphanumeric value in a column the latest revision inferred as `INTEGER`), strict translation threw `NumberFormatException` and aborted the whole sync.

## Fix

- **`Translator.translateLeniently(String, boolean)`** (new default method): translates as `ConType.STRING` instead of throwing when a value doesn't fit the column's type. A blank value is still normalized to no-value for types that reject blank (INTEGER/DOUBLE/DATE/JSON); types that accept any string translate blank exactly as the strict path does. The `catch` is scoped to `IllegalArgumentException | JSONException` — the only exceptions any current `Translator` implementation actually throws — so a genuine translator defect (e.g. an NPE) still propagates instead of silently becoming a text cell.
- **`RecordSetSourceHandler.createSynchRow`** now routes non-key column values through `translateLeniently` instead of `translateNullable`, so a baseline-only type mismatch is carried through as text and the sync completes.
- **`RecordSetSourceHandler` constructor** wraps `initialize()` in a try/catch that closes (and deletes) the temp file it creates before rethrowing — `initialize()` runs from the constructor, so a failure there previously leaked the temp file on every retry, since the handler is never returned to a try-with-resources.
- **`CsvDataStream`** (separate `GridCsvImportRequest` import path, same bug family): a blank cell in a non-key `INTEGER` column previously threw and failed the whole import. Non-key columns now translate leniently too; upsert-key columns stay strict because they back a typed `NOT NULL` temp-table column used to join against the grid's temp
  table.
