### PR TITLE
PLFM-9653

### DIFF
--- a/lib/lib-docusign/src/main/java/org/sagebionetworks/docusign/DocuSignEnvelopesApiImpl.java
+++ b/lib/lib-docusign/src/main/java/org/sagebionetworks/docusign/DocuSignEnvelopesApiImpl.java
@@ -77,7 +77,11 @@ class DocuSignEnvelopesApiImpl implements DocuSignEnvelopesApi {
 			EnvelopesApi envelopesApi = new EnvelopesApi(apiClient);
 			EnvelopeIdsRequest request = new EnvelopeIdsRequest();
 			request.setEnvelopeIds(envelopeIds);
-			EnvelopesInformation info = envelopesApi.listStatus(config.getAccountId(), request);
+			// The status endpoint only reads the envelope ids from the request body when the
+			// envelope_ids query parameter is set to "request_body"; otherwise DocuSign returns 400.
+			EnvelopesApi.ListStatusOptions options = envelopesApi.new ListStatusOptions();
+			options.setEnvelopeIds("request_body");
+			EnvelopesInformation info = envelopesApi.listStatus(config.getAccountId(), request, options);
 			return info.getEnvelopes() != null ? info.getEnvelopes() : Collections.<Envelope>emptyList();
 		});
 	}

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/dataaccess/RequestManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/dataaccess/RequestManagerImpl.java
@@ -143,6 +143,9 @@ public class RequestManagerImpl implements RequestManager{
 			throws NotFoundException {
 		ValidateArgument.required(userInfo, "userInfo");
 		ValidateArgument.required(accessRequirementId, "accessRequirementId");
+		// Verify the access requirement exists; a missing one must be a 404 rather than falling
+		// through to a blank new-request stub.
+		accessRequirementDao.get(accessRequirementId);
 		try {
 			return requestDao.getUserOwnCurrentRequest(accessRequirementId, userInfo.getId().toString());
 		} catch (NotFoundException e) {
@@ -202,7 +205,6 @@ public class RequestManagerImpl implements RequestManager{
 			throws NotFoundException, UnauthorizedException {
 		ValidateArgument.required(userInfo, "userInfo");
 		validateRequest(toUpdate);
-		validateEnvelopeCompletion(toUpdate);
 		validateFileHandleAccess(userInfo, toUpdate);
 
 		RequestInterface original = requestDao.getForUpdate(toUpdate.getId());
@@ -225,6 +227,15 @@ public class RequestManagerImpl implements RequestManager{
 				userInfo.getId().toString(), toUpdate.getAccessRequirementId(),
 				SubmissionState.SUBMITTED),
 				"A submission has been created. User needs to cancel the created submission or wait for an ACT member to review it before create another submission.");
+
+		// The eDUC signature envelope id is managed by the server (set when routing for signature
+		// and cleared when cancelling). Preserve the persisted value so a client editing the
+		// request cannot resurrect or change it from a stale copy. This must happen before
+		// validateEnvelopeCompletion so the envelope-completion check runs against the authoritative
+		// envelope id rather than whatever the client sent.
+		toUpdate.setEDucSignatureEnvelopeId(original.getEDucSignatureEnvelopeId());
+
+		validateEnvelopeCompletion(toUpdate);
 
 		toUpdate = prepareUpdateFields(toUpdate, userInfo.getId().toString());
 		RequestInterface result = requestDao.update(toUpdate);

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/dataaccess/RequestManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/dataaccess/RequestManagerImplTest.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -234,6 +236,18 @@ public class RequestManagerImplTest {
 		assertEquals(Request.class.getName(), request.getConcreteType());
 	}
 
+	@Test
+	public void testGetRequestForUpdateWithNonExistentAccessRequirement() {
+		// A nonexistent access requirement must be a 404, not a blank new-request stub.
+		when(mockAccessRequirementDao.get(accessRequirementId)).thenThrow(new NotFoundException(""));
+
+		assertThrows(NotFoundException.class, () -> {
+			manager.getRequestForUpdate(mockUser, accessRequirementId);
+		});
+
+		verifyNoInteractions(mockRequestDao);
+	}
+
 	/**
 	 * For this case the current request is a request (not a renewal).
 	 */
@@ -444,6 +458,81 @@ public class RequestManagerImplTest {
 		assertEquals(userId, updated.getCreatedBy());
 		assertEquals(userId, updated.getModifiedBy());
 		assertEquals("777", updated.getDucFileHandleId());
+	}
+
+	@Test
+	public void testUpdatePreservesEDucSignatureEnvelopeId() {
+		// The persisted (original) request has an envelope id set by the server.
+		request.setEDucSignatureEnvelopeId("server-managed-envelope");
+
+		when(mockUser.getId()).thenReturn(1L);
+		when(mockRequestDao.getForUpdate(requestId)).thenReturn(request);
+		when(mockRequestDao.update(any())).thenReturn(request);
+		when(mockSubmissionDao.hasSubmissionWithState(any(), any(), any())).thenReturn(false);
+
+		Renewal toUpdate = RequestManagerImpl.createRenewalFromApprovedRequest(request);
+		// A stale client copy tries to send a different envelope id.
+		toUpdate.setEDucSignatureEnvelopeId("stale-envelope");
+
+		// call under test
+		manager.update(mockUser, toUpdate);
+
+		ArgumentCaptor<Renewal> captor = ArgumentCaptor.forClass(Renewal.class);
+		verify(mockRequestDao).update(captor.capture());
+		// The server-managed value from the original is preserved, not the client's stale value.
+		assertEquals("server-managed-envelope", captor.getValue().getEDucSignatureEnvelopeId());
+	}
+
+	@Test
+	public void testUpdateValidatesEnvelopeCompletionAgainstServerEnvelopeId() {
+		// The persisted request has an in-flight (not completed) eDUC envelope.
+		request.setEDucSignatureEnvelopeId("server-managed-envelope");
+		EDucSignatureStatus status = new EDucSignatureStatus();
+		status.setDucStatus(EDucStatusEnum.sent);
+		when(mockDocuSignClient.getEnvelopeStatus("server-managed-envelope"))
+				.thenReturn(new EnvelopeStatusResult(status, List.of()));
+
+		when(mockUser.getId()).thenReturn(1L);
+		when(mockRequestDao.getForUpdate(requestId)).thenReturn(request);
+		when(mockFileHandleAuthorizationManager.canAccessRawFileHandleById(any(), any())).thenReturn(AuthorizationStatus.authorized());
+		when(mockSubmissionDao.hasSubmissionWithState(any(), any(), any())).thenReturn(false);
+
+		// A stale client omits the envelope id and tries to attach a signed DUC document. The
+		// completion check must run against the server's (in-flight) envelope, not the client's
+		// null, so the update is rejected.
+		Renewal toUpdate = RequestManagerImpl.createRenewalFromApprovedRequest(request);
+		toUpdate.setEDucSignatureEnvelopeId(null);
+		toUpdate.setDucFileHandleId("777");
+
+		// call under test
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> manager.update(mockUser, toUpdate));
+
+		assertEquals("Cannot set ducFileHandleId: the eDUC envelope has not been completed.", ex.getMessage());
+		verify(mockRequestDao, never()).update(any());
+	}
+
+	@Test
+	public void testUpdateDoesNotResurrectClearedEDucSignatureEnvelopeId() {
+		// The persisted (original) request has no envelope id (e.g. signature was cancelled).
+		request.setEDucSignatureEnvelopeId(null);
+
+		when(mockUser.getId()).thenReturn(1L);
+		when(mockRequestDao.getForUpdate(requestId)).thenReturn(request);
+		when(mockRequestDao.update(any())).thenReturn(request);
+		when(mockSubmissionDao.hasSubmissionWithState(any(), any(), any())).thenReturn(false);
+
+		Renewal toUpdate = RequestManagerImpl.createRenewalFromApprovedRequest(request);
+		// A stale client copy still carries the old envelope id.
+		toUpdate.setEDucSignatureEnvelopeId("stale-envelope");
+
+		// call under test
+		manager.update(mockUser, toUpdate);
+
+		ArgumentCaptor<Renewal> captor = ArgumentCaptor.forClass(Renewal.class);
+		verify(mockRequestDao).update(captor.capture());
+		// The cleared value is not resurrected from the stale client copy.
+		assertNull(captor.getValue().getEDucSignatureEnvelopeId());
 	}
 
 	@Test


### PR DESCRIPTION
- when retrieving an access request by access requirement ID, make sure the access requirement exists;
- prevent the client from arbitrarily changing the envelope ID in the access request;
- fixes a small bug in retrieving envelope status