### PR TITLE
Fix OpenAPI $recursiveRef resolution for inline named types

### DIFF
--- a/lib/lib-openapi/src/main/java/org/sagebionetworks/translator/ObjectSchemaUtils.java
+++ b/lib/lib-openapi/src/main/java/org/sagebionetworks/translator/ObjectSchemaUtils.java
@@ -24,6 +24,13 @@ import org.sagebionetworks.util.ValidateArgument;
 
 public class ObjectSchemaUtils {
 	/**
+	 * Maps the id of a schema to the nearest enclosing {@code $recursiveAnchor} schema it was reached
+	 * through, for schemas that do not carry a {@code $recursiveAnchor} of their own. Populated by
+	 * {@link #getConcreteClasses(Iterator)}; used to resolve {@code $recursiveRef} on such schemas.
+	 */
+	final Map<String, ObjectSchema> anchorMap = new HashMap<>();
+
+	/**
 	 * Generates a mapping of class id to an ObjectSchema that represents that
 	 * class. Starts out with all of the concrete classes found in `autoGen`
 	 * 
@@ -37,7 +44,7 @@ public class ObjectSchemaUtils {
 		while (concreteClassNames.hasNext()) {
 			String className = concreteClassNames.next();
 			ObjectSchema schema = SchemaUtils.getSchema(className);
-			SchemaUtils.recursiveAddTypes(classNameToObjectSchema, className, schema);
+			SchemaUtils.recursiveAddTypes(classNameToObjectSchema, className, schema, anchorMap, null);
 		}
 		return classNameToObjectSchema;
 	}
@@ -253,7 +260,7 @@ public class ObjectSchemaUtils {
 		ValidateArgument.required(property, "property");
 		ValidateArgument.required(schemaId, "schemaId");
 		if (isSelfReferencing(property)) {
-			return generateReferenceSchema(schemaId);
+			return generateReferenceSchema(resolveSelfReferenceId(schemaId));
 		}
 		return translateObjectSchemaPropertyToJsonSchema(property, schemaId);
 	}
@@ -269,10 +276,23 @@ public class ObjectSchemaUtils {
 		ValidateArgument.required(schema, "schema");
 		ValidateArgument.required(property, "property");
 		ValidateArgument.required(schemaId, "schemaId");
-		String referenceId = isSelfReferencing(property) ? schemaId : property.getId();
+		String referenceId = isSelfReferencing(property) ? resolveSelfReferenceId(schemaId) : property.getId();
 		if (referenceId != null) {
 			schema.set$ref(getPathInComponents(referenceId));
 		}
+	}
+
+	/**
+	 * Resolves the id a {@code $recursiveRef: "#"} on schemaId should point to. A schema with no
+	 * {@code $recursiveAnchor} of its own resolves its self-references to the enclosing anchor
+	 * recorded in {@link #anchorMap}, rather than to schemaId itself.
+	 *
+	 * @param schemaId the id of the schema currently being translated
+	 * @return the id the self-reference should point to
+	 */
+	String resolveSelfReferenceId(String schemaId) {
+		ObjectSchema anchor = anchorMap.get(schemaId);
+		return anchor != null ? anchor.getId() : schemaId;
 	}
 	
 	/**

--- a/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ObjectSchemaUtilsTest.java
+++ b/lib/lib-openapi/src/test/java/org/sagebionetworks/translator/ObjectSchemaUtilsTest.java
@@ -59,6 +59,28 @@ public class ObjectSchemaUtilsTest {
 		assertEquals(expected, util.getConcreteClasses(autoGen.getKeySetIterator()));
 	}
 	
+	/**
+	 * A schema with no {@code $recursiveAnchor} of its own has an entry in {@code anchorMap}
+	 * pointing at the enclosing anchor it was reached through. A {@code $recursiveRef: "#"} on one
+	 * of its properties must resolve to that anchor, not to the schema itself.
+	 */
+	@Test
+	public void testGetPropertyAsJsonSchemaWithRecursiveRefInsideInlineNamedTypeResolvesToEnclosingAnchor() {
+		String inlineTypeId = "org.example.InlineType";
+		String anchorId = "org.example.Anchor";
+
+		ObjectSchema anchor = new ObjectSchemaImpl();
+		anchor.setId(anchorId);
+		util.anchorMap.put(inlineTypeId, anchor);
+
+		ObjectSchema recursiveRef = new ObjectSchemaImpl();
+		recursiveRef.set$recursiveRef("#");
+
+		// call under test
+		OpenApiJsonSchema result = util.getPropertyAsJsonSchema(recursiveRef, inlineTypeId);
+		assertEquals("#/components/schemas/" + anchorId, result.get$ref());
+	}
+
 	@Test
 	public void testGetClassNameToJsonSchema() throws JSONObjectAdapterException {
 		Map<String, ObjectSchema> classNameToObjectSchema = new HashMap<>();


### PR DESCRIPTION
## Problem

`ObjectSchemaUtils.isSelfReferencing()` / `getPropertyAsJsonSchema()` (`lib/lib-openapi`) resolve `$recursiveRef: "#"` by generating a `$ref` to the id of the schema currently being translated. That's correct when the schema carries its own `$recursiveAnchor`, but wrong for an inline named type nested inside an anchor schema: such a type has no anchor of its own, so its self-reference must point at the enclosing anchor, not at itself.

Concretely, for a schema like:

```json
{
  "$recursiveAnchor": true,
  "properties": {
    "compound": {
      "type": "object",
      "id": "org.example.Compound",
      "properties": {
        "children": { "type": "array", "items": { "$recursiveRef": "#" } }
      }
    }
  }
}
```

the generated OpenAPI spec typed `children` as `List[Compound]` instead of `List[<anchor type>]`.

The other two consumers of this schema pattern (schema-to-pojo POJO generation, and the `lib-javadoc` REST docs generator) already handle this correctly. `SchemaUtils.recursiveAddTypes` has a 5-arg overload — added for the javadoc generator's fix — that records the enclosing `$recursiveAnchor` per schema id as it walks sub-schemas. `lib-openapi`'s `ObjectSchemaUtils.getConcreteClasses` was still calling the 3-arg overload, which drops that anchor information.

## Testing

This was directly affecting the generation of `org.sagebionetworks.repo.model.search.dsl.BoolQuery`. Where before the change:

```
 "must": {
      "type": "array",
      "items": {"$ref": "#/components/schemas/org.sagebionetworks.repo.model.search.dsl.BoolQuery"},
      "description": "Sub-clauses that must all match (scored). Logical AND."
 },
```

After the change:
```
 "must": {
      "type": "array",
      "items": {"$ref": "#/components/schemas/org.sagebionetworks.repo.model.search.dsl.Query"},
      "description": "Sub-clauses that must all match (scored). Logical AND."
 },
```

