### PR TITLE
PLFM-9907

### DIFF
--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/DBORequestDAOImpl.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/DBORequestDAOImpl.java
@@ -229,11 +229,28 @@ public class DBORequestDAOImpl implements RequestDAO {
 	}
 
 	@Override
-	public List<RequestUserInfo> getUserRequests(Long userId, long limit, long offset,
-			AccessRequestSortField sortBy, SortDirection sortDirection) {
-		String orderBy = toOrderByClause(sortBy, sortDirection);
-		String sql = SQL_GET_USER_REQUESTS_BASE + orderBy + " LIMIT ? OFFSET ?";
-		return jdbcTemplate.query(sql, USER_REQUEST_MAPPER, userId, limit, offset);
+	public List<RequestUserInfo> getUserRequests(Long userId, Boolean isEDuc, Long accessRequirementId, long limit,
+			long offset, AccessRequestSortField sortBy, SortDirection sortDirection) {
+		StringBuilder sql = new StringBuilder(SQL_GET_USER_REQUESTS_BASE);
+		List<Object> parameters = new ArrayList<>();
+		parameters.add(userId);
+
+		// Filtering here rather than over the returned page keeps the page size and the next-page
+		// token counting only the rows the caller asked for.
+		if (isEDuc != null) {
+			// A request is an eDUC once it has an envelope, which is how the summary reports it.
+			sql.append(" AND r.").append(COL_DATA_ACCESS_REQUEST_EDUC_ENVELOPE_ID)
+					.append(isEDuc ? " IS NOT NULL" : " IS NULL");
+		}
+		if (accessRequirementId != null) {
+			sql.append(" AND r.").append(COL_DATA_ACCESS_REQUEST_ACCESS_REQUIREMENT_ID).append(" = ?");
+			parameters.add(accessRequirementId);
+		}
+
+		sql.append(toOrderByClause(sortBy, sortDirection)).append(" LIMIT ? OFFSET ?");
+		parameters.add(limit);
+		parameters.add(offset);
+		return jdbcTemplate.query(sql.toString(), USER_REQUEST_MAPPER, parameters.toArray());
 	}
 
 	static String toOrderByClause(AccessRequestSortField sortBy, SortDirection sortDirection) {

--- a/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/RequestDAO.java
+++ b/lib/jdomodels/src/main/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/RequestDAO.java
@@ -88,8 +88,16 @@ public interface RequestDAO {
 
 	/**
 	 * Returns requests associated with the given user (as creator, PI, or collaborator).
+	 * <p>
+	 * The two filters are independent; each is applied only when it is provided.
+	 *
+	 * @param isEDuc when true, limits the results to requests that have a DUC envelope; when false,
+	 *        to those that do not; when null, requests are returned regardless
+	 * @param accessRequirementId when non-null, limits the results to requests for that access
+	 *        requirement
 	 */
-	List<RequestUserInfo> getUserRequests(Long userId, long limit, long offset, AccessRequestSortField sortBy, SortDirection sortDirection);
+	List<RequestUserInfo> getUserRequests(Long userId, Boolean isEDuc, Long accessRequirementId, long limit,
+			long offset, AccessRequestSortField sortBy, SortDirection sortDirection);
 
 	// For testing
 

--- a/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/DBORequestDAOImplTest.java
+++ b/lib/jdomodels/src/test/java/org/sagebionetworks/repo/model/dbo/dao/dataaccess/DBORequestDAOImplTest.java
@@ -10,7 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -84,10 +87,19 @@ public class DBORequestDAOImplTest {
 	private String toDelete;
 	private String submissionToDelete;
 
+	// A second access requirement is needed to give one user two requests: the request table has a
+	// unique key on (ACCESS_REQUIREMENT_ID, CREATED_BY).
+	private ManagedACTAccessRequirement secondAccessRequirement = null;
+	private ResearchProject secondResearchProject = null;
+	private String secondRequestToDelete = null;
+
 	@BeforeEach
 	public void before() {
 		toDelete = null;
 		submissionToDelete = null;
+		secondRequestToDelete = null;
+		secondResearchProject = null;
+		secondAccessRequirement = null;
 
 		// create a user
 		individualGroup = new UserGroup();
@@ -128,6 +140,15 @@ public class DBORequestDAOImplTest {
 	public void after() {
 		if (submissionToDelete != null) {
 			submissionDao.delete(submissionToDelete);
+		}
+		if (secondRequestToDelete != null) {
+			requestDao.delete(secondRequestToDelete);
+		}
+		if (secondResearchProject != null) {
+			researchProjectDao.delete(secondResearchProject.getId());
+		}
+		if (secondAccessRequirement != null) {
+			accessRequirementDAO.delete(secondAccessRequirement.getId().toString());
 		}
 		if (toDelete != null) {
 			requestDao.delete(toDelete);
@@ -346,7 +367,7 @@ public class DBORequestDAOImplTest {
 
 		// call under test
 		List<RequestUserInfo> results = requestDao.getUserRequests(
-				Long.parseLong(individualGroup.getId()), 10, 0, null, null);
+				Long.parseLong(individualGroup.getId()), null, null, 10, 0, null, null);
 
 		assertEquals(1, results.size());
 		RequestUserInfo info = results.get(0);
@@ -390,7 +411,7 @@ public class DBORequestDAOImplTest {
 
 		// call under test
 		List<RequestUserInfo> results = requestDao.getUserRequests(
-				Long.parseLong(individualGroup.getId()), 10, 0, null, null);
+				Long.parseLong(individualGroup.getId()), null, null, 10, 0, null, null);
 
 		assertEquals(1, results.size());
 		RequestUserInfo info = results.get(0);
@@ -400,10 +421,162 @@ public class DBORequestDAOImplTest {
 		assertNotNull(info.getModifiedOn());
 	}
 
+	/**
+	 * Creates a second access requirement, research project and request owned by the same user, so
+	 * that a filter can be shown to select one of the user's two requests and not the other.
+	 *
+	 * @param envelopeId the DUC envelope to record on the request, or null for a request that has none
+	 * @return the ID of the created request
+	 */
+	private String createSecondRequest(String envelopeId) {
+		secondAccessRequirement = new ManagedACTAccessRequirement();
+		secondAccessRequirement.setCreatedBy(individualGroup.getId());
+		secondAccessRequirement.setCreatedOn(new Date());
+		secondAccessRequirement.setModifiedBy(individualGroup.getId());
+		secondAccessRequirement.setModifiedOn(new Date());
+		secondAccessRequirement.setEtag("11");
+		secondAccessRequirement.setAccessType(ACCESS_TYPE.DOWNLOAD);
+		RestrictableObjectDescriptor rod = AccessRequirementUtilsTest
+				.createRestrictableObjectDescriptor(node.getId());
+		secondAccessRequirement.setSubjectIds(Arrays.asList(new RestrictableObjectDescriptor[] { rod, rod }));
+		secondAccessRequirement = accessRequirementDAO.create(secondAccessRequirement);
+
+		secondResearchProject = ResearchProjectTestUtils.createNewDto();
+		secondResearchProject.setAccessRequirementId(secondAccessRequirement.getId().toString());
+		secondResearchProject = researchProjectDao.create(secondResearchProject);
+
+		Request dto = RequestTestUtils.createNewRequest();
+		dto.setAccessRequirementId(secondAccessRequirement.getId().toString());
+		dto.setResearchProjectId(secondResearchProject.getId());
+		dto.setCreatedBy(individualGroup.getId());
+		dto.setModifiedBy(individualGroup.getId());
+		dto.setAccessorChanges(null);
+		dto.setEDucSignatureEnvelopeId(envelopeId);
+		Request created = requestDao.create(dto);
+		secondRequestToDelete = created.getId();
+		return created.getId();
+	}
+
+	/**
+	 * Creates the request owned by the shared access requirement.
+	 *
+	 * @param envelopeId the DUC envelope to record on the request, or null for a request that has none
+	 * @return the ID of the created request
+	 */
+	private String createFirstRequest(String envelopeId) {
+		Request dto = RequestTestUtils.createNewRequest();
+		dto.setAccessRequirementId(accessRequirement.getId().toString());
+		dto.setResearchProjectId(researchProject.getId());
+		dto.setCreatedBy(individualGroup.getId());
+		dto.setModifiedBy(individualGroup.getId());
+		dto.setAccessorChanges(null);
+		dto.setEDucSignatureEnvelopeId(envelopeId);
+		Request created = requestDao.create(dto);
+		toDelete = created.getId();
+		return created.getId();
+	}
+
+	private static List<String> requestIds(List<RequestUserInfo> results) {
+		return results.stream().map(RequestUserInfo::getRequestId).collect(Collectors.toList());
+	}
+
+	@Test
+	public void testGetUserRequestsWithIsEDucTrue() {
+		String withEnvelope = createFirstRequest("env-123");
+		createSecondRequest(null);
+		Long userId = Long.parseLong(individualGroup.getId());
+
+		// call under test
+		List<RequestUserInfo> results = requestDao.getUserRequests(userId, true, null, 10, 0, null, null);
+
+		assertEquals(List.of(withEnvelope), requestIds(results));
+		assertEquals("env-123", results.get(0).getEnvelopeId());
+	}
+
+	@Test
+	public void testGetUserRequestsWithIsEDucFalse() {
+		createFirstRequest("env-123");
+		String withoutEnvelope = createSecondRequest(null);
+		Long userId = Long.parseLong(individualGroup.getId());
+
+		// call under test
+		List<RequestUserInfo> results = requestDao.getUserRequests(userId, false, null, 10, 0, null, null);
+
+		assertEquals(List.of(withoutEnvelope), requestIds(results));
+		assertNull(results.get(0).getEnvelopeId());
+	}
+
+	@Test
+	public void testGetUserRequestsWithNoIsEDucFilter() {
+		String withEnvelope = createFirstRequest("env-123");
+		String withoutEnvelope = createSecondRequest(null);
+		Long userId = Long.parseLong(individualGroup.getId());
+
+		// call under test — a null filter returns both, regardless of envelope
+		List<RequestUserInfo> results = requestDao.getUserRequests(userId, null, null, 10, 0, null, null);
+
+		assertEquals(Set.of(withEnvelope, withoutEnvelope), new HashSet<>(requestIds(results)));
+	}
+
+	@Test
+	public void testGetUserRequestsWithAccessRequirementIdFilter() {
+		String firstRequest = createFirstRequest(null);
+		String secondRequest = createSecondRequest(null);
+		Long userId = Long.parseLong(individualGroup.getId());
+
+		// call under test
+		List<RequestUserInfo> forFirstAr = requestDao.getUserRequests(
+				userId, null, accessRequirement.getId(), 10, 0, null, null);
+
+		assertEquals(List.of(firstRequest), requestIds(forFirstAr));
+		assertEquals(accessRequirement.getId().toString(), forFirstAr.get(0).getAccessRequirementId());
+
+		// call under test — the other requirement selects the other request
+		List<RequestUserInfo> forSecondAr = requestDao.getUserRequests(
+				userId, null, secondAccessRequirement.getId(), 10, 0, null, null);
+
+		assertEquals(List.of(secondRequest), requestIds(forSecondAr));
+	}
+
+	@Test
+	public void testGetUserRequestsWithBothFilters() {
+		String withEnvelope = createFirstRequest("env-123");
+		createSecondRequest(null);
+		Long userId = Long.parseLong(individualGroup.getId());
+
+		// call under test — the filters combine, so the eDUC request is found under its own requirement
+		List<RequestUserInfo> matching = requestDao.getUserRequests(
+				userId, true, accessRequirement.getId(), 10, 0, null, null);
+
+		assertEquals(List.of(withEnvelope), requestIds(matching));
+
+		// call under test — but not under the other requirement, proving the filters are combined
+		// rather than either one alone being applied
+		List<RequestUserInfo> conflicting = requestDao.getUserRequests(
+				userId, true, secondAccessRequirement.getId(), 10, 0, null, null);
+
+		assertEquals(0, conflicting.size());
+	}
+
+	@Test
+	public void testGetUserRequestsWithFilterAndPagination() {
+		// the filter has to be applied in the query, or a page would be built from unfiltered rows
+		String withEnvelope = createFirstRequest("env-123");
+		createSecondRequest(null);
+		Long userId = Long.parseLong(individualGroup.getId());
+
+		// call under test — one match, so the first page holds it and the second is empty
+		List<RequestUserInfo> firstPage = requestDao.getUserRequests(userId, true, null, 1, 0, null, null);
+		List<RequestUserInfo> secondPage = requestDao.getUserRequests(userId, true, null, 1, 1, null, null);
+
+		assertEquals(List.of(withEnvelope), requestIds(firstPage));
+		assertEquals(0, secondPage.size());
+	}
+
 	@Test
 	public void testGetUserRequestsWithNoResults() {
 		// call under test
-		List<RequestUserInfo> results = requestDao.getUserRequests(999999L, 10, 0, null, null);
+		List<RequestUserInfo> results = requestDao.getUserRequests(999999L, null, null, 10, 0, null, null);
 
 		assertEquals(0, results.size());
 	}
@@ -421,7 +594,7 @@ public class DBORequestDAOImplTest {
 
 		// call under test — offset past the single result
 		List<RequestUserInfo> results = requestDao.getUserRequests(
-				Long.parseLong(individualGroup.getId()), 10, 1, null, null);
+				Long.parseLong(individualGroup.getId()), null, null, 10, 1, null, null);
 
 		assertEquals(0, results.size());
 	}
@@ -471,7 +644,7 @@ public class DBORequestDAOImplTest {
 
 		// call under test
 		List<RequestUserInfo> results = requestDao.getUserRequests(
-				Long.parseLong(individualGroup.getId()), 10, 0, null, null);
+				Long.parseLong(individualGroup.getId()), null, null, 10, 0, null, null);
 
 		assertEquals(1, results.size());
 		assertNotNull(results.get(0).getExpiresOn());
@@ -509,7 +682,7 @@ public class DBORequestDAOImplTest {
 
 		// call under test — no approval exists
 		List<RequestUserInfo> results = requestDao.getUserRequests(
-				Long.parseLong(individualGroup.getId()), 10, 0, null, null);
+				Long.parseLong(individualGroup.getId()), null, null, 10, 0, null, null);
 
 		assertEquals(1, results.size());
 		assertNull(results.get(0).getExpiresOn());
@@ -560,7 +733,7 @@ public class DBORequestDAOImplTest {
 
 		// call under test — the requesting user has no approval, only otherUser does
 		List<RequestUserInfo> results = requestDao.getUserRequests(
-				Long.parseLong(individualGroup.getId()), 10, 0, null, null);
+				Long.parseLong(individualGroup.getId()), null, null, 10, 0, null, null);
 
 		assertEquals(1, results.size());
 		assertNull(results.get(0).getExpiresOn());
@@ -602,7 +775,7 @@ public class DBORequestDAOImplTest {
 		try {
 			// call under test
 			List<RequestUserInfo> results = requestDao.getUserRequests(
-					Long.parseLong(individualGroup.getId()), 10, 0,
+					Long.parseLong(individualGroup.getId()), null, null, 10, 0,
 					AccessRequestSortField.ACCESS_REQUIREMENT_NAME, SortDirection.ASC);
 
 			assertEquals(2, results.size());
@@ -645,7 +818,7 @@ public class DBORequestDAOImplTest {
 		try {
 			// call under test — DESC: most recent first
 			List<RequestUserInfo> desc = requestDao.getUserRequests(
-					Long.parseLong(individualGroup.getId()), 10, 0,
+					Long.parseLong(individualGroup.getId()), null, null, 10, 0,
 					AccessRequestSortField.SUBMITTED_ON, SortDirection.DESC);
 
 			assertEquals(2, desc.size());
@@ -654,7 +827,7 @@ public class DBORequestDAOImplTest {
 
 			// call under test — ASC: oldest first
 			List<RequestUserInfo> asc = requestDao.getUserRequests(
-					Long.parseLong(individualGroup.getId()), 10, 0,
+					Long.parseLong(individualGroup.getId()), null, null, 10, 0,
 					AccessRequestSortField.SUBMITTED_ON, SortDirection.ASC);
 
 			assertEquals(2, asc.size());
@@ -704,7 +877,7 @@ public class DBORequestDAOImplTest {
 		try {
 			// call under test — ASC: earliest expiry first
 			List<RequestUserInfo> asc = requestDao.getUserRequests(
-					Long.parseLong(individualGroup.getId()), 10, 0,
+					Long.parseLong(individualGroup.getId()), null, null, 10, 0,
 					AccessRequestSortField.EXPIRES_ON, SortDirection.ASC);
 
 			assertEquals(2, asc.size());
@@ -713,7 +886,7 @@ public class DBORequestDAOImplTest {
 
 			// call under test — DESC: latest expiry first
 			List<RequestUserInfo> desc = requestDao.getUserRequests(
-					Long.parseLong(individualGroup.getId()), 10, 0,
+					Long.parseLong(individualGroup.getId()), null, null, 10, 0,
 					AccessRequestSortField.EXPIRES_ON, SortDirection.DESC);
 
 			assertEquals(2, desc.size());
@@ -757,7 +930,7 @@ public class DBORequestDAOImplTest {
 		try {
 			// call under test — DESC: most recently modified first
 			List<RequestUserInfo> desc = requestDao.getUserRequests(
-					Long.parseLong(individualGroup.getId()), 10, 0,
+					Long.parseLong(individualGroup.getId()), null, null, 10, 0,
 					AccessRequestSortField.MODIFIED_ON, SortDirection.DESC);
 
 			assertEquals(2, desc.size());
@@ -766,7 +939,7 @@ public class DBORequestDAOImplTest {
 
 			// call under test — ASC: least recently modified first
 			List<RequestUserInfo> asc = requestDao.getUserRequests(
-					Long.parseLong(individualGroup.getId()), 10, 0,
+					Long.parseLong(individualGroup.getId()), null, null, 10, 0,
 					AccessRequestSortField.MODIFIED_ON, SortDirection.ASC);
 
 			assertEquals(2, asc.size());

--- a/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/dataaccess/AccessRequestListRequest.json
+++ b/lib/lib-auto-generated/src/main/resources/schema/org/sagebionetworks/repo/model/dataaccess/AccessRequestListRequest.json
@@ -12,6 +12,14 @@
         "sortDirection": {
             "$ref": "org.sagebionetworks.repo.model.dataaccess.SortDirection",
             "description": "Optional sort direction. Defaults to DESC if omitted."
+        },
+        "isEDuc": {
+            "type": "boolean",
+            "description": "Optional filter. When true, only requests that use the eDUC flow are included; when false, only requests that do not. If omitted, requests are included regardless of whether they use the eDUC flow."
+        },
+        "accessRequirementId": {
+            "type": "string",
+            "description": "Optional filter. When set, only requests for the given access requirement are included. If omitted, requests for all access requirements are included."
         }
     }
 }

--- a/lib/lib-docusign/src/main/java/org/sagebionetworks/docusign/DocuSignClient.java
+++ b/lib/lib-docusign/src/main/java/org/sagebionetworks/docusign/DocuSignClient.java
@@ -530,11 +530,15 @@ public class DocuSignClient {
 		return new EnvelopeStatusResult(status, signerEmails);
 	}
 
+	/**
+	 * The status of each of the given envelopes, with recipients populated so that the callers can
+	 * count how many signatures an envelope has requested and acquired.
+	 */
 	public List<Envelope> listEnvelopeStatuses(List<String> envelopeIds) {
 		if (Collections.isEmpty(envelopeIds)) {
 			return List.of();
 		}
-		return envelopesApi.listStatus(envelopeIds);
+		return envelopesApi.listStatusChanges(envelopeIds);
 	}
 
 	public byte[] getDocument(String envelopeId) {

--- a/lib/lib-docusign/src/main/java/org/sagebionetworks/docusign/DocuSignEnvelopesApi.java
+++ b/lib/lib-docusign/src/main/java/org/sagebionetworks/docusign/DocuSignEnvelopesApi.java
@@ -19,7 +19,14 @@ interface DocuSignEnvelopesApi {
 
 	Envelope getEnvelope(String envelopeId);
 
-	List<Envelope> listStatus(List<String> envelopeIds);
+	/**
+	 * The given envelopes, each with its recipients populated.
+	 * <p>
+	 * This deliberately uses DocuSign's envelope listing rather than its status endpoint. The status
+	 * endpoint returns a status-only projection: it has no way to ask for recipients, so every
+	 * envelope it returns has a null recipient list and a signature count cannot be derived from it.
+	 */
+	List<Envelope> listStatusChanges(List<String> envelopeIds);
 
 	/**
 	 * The templates that were applied to an envelope. An envelope created from a template does not

--- a/lib/lib-docusign/src/main/java/org/sagebionetworks/docusign/DocuSignEnvelopesApiImpl.java
+++ b/lib/lib-docusign/src/main/java/org/sagebionetworks/docusign/DocuSignEnvelopesApiImpl.java
@@ -9,7 +9,6 @@ import com.docusign.esign.api.EnvelopesApi;
 import com.docusign.esign.client.ApiClient;
 import com.docusign.esign.model.Envelope;
 import com.docusign.esign.model.EnvelopeDefinition;
-import com.docusign.esign.model.EnvelopeIdsRequest;
 import com.docusign.esign.model.EnvelopeSummary;
 import com.docusign.esign.model.EnvelopesInformation;
 import com.docusign.esign.model.Recipients;
@@ -73,18 +72,22 @@ class DocuSignEnvelopesApiImpl implements DocuSignEnvelopesApi {
 	}
 
 	@Override
-	public List<Envelope> listStatus(List<String> envelopeIds) {
+	public List<Envelope> listStatusChanges(List<String> envelopeIds) {
 		return retryHelper.executeWithRetry(accessToken -> {
 			ApiClient apiClient = new ApiClient(config.getBasePath());
 			apiClient.addDefaultHeader("Authorization", "Bearer " + accessToken);
 			EnvelopesApi envelopesApi = new EnvelopesApi(apiClient);
-			EnvelopeIdsRequest request = new EnvelopeIdsRequest();
-			request.setEnvelopeIds(envelopeIds);
-			// The status endpoint only reads the envelope ids from the request body when the
-			// envelope_ids query parameter is set to "request_body"; otherwise DocuSign returns 400.
-			EnvelopesApi.ListStatusOptions options = envelopesApi.new ListStatusOptions();
-			options.setEnvelopeIds("request_body");
-			EnvelopesInformation info = envelopesApi.listStatus(config.getAccountId(), request, options);
+			EnvelopesApi.ListStatusChangesOptions options = envelopesApi.new ListStatusChangesOptions();
+			// Naming the envelopes explicitly satisfies this endpoint's requirement that a request be
+			// bounded by either a date range or a set of ids.
+			options.setEnvelopeIds(String.join(",", envelopeIds));
+			// Recipients are not returned unless asked for, and they are the whole reason this endpoint
+			// is used in place of the status endpoint.
+			options.setInclude("recipients");
+			// The listing is paged, so a default page smaller than the request would silently drop
+			// envelopes and leave them looking as though they had never been routed.
+			options.setCount(Integer.toString(envelopeIds.size()));
+			EnvelopesInformation info = envelopesApi.listStatusChanges(config.getAccountId(), options);
 			return info.getEnvelopes() != null ? info.getEnvelopes() : Collections.<Envelope>emptyList();
 		});
 	}

--- a/lib/lib-docusign/src/test/java/org/sagebionetworks/docusign/DocuSignClientTest.java
+++ b/lib/lib-docusign/src/test/java/org/sagebionetworks/docusign/DocuSignClientTest.java
@@ -556,7 +556,7 @@ public class DocuSignClientTest {
 		Envelope env2 = new Envelope();
 		env2.setEnvelopeId("env-2");
 		env2.setStatus("completed");
-		when(mockDocuSignEnvelopesApi.listStatus(List.of("env-1", "env-2")))
+		when(mockDocuSignEnvelopesApi.listStatusChanges(List.of("env-1", "env-2")))
 				.thenReturn(List.of(env1, env2));
 
 		// call under test
@@ -567,6 +567,29 @@ public class DocuSignClientTest {
 		assertEquals("sent", result.get(0).getStatus());
 		assertEquals("env-2", result.get(1).getEnvelopeId());
 		assertEquals("completed", result.get(1).getStatus());
+	}
+
+	@Test
+	public void testListEnvelopeStatusesReturnsRecipients() {
+		// The signature counts in a request listing are derived from the recipients, so an envelope
+		// has to come back with them populated. Only DocuSign can prove it actually does — see the
+		// corresponding step in DocuSignLiveTest — but this pins the shape the caller depends on.
+		Signer signer = new Signer();
+		signer.setRoleName("collaborator_1");
+		signer.setStatus("completed");
+		Recipients recipients = new Recipients();
+		recipients.setSigners(List.of(signer));
+		Envelope env = new Envelope();
+		env.setEnvelopeId("env-1");
+		env.setStatus("sent");
+		env.setRecipients(recipients);
+		when(mockDocuSignEnvelopesApi.listStatusChanges(List.of("env-1"))).thenReturn(List.of(env));
+
+		// call under test
+		List<Envelope> result = client.listEnvelopeStatuses(List.of("env-1"));
+
+		assertEquals(1, result.get(0).getRecipients().getSigners().size());
+		assertEquals("completed", result.get(0).getRecipients().getSigners().get(0).getStatus());
 	}
 
 	@Test

--- a/lib/lib-docusign/src/test/java/org/sagebionetworks/docusign/DocuSignLiveTest.java
+++ b/lib/lib-docusign/src/test/java/org/sagebionetworks/docusign/DocuSignLiveTest.java
@@ -63,6 +63,7 @@ import com.docusign.esign.model.TemplateSummary;
  * $MVN -Dtest=DocuSignLiveTest#step7_verifyAfterCorrection
  * # --- optionally sign as the collaborator and the signing official ---
  * $MVN -Dtest=DocuSignLiveTest#step8_downloadCertificate
+ * $MVN -Dtest=DocuSignLiveTest#step9_verifyListReturnsRecipients
  * $MVN -Dtest=DocuSignLiveTest#stepReset_voidAndClearState
  * </pre>
  *
@@ -356,6 +357,40 @@ public class DocuSignLiveTest {
 		print("wrote", out.toAbsolutePath().toString());
 		System.out.println("Read the signing order on the certificate: a collaborator added after the"
 				+ " signing official countersigned appears after them, despite routing order 1.");
+	}
+
+	/**
+	 * The signature counts on a request listing are derived from each envelope's recipients, so a bulk
+	 * envelope read has to return them. DocuSign's status endpoint does not: it answers with a
+	 * status-only projection in which the recipient list is always null, which left the counts silently
+	 * absent from every listed request. This is the step that catches that, since no mock can.
+	 */
+	@Test
+	public void step9_verifyListReturnsRecipients() {
+		String envelopeId = state("envelopeId");
+
+		// call under test — the same call the request listing makes
+		List<Envelope> envelopes = client.listEnvelopeStatuses(List.of(envelopeId));
+
+		verdict("the requested envelope came back", envelopes.size() == 1);
+		if (envelopes.size() != 1) {
+			return;
+		}
+		Envelope envelope = envelopes.get(0);
+		print("status", envelope.getStatus());
+		verdict("the envelope carries its recipients, so signatures can be counted",
+				envelope.getRecipients() != null && envelope.getRecipients().getSigners() != null
+						&& !envelope.getRecipients().getSigners().isEmpty());
+		System.out.println("  (a FAIL here means the bulk read has reverted to DocuSign's status"
+				+ " endpoint, which cannot return recipients)");
+		if (envelope.getRecipients() != null && envelope.getRecipients().getSigners() != null) {
+			printRecipients("as reported by the bulk read", envelope);
+			long acquired = envelope.getRecipients().getSigners().stream()
+					.filter(DocuSignLiveTest::isCompleted)
+					.count();
+			print("signaturesRequested", Integer.toString(envelope.getRecipients().getSigners().size()));
+			print("signaturesAcquired", Long.toString(acquired));
+		}
 	}
 
 	/**

--- a/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/dataaccess/RequestManagerImpl.java
+++ b/services/repository-managers/src/main/java/org/sagebionetworks/repo/manager/dataaccess/RequestManagerImpl.java
@@ -288,8 +288,11 @@ public class RequestManagerImpl implements RequestManager{
 		ValidateArgument.required(request, "request");
 
 		NextPageToken token = new NextPageToken(request.getNextPageToken());
+		Long accessRequirementIdFilter = request.getAccessRequirementId() == null ? null
+				: Long.parseLong(request.getAccessRequirementId());
 		List<RequestUserInfo> page = requestDao.getUserRequests(
-				userInfo.getId(), token.getLimitForQuery(), token.getOffset(),
+				userInfo.getId(), request.getIsEDuc(), accessRequirementIdFilter,
+				token.getLimitForQuery(), token.getOffset(),
 				request.getSortBy(), request.getSortDirection());
 
 		List<String> envelopeIds = page.stream()

--- a/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/dataaccess/RequestManagerImplTest.java
+++ b/services/repository-managers/src/test/java/org/sagebionetworks/repo/manager/dataaccess/RequestManagerImplTest.java
@@ -806,7 +806,7 @@ public class RequestManagerImplTest {
 	@Test
 	public void testListUserRequestsWithNoRequests() {
 		when(mockUser.getId()).thenReturn(1L);
-		when(mockRequestDao.getUserRequests(1L, 51L, 0L, null, null)).thenReturn(List.of());
+		when(mockRequestDao.getUserRequests(1L, null, null, 51L, 0L, null, null)).thenReturn(List.of());
 
 		AccessRequestListRequest listRequest = new AccessRequestListRequest();
 
@@ -831,7 +831,7 @@ public class RequestManagerImplTest {
 		info.setSubmittedOn(new Date(1000L));
 		info.setModifiedOn(new Date(2000L));
 
-		when(mockRequestDao.getUserRequests(1L, 51L, 0L, null, null)).thenReturn(List.of(info));
+		when(mockRequestDao.getUserRequests(1L, null, null, 51L, 0L, null, null)).thenReturn(List.of(info));
 
 		AccessRequestListRequest listRequest = new AccessRequestListRequest();
 
@@ -861,7 +861,7 @@ public class RequestManagerImplTest {
 		info.setSubmissionStatus(null);
 		info.setEnvelopeId("env-abc");
 
-		when(mockRequestDao.getUserRequests(1L, 51L, 0L, null, null)).thenReturn(List.of(info));
+		when(mockRequestDao.getUserRequests(1L, null, null, 51L, 0L, null, null)).thenReturn(List.of(info));
 
 		Signer signer1 = new Signer();
 		signer1.setStatus("completed");
@@ -895,6 +895,36 @@ public class RequestManagerImplTest {
 	}
 
 	@Test
+	public void testListUserRequestsWithEnvelopeMissingRecipients() {
+		// An envelope read that does not carry recipients yields a status but no signature counts. This
+		// is what a caller sees if the bulk read ever stops asking DocuSign to include recipients.
+		when(mockUser.getId()).thenReturn(1L);
+
+		RequestUserInfo info = new RequestUserInfo();
+		info.setRequestId("200");
+		info.setEnvelopeId("env-abc");
+		info.setSubmissionStatus(null);
+
+		when(mockRequestDao.getUserRequests(1L, null, null, 51L, 0L, null, null)).thenReturn(List.of(info));
+
+		Envelope envelope = new Envelope();
+		envelope.setEnvelopeId("env-abc");
+		envelope.setStatus("completed");
+		envelope.setRecipients(null);
+
+		when(mockDocuSignClient.listEnvelopeStatuses(List.of("env-abc"))).thenReturn(List.of(envelope));
+
+		// call under test
+		AccessRequestList result = manager.listUserRequests(mockUser, new AccessRequestListRequest());
+
+		AccessRequestSummary summary = result.getResults().get(0);
+		assertEquals(AccessRequestStatusEnum.completed, summary.getStatus());
+		assertEquals(true, summary.getIsEDuc());
+		assertNull(summary.getSignaturesRequested());
+		assertNull(summary.getSignaturesAcquired());
+	}
+
+	@Test
 	public void testListUserRequestsWithNoSubmissionAndNoEnvelope() {
 		when(mockUser.getId()).thenReturn(1L);
 
@@ -904,7 +934,7 @@ public class RequestManagerImplTest {
 		info.setSubmissionStatus(null);
 		info.setEnvelopeId(null);
 
-		when(mockRequestDao.getUserRequests(1L, 51L, 0L, null, null)).thenReturn(List.of(info));
+		when(mockRequestDao.getUserRequests(1L, null, null, 51L, 0L, null, null)).thenReturn(List.of(info));
 
 		AccessRequestListRequest listRequest = new AccessRequestListRequest();
 
@@ -918,6 +948,77 @@ public class RequestManagerImplTest {
 		assertEquals(false, summary.getIsEDuc());
 		assertNull(summary.getSignaturesRequested());
 		assertNull(summary.getSignaturesAcquired());
+	}
+
+	@Test
+	public void testListUserRequestsWithIsEDucTrue() {
+		when(mockUser.getId()).thenReturn(1L);
+		when(mockRequestDao.getUserRequests(1L, true, null, 51L, 0L, null, null)).thenReturn(List.of());
+
+		AccessRequestListRequest listRequest = new AccessRequestListRequest();
+		listRequest.setIsEDuc(true);
+
+		// call under test
+		manager.listUserRequests(mockUser, listRequest);
+
+		verify(mockRequestDao).getUserRequests(1L, true, null, 51L, 0L, null, null);
+	}
+
+	@Test
+	public void testListUserRequestsWithIsEDucFalse() {
+		when(mockUser.getId()).thenReturn(1L);
+		when(mockRequestDao.getUserRequests(1L, false, null, 51L, 0L, null, null)).thenReturn(List.of());
+
+		AccessRequestListRequest listRequest = new AccessRequestListRequest();
+		listRequest.setIsEDuc(false);
+
+		// call under test
+		manager.listUserRequests(mockUser, listRequest);
+
+		// false must reach the DAO as a filter rather than being treated as "no filter"
+		verify(mockRequestDao).getUserRequests(1L, false, null, 51L, 0L, null, null);
+	}
+
+	@Test
+	public void testListUserRequestsWithAccessRequirementId() {
+		when(mockUser.getId()).thenReturn(1L);
+		when(mockRequestDao.getUserRequests(1L, null, 55L, 51L, 0L, null, null)).thenReturn(List.of());
+
+		AccessRequestListRequest listRequest = new AccessRequestListRequest();
+		listRequest.setAccessRequirementId("55");
+
+		// call under test
+		manager.listUserRequests(mockUser, listRequest);
+
+		verify(mockRequestDao).getUserRequests(1L, null, 55L, 51L, 0L, null, null);
+	}
+
+	@Test
+	public void testListUserRequestsWithBothFilters() {
+		// the two filters are independent and may be combined
+		when(mockUser.getId()).thenReturn(1L);
+		when(mockRequestDao.getUserRequests(1L, true, 55L, 51L, 0L, null, null)).thenReturn(List.of());
+
+		AccessRequestListRequest listRequest = new AccessRequestListRequest();
+		listRequest.setIsEDuc(true);
+		listRequest.setAccessRequirementId("55");
+
+		// call under test
+		manager.listUserRequests(mockUser, listRequest);
+
+		verify(mockRequestDao).getUserRequests(1L, true, 55L, 51L, 0L, null, null);
+	}
+
+	@Test
+	public void testListUserRequestsWithNonNumericAccessRequirementId() {
+		AccessRequestListRequest listRequest = new AccessRequestListRequest();
+		listRequest.setAccessRequirementId("not-a-number");
+
+		// call under test — NumberFormatException extends IllegalArgumentException, so this is a 400
+		assertThrows(NumberFormatException.class,
+				() -> manager.listUserRequests(mockUser, listRequest));
+
+		verifyNoInteractions(mockRequestDao);
 	}
 
 	@Test

--- a/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/DataAccessController.java
+++ b/services/repository/src/main/java/org/sagebionetworks/repo/web/controller/DataAccessController.java
@@ -122,9 +122,12 @@ public class DataAccessController {
 
 	/**
 	 * List data access requests associated with the current user.
+	 * <p>
+	 * The results may optionally be filtered to requests that do or do not use the eDUC flow, and
+	 * to a single access requirement. The two filters are independent.
 	 *
 	 * @param userId  - The ID of the user who is making the request.
-	 * @param request - Pagination parameters.
+	 * @param request - Pagination, sorting and filter parameters.
 	 * @return A paginated list of access request summaries.
 	 */
 	@RequiredScope({view})


### PR DESCRIPTION
Updates to the [service](https://rest-docs.synapse.org/rest/POST/dataAccessRequest/list.html) to list data access requests:
- add filter parameters: (1) access requirement id, (2) isEDuc;
- fix the missing signaturesAcquired and signaturesRequested fields

The fix involves calling a different Docusign API:  Instead of calling `listStatus` we now call `listStatusChanges` which includes the recipients for the routed envelopes along with the envelopes' statuses.  Once we have the recipients we can count them up and fill the signaturesAcquired and signaturesRequested fields.

This PR adds a manual test that I ran to verify that the new API returns the recipient information as expected.