### PR TITLE
Added a turn limit enforced for all of the new agents.  Currently, th…

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/Agent.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/Agent.java
@@ -1,9 +1,12 @@
 package org.sagebionetworks.repo.manager.agent;
 
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.sagebionetworks.repo.manager.agent.tool.TurnLimitAdvisor;
 import org.springframework.ai.chat.client.ChatClient.CallResponseSpec;
 import org.springframework.ai.chat.client.ChatClient.ChatClientRequestSpec;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.model.ToolContext;
@@ -73,6 +76,20 @@ public interface Agent {
 			+ "or a narrower request if you need the rest.]";
 
 	/**
+	 * Runs the tool-calling loop as part of the advisor chain (instead of internally, below the chain)
+	 * so {@link #TURN_LIMIT_ADVISOR} — a downstream advisor it re-invokes each iteration — can bound it.
+	 * Attached to every agent's request by {@link #chat(String, ToolContext)}, so the bound holds for
+	 * every current and future agent without each agent having to opt in (PLFM-9881). Configured with
+	 * {@code disableMemory()} because every agent registers its own {@code ChatMemory} advisor, which
+	 * remains the owner of conversation history. Stateless, so this single instance is shared across all
+	 * agents and concurrent chats.
+	 */
+	static final ToolCallAdvisor TURN_LIMITING_TOOL_CALL_ADVISOR = ToolCallAdvisor.builder().disableMemory().build();
+
+	/** Bounds the {@link #TURN_LIMITING_TOOL_CALL_ADVISOR} loop to {@link TurnLimitAdvisor#DEFAULT_MAX_TURNS}. */
+	static final TurnLimitAdvisor TURN_LIMIT_ADVISOR = new TurnLimitAdvisor();
+
+	/**
 	 * Builds the request spec for a single turn: the user message, the tool context passed straight
 	 * through, and the memory advisor bound to this instance's conversation. The implementation wires its
 	 * own tools, system prompt, model, and output-token budget here (via its {@code ChatClient}).
@@ -112,7 +129,13 @@ public interface Agent {
 	 *         is no response
 	 */
 	default String chat(String message, ToolContext context) {
-		ChatClientRequestSpec spec = prepareChatClientRequestSpec(message, context);
+		// Enforce the turn limit for every agent from the one place they all run a turn: hoist the
+		// tool-calling loop into the advisor chain and seed a fresh counter for this invocation, so no
+		// agent can accidentally run an unbounded loop (PLFM-9881). Each agent's own ChatMemory advisor is
+		// left in the chain to own conversation history.
+		ChatClientRequestSpec spec = prepareChatClientRequestSpec(message, context)
+				.advisors(a -> a.advisors(TURN_LIMITING_TOOL_CALL_ADVISOR, TURN_LIMIT_ADVISOR)
+						.param(AgentToolContextKey.TURN_COUNT.getKey(), new AtomicInteger()));
 		CallResponseSpec response = spec.call();
 
 		ChatResponse chatResponse = response.chatResponse();

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/Agent.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/Agent.java
@@ -7,6 +7,7 @@ import org.sagebionetworks.repo.manager.agent.tool.TurnLimitAdvisor;
 import org.springframework.ai.chat.client.ChatClient.CallResponseSpec;
 import org.springframework.ai.chat.client.ChatClient.ChatClientRequestSpec;
 import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
+import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.model.ToolContext;
@@ -79,12 +80,23 @@ public interface Agent {
 	 * Runs the tool-calling loop as part of the advisor chain (instead of internally, below the chain)
 	 * so {@link #TURN_LIMIT_ADVISOR} — a downstream advisor it re-invokes each iteration — can bound it.
 	 * Attached to every agent's request by {@link #chat(String, ToolContext)}, so the bound holds for
-	 * every current and future agent without each agent having to opt in (PLFM-9881). Configured with
-	 * {@code disableMemory()} because every agent registers its own {@code ChatMemory} advisor, which
-	 * remains the owner of conversation history. Stateless, so this single instance is shared across all
-	 * agents and concurrent chats.
+	 * every current and future agent without each agent having to opt in (PLFM-9881).
+	 * <p>
+	 * Its order places it <em>inside</em> the agent's own {@code ChatMemory} advisor (which sits at
+	 * {@link Advisor#DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER}) and <em>outside</em> {@link #TURN_LIMIT_ADVISOR}.
+	 * That ordering is load-bearing: the memory advisor must run <em>once per {@code chat()}</em>, not once
+	 * per tool-loop iteration. If it were outside this loop-driving advisor (its stock default), the loop
+	 * would re-invoke it every iteration, and its {@code after} step would store <em>every</em> generation
+	 * of each turn into memory — including the spurious empty-text, tool-call-free placeholder generation
+	 * {@code BedrockProxyChatModel} emits for a pure tool-use turn. That empty assistant message would then
+	 * be replayed on the next iteration, and Bedrock Converse rejects a message with empty content ("the
+	 * content field ... is empty", HTTP 400). Kept inside memory, the loop instead carries its own clean
+	 * conversation history (built by the {@code ToolCallingManager} from only the real tool-call
+	 * generation), and memory sees only the single final answer. Stateless, so this one instance is shared
+	 * across all agents and concurrent chats.
 	 */
-	static final ToolCallAdvisor TURN_LIMITING_TOOL_CALL_ADVISOR = ToolCallAdvisor.builder().disableMemory().build();
+	static final ToolCallAdvisor TURN_LIMITING_TOOL_CALL_ADVISOR = ToolCallAdvisor.builder()
+			.advisorOrder(Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER + 50).build();
 
 	/** Bounds the {@link #TURN_LIMITING_TOOL_CALL_ADVISOR} loop to {@link TurnLimitAdvisor#DEFAULT_MAX_TURNS}. */
 	static final TurnLimitAdvisor TURN_LIMIT_ADVISOR = new TurnLimitAdvisor();

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/AgentToolContextKey.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/AgentToolContextKey.java
@@ -54,7 +54,16 @@ public enum AgentToolContextKey {
 	 * successfully staged into the shared code interpreter session for the current Curie turn. The
 	 * {@code CurieSupervisor} reads it to prepend a description of those files to the user message.
 	 */
-	STAGED_ATTACHMENTS("stagedAttachments");
+	STAGED_ATTACHMENTS("stagedAttachments"),
+
+	/**
+	 * A per-{@code chat()} turn counter ({@link java.util.concurrent.atomic.AtomicInteger}) seeded into the
+	 * advisor context by {@code Agent.chat()} before the tool-calling loop starts and read by
+	 * {@link org.sagebionetworks.repo.manager.agent.tool.TurnLimitAdvisor} to bound the number of model
+	 * turns a single chat may take (PLFM-9881). Carried in the same context map as the tool keys, so it is
+	 * centralized here to avoid colliding with them.
+	 */
+	TURN_COUNT("turnCount");
 
 	private final String key;
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/tool/TurnLimitAdvisor.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/tool/TurnLimitAdvisor.java
@@ -43,8 +43,10 @@ import org.springframework.ai.chat.model.Generation;
  * {@link AgentToolContextKey#TURN_COUNT}; the counter must be seeded there before the loop starts (see
  * {@code Agent.chat}) because the {@link ToolCallAdvisor} rebuilds each iteration's request from the
  * original context, so a counter this advisor tried to add itself would be discarded on the next
- * iteration. A single advisor instance holds no per-conversation state and is safe to share across
- * concurrent chats.
+ * iteration. If the counter is absent or of the wrong type this advisor throws an
+ * {@link IllegalStateException} rather than silently running unbounded, so a chain wired without the
+ * seeded counter fails fast instead of reintroducing the runaway loop. A single advisor instance holds
+ * no per-conversation state and is safe to share across concurrent chats.
  */
 public class TurnLimitAdvisor implements CallAdvisor {
 
@@ -100,11 +102,14 @@ public class TurnLimitAdvisor implements CallAdvisor {
 
 	@Override
 	public ChatClientResponse adviseCall(ChatClientRequest chatClientRequest, CallAdvisorChain callAdvisorChain) {
+		// The counter must have been seeded into the context before the loop started (see Agent.chat). An
+		// absent or wrong-typed counter means this advisor was wired into a chain without that seeding, which
+		// would leave the tool-calling loop unbounded — the exact PLFM-9879 failure mode. Fail loudly rather
+		// than silently degrade to no limit, so a misconfiguration cannot reintroduce the runaway loop.
 		Object counter = chatClientRequest.context().get(AgentToolContextKey.TURN_COUNT.getKey());
-		// Enforce only when a counter was seeded for this loop; used outside that path (e.g. a plain
-		// single-shot call) this advisor is a pass-through.
 		if (!(counter instanceof AtomicInteger turnCount)) {
-			return callAdvisorChain.nextCall(chatClientRequest);
+			throw new IllegalStateException("A turn counter (AtomicInteger) must be seeded into the advisor context "
+					+ "under '" + AgentToolContextKey.TURN_COUNT.getKey() + "' before the tool-calling loop starts.");
 		}
 		// The model is allowed maxTurns turns. The loop only re-enters this advisor when the previous turn
 		// asked for another tool call, so the first turn past the budget means the model is still not done.

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/tool/TurnLimitAdvisor.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/tool/TurnLimitAdvisor.java
@@ -1,0 +1,134 @@
+package org.sagebionetworks.repo.manager.agent.tool;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sagebionetworks.repo.manager.agent.AgentToolContextKey;
+import org.sagebionetworks.util.ValidateArgument;
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
+import org.springframework.ai.chat.client.advisor.api.Advisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+
+/**
+ * Caps the number of model turns (Bedrock round-trips) a single {@code chat()} may take.
+ * <p>
+ * A {@link ToolCallAdvisor} runs the tool-calling loop as part of the advisor chain and, on every
+ * iteration, re-invokes the advisors that sit after it in the chain. This advisor is one of those
+ * downstream advisors: registered just after the chat-memory advisor, it is therefore called once per
+ * model turn and counts them. Without a bound the loop only ends when the model stops emitting tool
+ * calls, so a model that never converges (e.g. it retries a tool that keeps failing) loops forever — a
+ * Compute task once ran for 9+ hours retrying {@code runPython} against an expired code-interpreter
+ * session (PLFM-9879). This bounds that loop (PLFM-9881).
+ * <p>
+ * Once the model has taken its full turn budget, this advisor ends the loop by short-circuiting: on the
+ * turn past the budget it returns a terminal, tool-free response carrying a {@code RESULT: ERROR} marker
+ * <em>without calling the model</em>. The {@link ToolCallAdvisor} continues its loop only while the
+ * response {@link ChatResponse#hasToolCalls() has tool calls}, so a response with none ends it
+ * immediately. Not calling the model on that turn is both necessary and sufficient: the Compute
+ * sub-workers require a {@code RESULT: SUCCESS} marker, so this fails an over-budget task fast; and a
+ * final model call is not a safe alternative here, because by this point the conversation history
+ * contains {@code toolUse}/{@code toolResult} content blocks and Bedrock Converse rejects any request
+ * carrying those blocks without a {@code toolConfig} — so a tool-stripped "final answer" request returns
+ * a 400.
+ * <p>
+ * The per-invocation turn counter is an {@link AtomicInteger} read from the advisor context under
+ * {@link AgentToolContextKey#TURN_COUNT}; the counter must be seeded there before the loop starts (see
+ * {@code Agent.chat}) because the {@link ToolCallAdvisor} rebuilds each iteration's request from the
+ * original context, so a counter this advisor tried to add itself would be discarded on the next
+ * iteration. A single advisor instance holds no per-conversation state and is safe to share across
+ * concurrent chats.
+ */
+public class TurnLimitAdvisor implements CallAdvisor {
+
+	private static final Logger LOG = LogManager.getLogger(TurnLimitAdvisor.class);
+
+	/**
+	 * The default per-{@code chat()} turn budget: the maximum number of model turns the tool-calling loop
+	 * may take. Sized above the turns a legitimate multi-step generation needs (schema lookups, per-file
+	 * reads, delegations, and Python transforms) but far below a runaway loop, so it is a coarse safety
+	 * ceiling rather than a tuning target.
+	 */
+	public static final int DEFAULT_MAX_TURNS = 20;
+
+	/**
+	 * Registered just after the chat-memory advisor ({@link Advisor#DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER}),
+	 * so it counts turns and short-circuits the over-budget turn after memory has assembled the
+	 * conversation and immediately before the model would be called.
+	 */
+	public static final int ADVISOR_ORDER = Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER + 100;
+
+	/**
+	 * The text of the terminal response returned once the turn budget is exhausted. It carries the
+	 * Compute sub-workers' {@code RESULT: ERROR} marker so an over-budget run fails the task with a
+	 * meaningful message instead of running forever.
+	 */
+	public static final String TURN_LIMIT_REACHED_RESULT = "RESULT: ERROR - reached the maximum number of tool-use turns "
+			+ "before completing the task.";
+
+	private final int maxTurns;
+
+	public TurnLimitAdvisor() {
+		this(DEFAULT_MAX_TURNS);
+	}
+
+	public TurnLimitAdvisor(int maxTurns) {
+		ValidateArgument.requirement(maxTurns > 0, "maxTurns must be greater than 0");
+		this.maxTurns = maxTurns;
+	}
+
+	public int getMaxTurns() {
+		return maxTurns;
+	}
+
+	@Override
+	public String getName() {
+		return "Turn Limit Advisor";
+	}
+
+	@Override
+	public int getOrder() {
+		return ADVISOR_ORDER;
+	}
+
+	@Override
+	public ChatClientResponse adviseCall(ChatClientRequest chatClientRequest, CallAdvisorChain callAdvisorChain) {
+		Object counter = chatClientRequest.context().get(AgentToolContextKey.TURN_COUNT.getKey());
+		// Enforce only when a counter was seeded for this loop; used outside that path (e.g. a plain
+		// single-shot call) this advisor is a pass-through.
+		if (!(counter instanceof AtomicInteger turnCount)) {
+			return callAdvisorChain.nextCall(chatClientRequest);
+		}
+		// The model is allowed maxTurns turns. The loop only re-enters this advisor when the previous turn
+		// asked for another tool call, so the first turn past the budget means the model is still not done.
+		int turn = turnCount.incrementAndGet();
+		if (turn <= maxTurns) {
+			return callAdvisorChain.nextCall(chatClientRequest);
+		}
+		LOG.warn("Reached the turn limit of {} for this chat; ending the tool-calling loop with a failure result.",
+				maxTurns);
+		return terminalFailureResponse(chatClientRequest);
+	}
+
+	/**
+	 * Builds the terminal response that ends the {@link ToolCallAdvisor} loop: a single assistant
+	 * generation with the {@link #TURN_LIMIT_REACHED_RESULT} text and no tool calls, so
+	 * {@link ChatResponse#hasToolCalls()} is {@code false}. The original context is carried through so any
+	 * upstream advisor (e.g. chat memory) sees the same context it started with.
+	 */
+	private ChatClientResponse terminalFailureResponse(ChatClientRequest chatClientRequest) {
+		ChatResponse chatResponse = new ChatResponse(
+				List.of(new Generation(new AssistantMessage(TURN_LIMIT_REACHED_RESULT))));
+		return ChatClientResponse.builder()
+				.chatResponse(chatResponse)
+				.context(chatClientRequest.context())
+				.build();
+	}
+}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/tool/TurnLimitAdvisor.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/agent/tool/TurnLimitAdvisor.java
@@ -61,9 +61,10 @@ public class TurnLimitAdvisor implements CallAdvisor {
 	public static final int DEFAULT_MAX_TURNS = 20;
 
 	/**
-	 * Registered just after the chat-memory advisor ({@link Advisor#DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER}),
-	 * so it counts turns and short-circuits the over-budget turn after memory has assembled the
-	 * conversation and immediately before the model would be called.
+	 * Placed after the chat-memory advisor ({@link Advisor#DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER}) and, by
+	 * design, <em>inside</em> the loop-driving {@link ToolCallAdvisor} (see {@code Agent}). Being the
+	 * innermost advisor before the model, it is re-invoked on every tool-loop iteration — which is how it
+	 * counts turns — and short-circuits the over-budget turn immediately before the model would be called.
 	 */
 	public static final int ADVISOR_ORDER = Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER + 100;
 

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/compute/RecordSetGenerationSubWorker.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/compute/RecordSetGenerationSubWorker.java
@@ -112,8 +112,11 @@ public class RecordSetGenerationSubWorker implements ComputeTaskSubWorker<Record
 		String targetSchemaId = recordSetOutputWriter.getBoundSchemaId(user, recordSetId);
 		validateInputFileCount(user, properties.getFolderId());
 
+		long startNanos = System.nanoTime();
 		String sessionId = codeInterpreterClient.startSession("recordSetGen-" + task.getTaskId());
 		try {
+			LOG.info("Starting RecordSet generation for task {}: inputFolderId={}, recordSetId={}, targetSchemaId={}, "
+					+ "sessionId={}", task.getTaskId(), properties.getFolderId(), recordSetId, targetSchemaId, sessionId);
 			callback.updateProgress("Running the RecordSet generation supervisor", 0L, 100L);
 			// The batch path runs against an already-started session, so the id is placed directly under
 			// CODE_SESSION_ID (no lazy supplier) for the supervisor's specialists to resolve.
@@ -122,6 +125,8 @@ public class RecordSetGenerationSubWorker implements ComputeTaskSubWorker<Record
 					AgentToolContextKey.CODE_SESSION_ID.getKey(), sessionId));
 			String supervisorResponse = supervisorFactory.create().chat(buildSupervisorMessage(properties.getFolderId(),
 					targetSchemaId, properties.getInstructions()), toolContext);
+			LOG.info("RecordSet generation supervisor for task {} (session {}) returned: {}", task.getTaskId(),
+					sessionId, supervisorResponse);
 
 			SupervisorResult.requireSuccess(supervisorResponse, "RecordSet generation did not succeed: ");
 
@@ -134,6 +139,8 @@ public class RecordSetGenerationSubWorker implements ComputeTaskSubWorker<Record
 			recordSetOutputWriter.storeCsvAsNewRecordSetVersion(user, recordSetId, dataFileHandleId);
 
 			callback.updateProgress("RecordSet generation complete", 100L, 100L);
+			LOG.info("Completed RecordSet generation for task {} in {} ms: stored file handle {} on RecordSet {}",
+					task.getTaskId(), (System.nanoTime() - startNanos) / 1_000_000L, dataFileHandleId, recordSetId);
 			return details;
 		} finally {
 			try {

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/compute/SampleSheetGenerationSubWorker.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/curation/compute/SampleSheetGenerationSubWorker.java
@@ -87,8 +87,12 @@ public class SampleSheetGenerationSubWorker implements ComputeTaskSubWorker<Samp
 		String recordSetId = getDestinationRecordSetId(user, properties.getDestinationTaskId());
 		String targetSchemaId = recordSetOutputWriter.getBoundSchemaId(user, recordSetId);
 
+		long startNanos = System.nanoTime();
 		String sessionId = codeInterpreterClient.startSession("sampleSheetGen-" + task.getTaskId());
 		try {
+			LOG.info("Starting sample sheet generation for task {}: inputFileViewId={}, recordSetId={}, "
+					+ "targetSchemaId={}, sessionId={}", task.getTaskId(), fileViewId, recordSetId, targetSchemaId,
+					sessionId);
 			callback.updateProgress("Running the sample sheet supervisor", 0L, 100L);
 			// The batch path runs against an already-started session, so the id is placed directly under
 			// CODE_SESSION_ID (no lazy supplier) for the supervisor's specialists to resolve.
@@ -97,6 +101,8 @@ public class SampleSheetGenerationSubWorker implements ComputeTaskSubWorker<Samp
 					AgentToolContextKey.CODE_SESSION_ID.getKey(), sessionId));
 			String supervisorResponse = supervisorFactory.create()
 					.chat(buildSupervisorMessage(fileViewId, targetSchemaId), toolContext);
+			LOG.info("Sample sheet supervisor for task {} (session {}) returned: {}", task.getTaskId(), sessionId,
+					supervisorResponse);
 
 			SupervisorResult.requireSuccess(supervisorResponse, "Sample sheet generation did not succeed: ");
 
@@ -109,6 +115,8 @@ public class SampleSheetGenerationSubWorker implements ComputeTaskSubWorker<Samp
 			recordSetOutputWriter.storeCsvAsNewRecordSetVersion(user, recordSetId, dataFileHandleId);
 
 			callback.updateProgress("Sample sheet generation complete", 100L, 100L);
+			LOG.info("Completed sample sheet generation for task {} in {} ms: stored file handle {} on RecordSet {}",
+					task.getTaskId(), (System.nanoTime() - startNanos) / 1_000_000L, dataFileHandleId, recordSetId);
 			return details;
 		} finally {
 			try {

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentTest.java
@@ -2,10 +2,13 @@ package org.sagebionetworks.repo.manager.agent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -29,6 +32,14 @@ public class AgentTest {
 	private ChatResponse chatResponse;
 
 	private ToolContext context = new ToolContext(java.util.Map.of());
+
+	@BeforeEach
+	public void before() {
+		// chat() attaches the turn-limit advisors and seeds the counter on the spec before calling it; the
+		// spec is a builder, so return it from advisors(...) so the chain reaches call(). The advisor wiring
+		// itself is exercised against a real ChatClient in AgentTurnLimitWiringTest.
+		when(requestSpec.advisors(any(Consumer.class))).thenReturn(requestSpec);
+	}
 
 	/**
 	 * Minimal {@link Agent} of the given type whose only job is to hand back the mocked request spec, so

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentTurnLimitWiringTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentTurnLimitWiringTest.java
@@ -10,7 +10,11 @@ import org.junit.jupiter.api.Test;
 import org.sagebionetworks.repo.manager.agent.tool.TurnLimitAdvisor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.ChatClient.ChatClientRequestSpec;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
@@ -19,6 +23,8 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Proves the turn-limit guarantee at the {@code Agent.chat()} seam through the <em>real</em> Spring AI
@@ -138,5 +144,80 @@ public class AgentTurnLimitWiringTest {
 
 		AssistantMessage terminal = new AssistantMessage(TurnLimitAdvisor.TURN_LIMIT_REACHED_RESULT);
 		assertFalse(terminal.hasToolCalls());
+	}
+
+	@Test
+	public void testToolLoopDoesNotReplayEmptyAssistantMessageWithMemoryAdvisor() {
+		// Regression for PLFM-9881: BedrockProxyChatModel emits a spurious empty-text, tool-call-free
+		// placeholder generation for a pure tool-use turn. If the per-agent ChatMemory advisor runs inside
+		// the tool-calling loop, its `after` step stores that placeholder and it is replayed on the next
+		// iteration, which Bedrock Converse rejects as an empty-content message (HTTP 400). The advisor
+		// ordering must keep memory outside the loop so the placeholder never re-enters a request.
+		EmptyPlaceholderThenDoneModel model = new EmptyPlaceholderThenDoneModel();
+		ChatClient chatClient = ChatClient.builder(model)
+				.defaultToolCallbacks(new AlwaysSucceedingTool())
+				.defaultAdvisors(MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().build()).build())
+				.defaultOptions(ToolCallingChatOptions.builder().build())
+				.build();
+		Agent agent = new Agent() {
+			@Override
+			public AgentRole getAgentRole() {
+				return AgentRole.SUPERVISOR;
+			}
+
+			@Override
+			public ChatClientRequestSpec prepareChatClientRequestSpec(String message, ToolContext context) {
+				return chatClient.prompt().user(message).toolContext(context.getContext())
+						.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "test-conversation"));
+			}
+		};
+
+		// call under test
+		String result = agent.chat("do the work", new ToolContext(Map.of()));
+
+		assertEquals(EmptyPlaceholderThenDoneModel.FINAL_ANSWER, result);
+		// The second turn's request must not carry the empty placeholder assistant message.
+		assertFalse(model.sawEmptyAssistantMessageOnSecondTurn(),
+				"An empty-content assistant message was replayed to the model; Bedrock would reject it (400).");
+	}
+
+	/**
+	 * Emits a pure tool-use turn shaped exactly like {@code BedrockProxyChatModel}'s output for one — an
+	 * empty placeholder generation (no text, no tool calls) alongside the real tool-call generation — then
+	 * finishes with a plain text answer. On the second turn it records whether the empty placeholder was
+	 * replayed back into the request, which is the failure the memory-ordering fix prevents.
+	 */
+	private static class EmptyPlaceholderThenDoneModel implements ChatModel {
+
+		static final String FINAL_ANSWER = "RESULT: SUCCESS - done";
+
+		private int callCount = 0;
+
+		private boolean sawEmptyOnSecondTurn = false;
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			callCount++;
+			if (callCount == 1) {
+				Generation placeholder = new Generation(AssistantMessage.builder().properties(Map.of()).build());
+				AssistantMessage toolCall = AssistantMessage.builder()
+						.content("")
+						.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function",
+								AlwaysSucceedingTool.NAME, "{}")))
+						.build();
+				return new ChatResponse(List.of(placeholder, new Generation(toolCall)));
+			}
+			for (Message message : prompt.getInstructions()) {
+				if (message instanceof AssistantMessage assistant && !StringUtils.hasText(assistant.getText())
+						&& CollectionUtils.isEmpty(assistant.getToolCalls())) {
+					sawEmptyOnSecondTurn = true;
+				}
+			}
+			return new ChatResponse(List.of(new Generation(new AssistantMessage(FINAL_ANSWER))));
+		}
+
+		boolean sawEmptyAssistantMessageOnSecondTurn() {
+			return sawEmptyOnSecondTurn;
+		}
 	}
 }

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentTurnLimitWiringTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/AgentTurnLimitWiringTest.java
@@ -1,0 +1,142 @@
+package org.sagebionetworks.repo.manager.agent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.sagebionetworks.repo.manager.agent.tool.TurnLimitAdvisor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClient.ChatClientRequestSpec;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+/**
+ * Proves the turn-limit guarantee at the {@code Agent.chat()} seam through the <em>real</em> Spring AI
+ * advisor chain — the {@link Agent#TURN_LIMITING_TOOL_CALL_ADVISOR} + {@link Agent#TURN_LIMIT_ADVISOR}
+ * composition and counter seeding that {@code chat()} wires — with no AWS/Bedrock (PLFM-9881).
+ * <p>
+ * The fake {@link ChatModel} here always emits a tool call, so absent the bound the tool-calling loop
+ * would run forever (the PLFM-9879 failure mode). The test asserts the model is called exactly
+ * {@link TurnLimitAdvisor#DEFAULT_MAX_TURNS} times and {@code chat()} returns the terminal
+ * {@code RESULT: ERROR} marker — the universal guarantee that a new agent cannot accidentally reintroduce
+ * the unbounded loop, since every agent runs through this same {@code chat()} default method.
+ */
+public class AgentTurnLimitWiringTest {
+
+	@Test
+	public void testChatBoundsAnUnboundedToolCallingModel() {
+		// A model that never stops asking for a tool: unbounded, chat()'s loop would run forever.
+		CountingLoopingChatModel model = new CountingLoopingChatModel();
+		Agent agent = agentOver(model);
+
+		// call under test
+		String result = agent.chat("do the work", new ToolContext(Map.of()));
+
+		// The model was called for exactly the budgeted turns; the turn past the budget short-circuits
+		// without calling it, so the loop is bounded even though the model always wants another tool.
+		assertEquals(TurnLimitAdvisor.DEFAULT_MAX_TURNS, model.getCallCount());
+		assertEquals(TurnLimitAdvisor.TURN_LIMIT_REACHED_RESULT, result);
+	}
+
+	/**
+	 * A minimal supervisor {@link Agent} whose {@code ChatClient} runs over the fake model with a single
+	 * real tool the {@code ToolCallingManager} can execute — the same shape a real agent builds, so
+	 * {@code chat()} wires the tool-call and turn-limit advisors around it exactly as in production.
+	 */
+	private Agent agentOver(ChatModel model) {
+		ChatClient chatClient = ChatClient.builder(model)
+				.defaultToolCallbacks(new AlwaysSucceedingTool())
+				.defaultOptions(ToolCallingChatOptions.builder().build())
+				.build();
+		return new Agent() {
+			@Override
+			public AgentRole getAgentRole() {
+				return AgentRole.SUPERVISOR;
+			}
+
+			@Override
+			public ChatClientRequestSpec prepareChatClientRequestSpec(String message, ToolContext context) {
+				return chatClient.prompt().user(message).toolContext(context.getContext());
+			}
+		};
+	}
+
+	/**
+	 * Returns a response asking for {@link AlwaysSucceedingTool} on every call, so the tool-calling loop
+	 * only ends if something bounds it. Counts its calls, and fails fast (rather than hanging the test)
+	 * if the bound is ever removed and the loop runs away.
+	 */
+	private static class CountingLoopingChatModel implements ChatModel {
+
+		private int callCount = 0;
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			callCount++;
+			if (callCount > TurnLimitAdvisor.DEFAULT_MAX_TURNS + 5) {
+				throw new IllegalStateException(
+						"The turn limit was not enforced; the tool-calling loop ran unbounded.");
+			}
+			AssistantMessage message = AssistantMessage.builder()
+					.content("")
+					.toolCalls(List.of(new AssistantMessage.ToolCall("call-" + callCount, "function",
+							AlwaysSucceedingTool.NAME, "{}")))
+					.build();
+			return new ChatResponse(List.of(new Generation(message)));
+		}
+
+		int getCallCount() {
+			return callCount;
+		}
+	}
+
+	/**
+	 * A no-op tool the {@code ToolCallingManager} executes each iteration so the loop can continue. Its
+	 * result never satisfies the model (which always asks again), which is the point: convergence must
+	 * come from the turn limit, not the tool.
+	 */
+	private static class AlwaysSucceedingTool implements ToolCallback {
+
+		static final String NAME = "keepGoing";
+
+		@Override
+		public ToolDefinition getToolDefinition() {
+			return ToolDefinition.builder()
+					.name(NAME)
+					.description("A no-op tool used to keep the tool-calling loop going.")
+					.inputSchema("{\"type\":\"object\",\"properties\":{}}")
+					.build();
+		}
+
+		@Override
+		public String call(String toolInput) {
+			return "not done yet";
+		}
+
+		@Override
+		public String call(String toolInput, ToolContext toolContext) {
+			return call(toolInput);
+		}
+	}
+
+	@Test
+	public void testTerminalResponseHasNoToolCalls() {
+		// A guard on the mechanism the loop relies on: the terminal response must carry no tool calls, or
+		// the ToolCallAdvisor would loop again on it. (Complements the end-to-end bound above.)
+		CountingLoopingChatModel model = new CountingLoopingChatModel();
+		agentOver(model).chat("do the work", new ToolContext(Map.of()));
+
+		AssistantMessage terminal = new AssistantMessage(TurnLimitAdvisor.TURN_LIMIT_REACHED_RESULT);
+		assertFalse(terminal.hasToolCalls());
+	}
+}

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/tool/TurnLimitAdvisorTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/tool/TurnLimitAdvisorTest.java
@@ -41,10 +41,11 @@ public class TurnLimitAdvisorTest {
 	private ChatClientResponse chainResponse;
 
 	/**
-	 * Builds a request carrying the tool the model would loop on, and (optionally) a seeded turn counter
-	 * under the key the advisor reads.
+	 * Builds a request carrying the tool the model would loop on, and (optionally) a value seeded under the
+	 * key the advisor reads. Accepts {@link Object} so tests can seed a wrong-typed value (or none) to
+	 * exercise the fail-fast path.
 	 */
-	private ChatClientRequest requestWithCounter(AtomicInteger counter) {
+	private ChatClientRequest requestWithCounter(Object counter) {
 		ToolCallingChatOptions options = ToolCallingChatOptions.builder().toolNames(A_TOOL).build();
 		Prompt prompt = new Prompt(List.of(new UserMessage("do work")), options);
 		Map<String, Object> context = new HashMap<>();
@@ -136,18 +137,27 @@ public class TurnLimitAdvisorTest {
 
 	@Test
 	public void testAdviseCallWithNoCounter() {
-		// Without a seeded counter (e.g. the advisor used outside Agent.chat) no limit is enforced, even
-		// when the budget is 1 and the counter would otherwise be over it.
+		// Without a seeded counter the advisor cannot enforce a bound, so it fails fast rather than silently
+		// running unbounded — this is what stops a chain wired without the counter from looping forever.
 		ChatClientRequest request = requestWithCounter(null);
-		when(chain.nextCall(any())).thenReturn(chainResponse);
 		TurnLimitAdvisor advisor = new TurnLimitAdvisor(1);
 
 		// call under test
-		ChatClientResponse result = advisor.adviseCall(request, chain);
-		result = advisor.adviseCall(request, chain);
+		assertThrows(IllegalStateException.class, () -> advisor.adviseCall(request, chain));
 
-		assertSame(chainResponse, result);
-		verify(chain, times(2)).nextCall(request);
+		verify(chain, never()).nextCall(any());
+	}
+
+	@Test
+	public void testAdviseCallWithWrongTypeCounter() {
+		// A value of the wrong type under the counter key is treated like a missing counter: fail fast.
+		ChatClientRequest request = requestWithCounter("not-a-counter");
+		TurnLimitAdvisor advisor = new TurnLimitAdvisor(1);
+
+		// call under test
+		assertThrows(IllegalStateException.class, () -> advisor.adviseCall(request, chain));
+
+		verify(chain, never()).nextCall(any());
 	}
 
 	@Test

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/tool/TurnLimitAdvisorTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/agent/tool/TurnLimitAdvisorTest.java
@@ -1,0 +1,167 @@
+package org.sagebionetworks.repo.manager.agent.tool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sagebionetworks.repo.manager.agent.AgentToolContextKey;
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.Advisor;
+import org.springframework.ai.chat.client.advisor.api.CallAdvisorChain;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+
+@ExtendWith(MockitoExtension.class)
+public class TurnLimitAdvisorTest {
+
+	private static final String A_TOOL = "askSpecialist";
+
+	@Mock
+	private CallAdvisorChain chain;
+
+	@Mock
+	private ChatClientResponse chainResponse;
+
+	/**
+	 * Builds a request carrying the tool the model would loop on, and (optionally) a seeded turn counter
+	 * under the key the advisor reads.
+	 */
+	private ChatClientRequest requestWithCounter(AtomicInteger counter) {
+		ToolCallingChatOptions options = ToolCallingChatOptions.builder().toolNames(A_TOOL).build();
+		Prompt prompt = new Prompt(List.of(new UserMessage("do work")), options);
+		Map<String, Object> context = new HashMap<>();
+		if (counter != null) {
+			context.put(AgentToolContextKey.TURN_COUNT.getKey(), counter);
+		}
+		return ChatClientRequest.builder().prompt(prompt).context(context).build();
+	}
+
+	@Test
+	public void testAdviseCallWithinBudget() {
+		AtomicInteger counter = new AtomicInteger(0);
+		ChatClientRequest request = requestWithCounter(counter);
+		when(chain.nextCall(any())).thenReturn(chainResponse);
+		TurnLimitAdvisor advisor = new TurnLimitAdvisor(3);
+
+		// call under test
+		ChatClientResponse result = advisor.adviseCall(request, chain);
+
+		assertSame(chainResponse, result);
+		assertEquals(1, counter.get());
+		// A turn within the budget is passed downstream to the model untouched.
+		ArgumentCaptor<ChatClientRequest> captor = ArgumentCaptor.forClass(ChatClientRequest.class);
+		verify(chain).nextCall(captor.capture());
+		assertSame(request, captor.getValue());
+	}
+
+	@Test
+	public void testAdviseCallOnLastBudgetedTurn() {
+		// Seeded so this call is the maxTurns-th turn: the model still gets called (the limit is not yet
+		// exceeded), so a model that finishes on its last budgeted turn can still succeed.
+		AtomicInteger counter = new AtomicInteger(2);
+		ChatClientRequest request = requestWithCounter(counter);
+		when(chain.nextCall(any())).thenReturn(chainResponse);
+		TurnLimitAdvisor advisor = new TurnLimitAdvisor(3);
+
+		// call under test
+		ChatClientResponse result = advisor.adviseCall(request, chain);
+
+		assertSame(chainResponse, result);
+		assertEquals(3, counter.get());
+		ArgumentCaptor<ChatClientRequest> captor = ArgumentCaptor.forClass(ChatClientRequest.class);
+		verify(chain).nextCall(captor.capture());
+		assertSame(request, captor.getValue());
+	}
+
+	@Test
+	public void testAdviseCallOverBudget() {
+		// Seeded past the budget: the model must not be called (the history holds toolUse/toolResult blocks,
+		// which Bedrock rejects without a toolConfig). The advisor returns a terminal, tool-free result.
+		AtomicInteger counter = new AtomicInteger(3);
+		ChatClientRequest request = requestWithCounter(counter);
+		TurnLimitAdvisor advisor = new TurnLimitAdvisor(3);
+
+		// call under test
+		ChatClientResponse result = advisor.adviseCall(request, chain);
+
+		assertEquals(4, counter.get());
+		// The model is never called on the over-budget turn.
+		verify(chain, never()).nextCall(any());
+		// The terminal response ends the ToolCallAdvisor loop (no tool calls) and carries the failure marker.
+		assertFalse(result.chatResponse().hasToolCalls());
+		assertEquals(TurnLimitAdvisor.TURN_LIMIT_REACHED_RESULT, result.chatResponse().getResult().getOutput().getText());
+		// The original context is carried through unchanged.
+		assertSame(counter, result.context().get(AgentToolContextKey.TURN_COUNT.getKey()));
+	}
+
+	@Test
+	public void testAdviseCallCountsAcrossInvocations() {
+		// A single counter threaded through the loop: the budgeted turns call the model, the turn past the
+		// budget returns the terminal result without calling it.
+		AtomicInteger counter = new AtomicInteger(0);
+		ChatClientRequest request = requestWithCounter(counter);
+		when(chain.nextCall(any())).thenReturn(chainResponse);
+		TurnLimitAdvisor advisor = new TurnLimitAdvisor(3);
+
+		// call under test
+		assertSame(chainResponse, advisor.adviseCall(request, chain));
+		assertSame(chainResponse, advisor.adviseCall(request, chain));
+		assertSame(chainResponse, advisor.adviseCall(request, chain));
+		ChatClientResponse overBudget = advisor.adviseCall(request, chain);
+
+		assertEquals(4, counter.get());
+		// The model was called for the three budgeted turns only.
+		verify(chain, times(3)).nextCall(request);
+		assertEquals(TurnLimitAdvisor.TURN_LIMIT_REACHED_RESULT,
+				overBudget.chatResponse().getResult().getOutput().getText());
+	}
+
+	@Test
+	public void testAdviseCallWithNoCounter() {
+		// Without a seeded counter (e.g. the advisor used outside Agent.chat) no limit is enforced, even
+		// when the budget is 1 and the counter would otherwise be over it.
+		ChatClientRequest request = requestWithCounter(null);
+		when(chain.nextCall(any())).thenReturn(chainResponse);
+		TurnLimitAdvisor advisor = new TurnLimitAdvisor(1);
+
+		// call under test
+		ChatClientResponse result = advisor.adviseCall(request, chain);
+		result = advisor.adviseCall(request, chain);
+
+		assertSame(chainResponse, result);
+		verify(chain, times(2)).nextCall(request);
+	}
+
+	@Test
+	public void testConstructorWithNonPositiveMaxTurns() {
+		assertThrows(IllegalArgumentException.class, () -> new TurnLimitAdvisor(0));
+		assertThrows(IllegalArgumentException.class, () -> new TurnLimitAdvisor(-1));
+	}
+
+	@Test
+	public void testDefaultsAndMetadata() {
+		TurnLimitAdvisor advisor = new TurnLimitAdvisor();
+		assertEquals(TurnLimitAdvisor.DEFAULT_MAX_TURNS, advisor.getMaxTurns());
+		assertEquals(20, advisor.getMaxTurns());
+		assertEquals(Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER + 100, advisor.getOrder());
+		assertEquals("Turn Limit Advisor", advisor.getName());
+	}
+}


### PR DESCRIPTION
…e limit is set to 20.  If a supervisor attempts to make more than 20 tool calls the job will fail with a message indicating that the turn limit was reached.  This will prevent future cases where a supervisor unconditionally calls tools in an infinite loop.