### PR TITLE
PLFM-9914

### DIFF
--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/docusign/EDucManager.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/docusign/EDucManager.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.http.entity.ContentType;
 import org.sagebionetworks.docusign.DocuSignClient;
 import org.sagebionetworks.docusign.EnvelopeStatusResult;
@@ -249,6 +250,7 @@ public class EDucManager {
 		ValidateArgument.required(pi, "principalInvestigator");
 		ValidateArgument.required(pi.getUserId(), "principalInvestigator.userId");
 		ValidateArgument.requiredNotBlank(pi.getName(), "principalInvestigator.name");
+		ValidateArgument.requiredNotBlank(pi.getInstitutionalEmail(), "principalInvestigator.institutionalEmail");
 
 		SigningOfficial so = request.getSigningOfficial();
 		ValidateArgument.required(so, "signingOfficial");
@@ -294,12 +296,19 @@ public class EDucManager {
 		status.setIncludesRequestChanges(true);
 
 		if (status.getSignerStatus() != null) {
+			PrincipalInvestigator pi = request.getPrincipalInvestigator();
 			for (int i = 0; i < status.getSignerStatus().size(); i++) {
 				EDucSignerStatus signerStatus = status.getSignerStatus().get(i);
 				String email = signerEmails.get(i);
-				PrincipalAlias principalAlias = principalAliasDao.findPrincipalWithAlias(email, AliasType.USER_EMAIL);
-				if (principalAlias != null) {
-					signerStatus.setUserId(principalAlias.getPrincipalId().toString());
+				// The principal investigator is addressed at their institutional email, which need
+				// not be a Synapse email alias, so take their user ID straight from the request.
+				if (pi != null && Strings.CI.equals(email, pi.getInstitutionalEmail())) {
+					signerStatus.setUserId(pi.getUserId());
+				} else {
+					PrincipalAlias principalAlias = principalAliasDao.findPrincipalWithAlias(email, AliasType.USER_EMAIL);
+					if (principalAlias != null) {
+						signerStatus.setUserId(principalAlias.getPrincipalId().toString());
+					}
 				}
 			}
 		}
@@ -400,17 +409,17 @@ public class EDucManager {
 
 	/**
 	 * Builds the map from DocuSign role name to the recipient's email and name. Every role must
-	 * have both before the envelope can be sent. The signing official and principal investigator
-	 * names come from the request (their presence is validated in {@link #createDraftEDuc}). A
-	 * collaborator's name comes from their user profile (first and/or last name) when available,
-	 * otherwise their Synapse user name, which every user is guaranteed to have.
+	 * have both before the envelope can be sent. The signing official's and principal
+	 * investigator's institutional emails and names come from the request (their presence is
+	 * validated in {@link #createDraftEDuc}). A collaborator is addressed at their Synapse
+	 * notification email, and their name comes from their user profile (first and/or last name)
+	 * when available, otherwise their Synapse user name, which every user is guaranteed to have.
 	 */
 	private Map<String, RecipientInfo> buildRecipients(RequestInterface request, List<CollaboratorInfo> collaborators) {
 		Map<String, RecipientInfo> recipients = new LinkedHashMap<>();
 
 		PrincipalInvestigator pi = request.getPrincipalInvestigator();
-		String piEmail = notificationEmailDao.getNotificationEmailForPrincipal(Long.parseLong(pi.getUserId()));
-		recipients.put("principal_investigator", new RecipientInfo(piEmail, pi.getName()));
+		recipients.put("principal_investigator", new RecipientInfo(pi.getInstitutionalEmail(), pi.getName()));
 
 		SigningOfficial so = request.getSigningOfficial();
 		recipients.put("signing_official", new RecipientInfo(so.getInstitutionalEmail(), so.getName()));

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/docusign/EDucManagerTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/docusign/EDucManagerTest.java
@@ -61,7 +61,6 @@ import org.sagebionetworks.repo.model.educ.EDucTemplateListRequest;
 import org.sagebionetworks.repo.model.educ.EDucTemplatePage;
 import org.sagebionetworks.repo.model.educ.EDucSignatureQuota;
 import org.sagebionetworks.repo.model.principal.AliasType;
-import org.sagebionetworks.repo.model.principal.PrincipalAlias;
 import org.sagebionetworks.repo.model.principal.PrincipalAliasDAO;
 import org.sagebionetworks.repo.web.NotFoundException;
 import org.sagebionetworks.util.Clock;
@@ -263,7 +262,6 @@ public class EDucManagerTest {
 		when(mockPrincipalAliasDao.getUserName(100L)).thenReturn("creatoruser");
 		when(mockPrincipalAliasDao.getUserName(301L)).thenReturn("collab1user");
 		when(mockPrincipalAliasDao.getUserName(302L)).thenReturn("collab2user");
-		when(mockNotificationEmailDao.getNotificationEmailForPrincipal(200L)).thenReturn("pi@synapse.org");
 		when(mockNotificationEmailDao.getNotificationEmailForPrincipal(100L)).thenReturn("creator@example.com");
 		when(mockNotificationEmailDao.getNotificationEmailForPrincipal(301L)).thenReturn("c1@example.com");
 		when(mockNotificationEmailDao.getNotificationEmailForPrincipal(302L)).thenReturn("c2@example.com");
@@ -297,10 +295,11 @@ public class EDucManagerTest {
 		verify(mockDocuSignClient).createEnvelope(eq("tpl-abc"), recipientsCaptor.capture(), tabsCaptor.capture());
 
 		// Collaborators: createdBy=100 first, then 301, 302 from accessorChanges (PI 200 excluded).
-		// Emails come from the notification email DAO; names are PI/SO from the request and
-		// collaborators from their user profile full names.
+		// The PI and SO are addressed at the institutional emails from the request, while
+		// collaborator emails come from the notification email DAO. Names are PI/SO from the
+		// request and collaborators from their user profile full names.
 		Map<String, RecipientInfo> recipients = recipientsCaptor.getValue();
-		assertEquals(new RecipientInfo("pi@synapse.org", "Dr. Jones"), recipients.get("principal_investigator"));
+		assertEquals(new RecipientInfo("pi@university.edu", "Dr. Jones"), recipients.get("principal_investigator"));
 		assertEquals(new RecipientInfo("so@university.edu", "Jane Admin"), recipients.get("signing_official"));
 		assertEquals(new RecipientInfo("creator@example.com", "Creator User"), recipients.get("collaborator_1"));
 		assertEquals(new RecipientInfo("c1@example.com", "Alice Smith"), recipients.get("collaborator_2"));
@@ -320,6 +319,8 @@ public class EDucManagerTest {
 		assertEquals("Alice Smith", tabValues.get(new RoleLabelKey("collaborator_2", "collaborator_2_name")));
 		assertEquals("collab2user", tabValues.get(new RoleLabelKey("collaborator_3", "collaborator_3_user_name")));
 		assertEquals("Bob Brown", tabValues.get(new RoleLabelKey("collaborator_3", "collaborator_3_name")));
+
+		verify(mockNotificationEmailDao, never()).getNotificationEmailForPrincipal(200L);
 	}
 
 	@Test
@@ -507,6 +508,22 @@ public class EDucManagerTest {
 	}
 
 	@Test
+	public void testRouteForSignatureWithNoPIInstitutionalEmail() {
+		Request request = buildValidRequest();
+		request.getPrincipalInvestigator().setInstitutionalEmail(null);
+		UserInfo user = new UserInfo(false, 100L, DEFAULT_REALM_ID);
+		when(mockRequestDao.get("req-1")).thenReturn(request);
+		when(mockAccessRequirementDao.get("456")).thenReturn(buildValidAccessRequirement());
+
+		// call under test
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> eDucManager.routeForSignature(user, "req-1"));
+
+		assertEquals("principalInvestigator.institutionalEmail is required and must not be the empty string.", ex.getMessage());
+		verifyNoInteractions(mockDocuSignClient);
+	}
+
+	@Test
 	public void testRouteForSignatureWithNoSOName() {
 		Request request = buildValidRequest();
 		request.getSigningOfficial().setName(null);
@@ -537,7 +554,6 @@ public class EDucManagerTest {
 		when(mockEDucQuotaDao.getGlobalCount(anyLong(), anyLong())).thenReturn(0L);
 		when(mockPrincipalAliasDao.getUserName(200L)).thenReturn("drjones");
 		when(mockPrincipalAliasDao.getUserName(100L)).thenReturn("creatoruser");
-		when(mockNotificationEmailDao.getNotificationEmailForPrincipal(200L)).thenReturn("pi@synapse.org");
 		when(mockNotificationEmailDao.getNotificationEmailForPrincipal(100L)).thenReturn("creator@example.com");
 		// the creator's profile has no first/last name
 		when(mockUserProfileDao.get("100")).thenReturn(new UserProfile());
@@ -566,7 +582,6 @@ public class EDucManagerTest {
 		when(mockEDucQuotaDao.getGlobalCount(anyLong(), anyLong())).thenReturn(0L);
 		when(mockPrincipalAliasDao.getUserName(200L)).thenReturn("drjones");
 		when(mockPrincipalAliasDao.getUserName(100L)).thenReturn("creatoruser");
-		when(mockNotificationEmailDao.getNotificationEmailForPrincipal(200L)).thenReturn("pi@synapse.org");
 		when(mockNotificationEmailDao.getNotificationEmailForPrincipal(100L)).thenReturn("creator@example.com");
 		UserProfile creatorProfile = new UserProfile();
 		creatorProfile.setFirstName("Creator");
@@ -586,6 +601,7 @@ public class EDucManagerTest {
 		verify(mockDocuSignClient).createEnvelope(eq("tpl-abc"), recipientsCaptor.capture(), any());
 		// PI + SO + createdBy as collaborator_1
 		assertEquals(3, recipientsCaptor.getValue().size());
+		assertEquals("pi@university.edu", recipientsCaptor.getValue().get("principal_investigator").email());
 		assertEquals("creator@example.com", recipientsCaptor.getValue().get("collaborator_1").email());
 	}
 
@@ -820,9 +836,6 @@ public class EDucManagerTest {
 				List.of("pi@university.edu", "so@university.edu"));
 		when(mockDocuSignClient.getEnvelopeStatus("env-123")).thenReturn(envelopeResult);
 
-		PrincipalAlias alias1 = new PrincipalAlias();
-		alias1.setPrincipalId(200L);
-		when(mockPrincipalAliasDao.findPrincipalWithAlias("pi@university.edu", AliasType.USER_EMAIL)).thenReturn(alias1);
 		when(mockPrincipalAliasDao.findPrincipalWithAlias("so@university.edu", AliasType.USER_EMAIL)).thenReturn(null);
 
 		// call under test
@@ -835,10 +848,40 @@ public class EDucManagerTest {
 		assertEquals(2, result.getSignerStatus().size());
 		assertEquals("Dr. Jones", result.getSignerStatus().get(0).getName());
 		assertEquals(EDucSignerStatusEnum.done, result.getSignerStatus().get(0).getStatus());
+		// the PI is matched by their institutional email, so their user ID comes from the request
 		assertEquals("200", result.getSignerStatus().get(0).getUserId());
 		assertEquals("Jane Admin", result.getSignerStatus().get(1).getName());
 		assertEquals(EDucSignerStatusEnum.pending, result.getSignerStatus().get(1).getStatus());
 		assertNull(result.getSignerStatus().get(1).getUserId());
+
+		verify(mockPrincipalAliasDao, never()).findPrincipalWithAlias("pi@university.edu", AliasType.USER_EMAIL);
+	}
+
+	@Test
+	public void testGetSignatureStatusWithPIEmailDifferentCase() {
+		UserInfo user = new UserInfo(false, 100L, DEFAULT_REALM_ID);
+		Request request = buildValidRequest();
+		request.setEDucSignatureEnvelopeId("env-123");
+		when(mockRequestDao.get("req-1")).thenReturn(request);
+
+		EDucSignerStatus signerStatus = new EDucSignerStatus();
+		signerStatus.setName("Dr. Jones");
+		signerStatus.setStatus(EDucSignerStatusEnum.done);
+
+		EDucSignatureStatus envelopeStatus = new EDucSignatureStatus();
+		envelopeStatus.setDucStatus(EDucStatusEnum.sent);
+		envelopeStatus.setSignerStatus(List.of(signerStatus));
+
+		// DocuSign may echo the recipient email back with different capitalization
+		EnvelopeStatusResult envelopeResult = new EnvelopeStatusResult(envelopeStatus,
+				List.of("PI@University.EDU"));
+		when(mockDocuSignClient.getEnvelopeStatus("env-123")).thenReturn(envelopeResult);
+
+		// call under test
+		EDucSignatureStatus result = eDucManager.getSignatureStatus(user, "req-1");
+
+		assertEquals("200", result.getSignerStatus().get(0).getUserId());
+		verify(mockPrincipalAliasDao, never()).findPrincipalWithAlias("PI@University.EDU", AliasType.USER_EMAIL);
 	}
 
 	@Test


### PR DESCRIPTION
In our eDUC/Docusign envelopes, when routing the Principal Investigator, we used the email address from the PI's Synapse account.  However, the data access request (DAR) creator is asked to enter the PI's "institutional address" into the DAR and the requirement is to route the envelope to that address rather than to the address from the PI's Synapse account.