### PR TITLE
PLFM-9652

### DIFF
--- a/lib/lib-docusign/src/main/java/org/sagebionetworks/docusign/DocuSignTemplateValidator.java
+++ b/lib/lib-docusign/src/main/java/org/sagebionetworks/docusign/DocuSignTemplateValidator.java
@@ -24,6 +24,7 @@ class DocuSignTemplateValidator {
 	record RequiredTab(String label, TabType type) {}
 
 	static final List<RequiredTab> SIGNING_OFFICIAL_TABS = List.of(
+			new RequiredTab("signing_official_institution", TabType.TEXT),
 			new RequiredTab("signing_official_name", TabType.FULL_NAME),
 			new RequiredTab("signing_official_title", TabType.TITLE),
 			new RequiredTab("signing_official_email", TabType.EMAIL_ADDRESS),
@@ -32,7 +33,6 @@ class DocuSignTemplateValidator {
 	);
 
 	static final List<RequiredTab> PRINCIPAL_INVESTIGATOR_TABS = List.of(
-			new RequiredTab("principal_investigator_institution", TabType.TEXT),
 			new RequiredTab("principal_investigator_name", TabType.FULL_NAME),
 			new RequiredTab("principal_investigator_title", TabType.TITLE),
 			new RequiredTab("principal_investigator_email", TabType.EMAIL_ADDRESS),

--- a/lib/lib-docusign/src/test/java/org/sagebionetworks/docusign/DocuSignClientTest.java
+++ b/lib/lib-docusign/src/test/java/org/sagebionetworks/docusign/DocuSignClientTest.java
@@ -183,7 +183,7 @@ public class DocuSignClientTest {
 				new RoleLabelKey("signing_official", "signing_official_name"), "Dr. Smith",
 				new RoleLabelKey("signing_official", "signing_official_title"), "Director",
 				new RoleLabelKey("signing_official", "signing_official_email"), "so@example.com",
-				new RoleLabelKey("principal_investigator", "principal_investigator_institution"), "MIT"
+				new RoleLabelKey("signing_official", "signing_official_institution"), "MIT"
 		);
 
 		// call under test
@@ -200,11 +200,7 @@ public class DocuSignClientTest {
 		assertEquals("Director", soRole.getTabs().getTitleTabs().get(0).getValue());
 		assertEquals(1, soRole.getTabs().getEmailTabs().size());
 		assertEquals("so@example.com", soRole.getTabs().getEmailTabs().get(0).getValue());
-
-		TemplateRole piRole = roles.stream()
-				.filter(r -> "principal_investigator".equals(r.getRoleName())).findFirst().orElseThrow();
-		assertEquals(1, piRole.getTabs().getTextTabs().size());
-		assertEquals("MIT", piRole.getTabs().getTextTabs().get(0).getValue());
+		assertEquals("MIT", soRole.getTabs().getTextTabs().get(0).getValue());
 	}
 
 	@Test

--- a/lib/lib-docusign/src/test/java/org/sagebionetworks/docusign/DocuSignTemplateValidatorTest.java
+++ b/lib/lib-docusign/src/test/java/org/sagebionetworks/docusign/DocuSignTemplateValidatorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -82,14 +83,12 @@ public class DocuSignTemplateValidatorTest {
 	public void testValidateWithMissingPrincipalInvestigatorTab() {
 		EnvelopeTemplate template = TestTemplateHelper.buildValidTemplate(0);
 		Signer pi = TestTemplateHelper.findSigner(template, "principal_investigator");
-		Text userName = new Text();
-		userName.setTabLabel("principal_investigator_user_name");
-		pi.getTabs().setTextTabs(List.of(userName));
+		pi.getTabs().setTextTabs(null);
 
 		// call under test
 		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
 				() -> DocuSignTemplateValidator.validate(template));
-		assertTrue(ex.getMessage().contains("principal_investigator_institution"));
+		assertTrue(ex.getMessage().contains("principal_investigator_user_name"));
 		assertTrue(ex.getMessage().contains("TEXT"));
 	}
 
@@ -137,7 +136,9 @@ public class DocuSignTemplateValidatorTest {
 		Signer so = TestTemplateHelper.findSigner(template, "signing_official");
 		Text extra = new Text();
 		extra.setTabLabel("some_extra_tab");
-		so.getTabs().setTextTabs(List.of(extra));
+		List<Text> newList = new ArrayList<Text>(so.getTabs().getTextTabs());
+		newList.add(extra);
+		so.getTabs().setTextTabs(newList);
 
 		// call under test
 		assertDoesNotThrow(() -> DocuSignTemplateValidator.validate(template));
@@ -158,6 +159,7 @@ public class DocuSignTemplateValidatorTest {
 
 	@Test
 	public void testTypeForRoleAndLabelWithSigningOfficial() {
+		assertEquals(TabType.TEXT, DocuSignTemplateValidator.typeforRoleAndLabel("signing_official", "signing_official_institution"));
 		assertEquals(TabType.FULL_NAME, DocuSignTemplateValidator.typeforRoleAndLabel("signing_official", "signing_official_name"));
 		assertEquals(TabType.TITLE, DocuSignTemplateValidator.typeforRoleAndLabel("signing_official", "signing_official_title"));
 		assertEquals(TabType.EMAIL_ADDRESS, DocuSignTemplateValidator.typeforRoleAndLabel("signing_official", "signing_official_email"));
@@ -167,7 +169,6 @@ public class DocuSignTemplateValidatorTest {
 
 	@Test
 	public void testTypeForRoleAndLabelWithPrincipalInvestigator() {
-		assertEquals(TabType.TEXT, DocuSignTemplateValidator.typeforRoleAndLabel("principal_investigator", "principal_investigator_institution"));
 		assertEquals(TabType.FULL_NAME, DocuSignTemplateValidator.typeforRoleAndLabel("principal_investigator", "principal_investigator_name"));
 		assertEquals(TabType.TITLE, DocuSignTemplateValidator.typeforRoleAndLabel("principal_investigator", "principal_investigator_title"));
 		assertEquals(TabType.EMAIL_ADDRESS, DocuSignTemplateValidator.typeforRoleAndLabel("principal_investigator", "principal_investigator_email"));

--- a/lib/lib-docusign/src/test/java/org/sagebionetworks/docusign/TestTemplateHelper.java
+++ b/lib/lib-docusign/src/test/java/org/sagebionetworks/docusign/TestTemplateHelper.java
@@ -38,6 +38,9 @@ class TestTemplateHelper {
 		FullName name = new FullName();
 		name.setTabLabel("signing_official_name");
 		tabs.setFullNameTabs(List.of(name));
+		Text institution = new Text();
+		institution.setTabLabel("signing_official_institution");
+		tabs.setTextTabs(List.of(institution));
 		Title title = new Title();
 		title.setTabLabel("signing_official_title");
 		tabs.setTitleTabs(List.of(title));
@@ -58,11 +61,9 @@ class TestTemplateHelper {
 		Signer signer = new Signer();
 		signer.setRoleName("principal_investigator");
 		Tabs tabs = new Tabs();
-		Text institution = new Text();
-		institution.setTabLabel("principal_investigator_institution");
 		Text userName = new Text();
 		userName.setTabLabel("principal_investigator_user_name");
-		tabs.setTextTabs(Arrays.asList(institution, userName));
+		tabs.setTextTabs(List.of(userName));
 		FullName name = new FullName();
 		name.setTabLabel("principal_investigator_name");
 		tabs.setFullNameTabs(List.of(name));

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/docusign/EDucManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/docusign/EDucManager.java
@@ -355,12 +355,12 @@ public class EDucManager {
 		addIfPresent(tabValues, "signing_official", "signing_official_name", so.getName());
 		addIfPresent(tabValues, "signing_official", "signing_official_title", so.getTitle());
 		addIfPresent(tabValues, "signing_official", "signing_official_email", so.getInstitutionalEmail());
+		addIfPresent(tabValues, "signing_official", "signing_official_institution", request.getInstitution());
 
 		PrincipalInvestigator pi = request.getPrincipalInvestigator();
 		addIfPresent(tabValues, "principal_investigator", "principal_investigator_name", pi.getName());
 		addIfPresent(tabValues, "principal_investigator", "principal_investigator_title", pi.getTitle());
 		addIfPresent(tabValues, "principal_investigator", "principal_investigator_email", pi.getInstitutionalEmail());
-		addIfPresent(tabValues, "principal_investigator", "principal_investigator_institution", request.getInstitution());
 
 		String piUserName = principalAliasDao.getUserName(Long.parseLong(pi.getUserId()));
 		addIfPresent(tabValues, "principal_investigator", "principal_investigator_user_name", piUserName);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/docusign/EDucManagerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/docusign/EDucManagerTest.java
@@ -308,11 +308,11 @@ public class EDucManagerTest {
 		assertEquals("Dr. Jones", tabValues.get(new RoleLabelKey("principal_investigator", "principal_investigator_name")));
 		assertEquals("Professor", tabValues.get(new RoleLabelKey("principal_investigator", "principal_investigator_title")));
 		assertEquals("pi@university.edu", tabValues.get(new RoleLabelKey("principal_investigator", "principal_investigator_email")));
-		assertEquals("MIT", tabValues.get(new RoleLabelKey("principal_investigator", "principal_investigator_institution")));
 		assertEquals("drjones", tabValues.get(new RoleLabelKey("principal_investigator", "principal_investigator_user_name")));
 		assertEquals("Jane Admin", tabValues.get(new RoleLabelKey("signing_official", "signing_official_name")));
 		assertEquals("VP Research", tabValues.get(new RoleLabelKey("signing_official", "signing_official_title")));
 		assertEquals("so@university.edu", tabValues.get(new RoleLabelKey("signing_official", "signing_official_email")));
+		assertEquals("MIT", tabValues.get(new RoleLabelKey("signing_official", "signing_official_institution")));
 		assertEquals("creatoruser", tabValues.get(new RoleLabelKey("collaborator_1", "collaborator_1_user_name")));
 		assertEquals("Creator User", tabValues.get(new RoleLabelKey("collaborator_1", "collaborator_1_name")));
 		assertEquals("collab1user", tabValues.get(new RoleLabelKey("collaborator_2", "collaborator_2_user_name")));


### PR DESCRIPTION
There was a mistake in the eDUC design:  The 'institution' entered by the DAR creator is supposed to go into the 'institution' field for the *signing official*, not for the *principal investigator*.  This PR introduces two changes:
- the template validator looks for a `signing_official_institution` field instead of a `principal_investigator_institution` field in the template;
- when creating an eDUC, the `institution` entered into the DAR is now copied into the `signing_official_institution` field.